### PR TITLE
Fixed memcpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ MessagePack Code Generator
 This is a code generation tool for serializing Go `struct`s using the [MesssagePack](http://msgpack.org) standard. It is targeted 
 at the `go generate` [tool](http://tip.golang.org/cmd/go/#hdr-Generate_Go_files_by_processing_source). You can read more about MessagePack and Go [in the wiki](http://github.com/philhofer/msgp/wiki).
 
+### Why
+
+The generated code is about five times faster than other reflection-based implementations of MessagePack, and an order of magnitude faster than `encoding/json`. Additionally, the memory footprint is much smaller (on both the stack and the heap.)
+
+Generated `msgp` code typically serializes/deserializes to `io.Writer`/`io.Readers`, respectively, in excess of 200MB/s.
+
 ### Quickstart
 
 *** Note: `go generate` is a go 1.4+ feature. ***

--- a/msgp/edit.go
+++ b/msgp/edit.go
@@ -1,7 +1,6 @@
 package msgp
 
 import (
-	"encoding/binary"
 	"math"
 )
 
@@ -191,15 +190,15 @@ func resizeMap(raw []byte, delta int64) []byte {
 	var sz int64
 	switch raw[0] {
 	case mmap16:
-		sz = int64(binary.BigEndian.Uint16(raw[1:]))
+		sz = int64(big.Uint16(raw[1:]))
 		if sz+delta <= math.MaxUint16 {
-			binary.BigEndian.PutUint16(raw[1:], uint16(sz+delta))
+			big.PutUint16(raw[1:], uint16(sz+delta))
 			return raw
 		}
 		if cap(raw)-len(raw) >= 2 {
 			raw = raw[0 : len(raw)+2]
 			copy(raw[5:], raw[3:])
-			binary.BigEndian.PutUint32(raw[1:], uint32(sz+delta))
+			big.PutUint32(raw[1:], uint32(sz+delta))
 			return raw
 		}
 		n := make([]byte, 0, len(raw)+5)
@@ -207,8 +206,8 @@ func resizeMap(raw []byte, delta int64) []byte {
 		return append(n, raw[3:]...)
 
 	case mmap32:
-		sz = int64(binary.BigEndian.Uint32(raw[1:]))
-		binary.BigEndian.PutUint32(raw[1:], uint32(sz+delta))
+		sz = int64(big.Uint32(raw[1:]))
+		big.PutUint32(raw[1:], uint32(sz+delta))
 		return raw
 
 	default:
@@ -221,7 +220,7 @@ func resizeMap(raw []byte, delta int64) []byte {
 				raw = raw[0 : len(raw)+2]
 				copy(raw[3:], raw[1:])
 				raw[0] = mmap16
-				binary.BigEndian.PutUint16(raw[1:], uint16(sz+delta))
+				big.PutUint16(raw[1:], uint16(sz+delta))
 				return raw
 			}
 			n := make([]byte, 0, len(raw)+5)
@@ -232,7 +231,7 @@ func resizeMap(raw []byte, delta int64) []byte {
 			raw = raw[0 : len(raw)+4]
 			copy(raw[5:], raw[1:])
 			raw[0] = mmap32
-			binary.BigEndian.PutUint32(raw[1:], uint32(sz+delta))
+			big.PutUint32(raw[1:], uint32(sz+delta))
 			return raw
 		}
 		n := make([]byte, 0, len(raw)+5)

--- a/msgp/extension.go
+++ b/msgp/extension.go
@@ -1,7 +1,6 @@
 package msgp
 
 import (
-	"encoding/binary"
 	"fmt"
 	"math"
 )
@@ -152,7 +151,7 @@ func (mw *Writer) WriteExtension(e Extension) error {
 				return err
 			}
 			mw.buf[o] = mext16
-			binary.BigEndian.PutUint16(mw.buf[o+1:], uint16(l))
+			big.PutUint16(mw.buf[o+1:], uint16(l))
 			mw.buf[3] = byte(e.ExtensionType())
 		default:
 			o, err := mw.require(6)
@@ -160,7 +159,7 @@ func (mw *Writer) WriteExtension(e Extension) error {
 				return err
 			}
 			mw.buf[o] = mext32
-			binary.BigEndian.PutUint32(mw.buf[o+1:], uint32(l))
+			big.PutUint32(mw.buf[o+1:], uint32(l))
 			mw.buf[5] = byte(e.ExtensionType())
 		}
 	}
@@ -337,7 +336,7 @@ func (m *Reader) ReadExtension(e Extension) (err error) {
 			err = errExt(int8(p[3]), e.ExtensionType())
 			return
 		}
-		read = int(binary.BigEndian.Uint16(p[1:]))
+		read = int(big.Uint16(p[1:]))
 		off = 4
 
 	case mext32:
@@ -349,7 +348,7 @@ func (m *Reader) ReadExtension(e Extension) (err error) {
 			err = errExt(int8(p[5]), e.ExtensionType())
 			return
 		}
-		read = int(binary.BigEndian.Uint32(p[1:]))
+		read = int(big.Uint32(p[1:]))
 		off = 6
 
 	default:
@@ -407,12 +406,12 @@ func AppendExtension(b []byte, e Extension) ([]byte, error) {
 		n += 3
 	case l < math.MaxUint16:
 		o[n] = mext16
-		binary.BigEndian.PutUint16(o[n+1:], uint16(l))
+		big.PutUint16(o[n+1:], uint16(l))
 		o[n+3] = byte(e.ExtensionType())
 		n += 4
 	default:
 		o[n] = mext32
-		binary.BigEndian.PutUint32(o[n+1:], uint32(l))
+		big.PutUint32(o[n+1:], uint32(l))
 		o[n+5] = byte(e.ExtensionType())
 		n += 6
 	}
@@ -469,14 +468,14 @@ func ReadExtensionBytes(b []byte, e Extension) ([]byte, error) {
 		if l < 4 {
 			return b, ErrShortBytes
 		}
-		sz = int(binary.BigEndian.Uint16(b[1:]))
+		sz = int(big.Uint16(b[1:]))
 		typ = int8(b[3])
 		off = 4
 	case mext32:
 		if l < 6 {
 			return b, ErrShortBytes
 		}
-		sz = int(binary.BigEndian.Uint32(b[1:]))
+		sz = int(big.Uint32(b[1:]))
 		typ = int8(b[5])
 		off = 6
 	default:

--- a/msgp/floatbench_test.go
+++ b/msgp/floatbench_test.go
@@ -1,0 +1,25 @@
+package msgp
+
+import (
+	"testing"
+)
+
+func BenchmarkReadWriteFloat32(b *testing.B) {
+	var f float32 = 3.9081
+	bts := AppendFloat32([]byte{}, f)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts = AppendFloat32(bts[0:0], f)
+		f, bts, _ = ReadFloat32Bytes(bts)
+	}
+}
+
+func BenchmarkReadWriteFloat64(b *testing.B) {
+	var f float64 = 3.9081
+	bts := AppendFloat64([]byte{}, f)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts = AppendFloat64(bts[0:0], f)
+		f, bts, _ = ReadFloat64Bytes(bts)
+	}
+}

--- a/msgp/integers.go
+++ b/msgp/integers.go
@@ -1,0 +1,188 @@
+package msgp
+
+import "unsafe"
+
+/* -----------------------------
+	integer encoding utilities
+	(inline-able)
+
+	TODO(philhofer): someday, when
+	inline assembler is supported,
+	we can use, for example
+	__asm {
+		movq   eax, i
+		bswapq eax
+	}
+   ----------------------------- */
+
+func putMint64(b []byte, i int64) {
+	b[0] = mint64
+	b[1] = byte(i >> 56)
+	b[2] = byte(i >> 48)
+	b[3] = byte(i >> 40)
+	b[4] = byte(i >> 32)
+	b[5] = byte(i >> 24)
+	b[6] = byte(i >> 16)
+	b[7] = byte(i >> 8)
+	b[8] = byte(i)
+}
+
+func getMint64(b []byte) (i int64) {
+	i |= int64(b[1]) << 56
+	i |= int64(b[2]) << 48
+	i |= int64(b[3]) << 40
+	i |= int64(b[4]) << 32
+	i |= int64(b[5]) << 24
+	i |= int64(b[6]) << 16
+	i |= int64(b[7]) << 8
+	i |= int64(b[8])
+	return
+}
+
+func putMint32(b []byte, i int32) {
+	b[0] = mint32
+	b[1] = byte(i >> 24)
+	b[2] = byte(i >> 16)
+	b[3] = byte(i >> 8)
+	b[4] = byte(i)
+}
+
+func getMint32(b []byte) (i int32) {
+	i |= int32(b[1]) << 24
+	i |= int32(b[2]) << 16
+	i |= int32(b[3]) << 8
+	i |= int32(b[4])
+	return
+}
+
+func putMint16(b []byte, i int16) {
+	b[0] = mint16
+	b[1] = byte(i >> 8)
+	b[2] = byte(i)
+}
+
+func getMint16(b []byte) (i int16) {
+	i |= int16(b[1]) << 8
+	i |= int16(b[2])
+	return
+}
+
+func putMint8(b []byte, i int8) {
+	b[0] = mint8
+	b[1] = byte(i)
+}
+
+func getMint8(b []byte) (i int8) {
+	i = int8(b[1])
+	return
+}
+
+func putMuint64(b []byte, u uint64) {
+	b[0] = muint64
+	b[1] = byte(u >> 56)
+	b[2] = byte(u >> 48)
+	b[3] = byte(u >> 40)
+	b[4] = byte(u >> 32)
+	b[5] = byte(u >> 24)
+	b[6] = byte(u >> 16)
+	b[7] = byte(u >> 8)
+	b[8] = byte(u)
+}
+
+func getMuint64(b []byte) (u uint64) {
+	u |= uint64(b[1]) << 56
+	u |= uint64(b[2]) << 48
+	u |= uint64(b[3]) << 40
+	u |= uint64(b[4]) << 32
+	u |= uint64(b[5]) << 24
+	u |= uint64(b[6]) << 16
+	u |= uint64(b[7]) << 8
+	u |= uint64(b[8])
+	return
+}
+
+func putMuint32(b []byte, u uint32) {
+	b[0] = muint32
+	b[1] = byte(u >> 24)
+	b[2] = byte(u >> 16)
+	b[3] = byte(u >> 8)
+	b[4] = byte(u)
+}
+
+func getMuint32(b []byte) (u uint32) {
+	u |= uint32(b[1]) << 24
+	u |= uint32(b[2]) << 16
+	u |= uint32(b[3]) << 8
+	u |= uint32(b[4])
+	return
+}
+
+func putMuint16(b []byte, u uint16) {
+	b[0] = muint16
+	b[1] = byte(u >> 8)
+	b[2] = byte(u)
+}
+
+func getMuint16(b []byte) (u uint16) {
+	u |= uint16(b[1]) << 8
+	u |= uint16(b[2])
+	return
+}
+
+func putMuint8(b []byte, u uint8) {
+	b[0] = muint8
+	b[1] = byte(u)
+}
+
+func getMuint8(b []byte) (u uint8) {
+	u = uint8(b[1])
+	return
+}
+
+/* ---------------------------
+	memory-copying utilities
+	WARNING: gross code ahead
+   --------------------------- */
+
+// copy 4 unaligned bytes w/o branch
+func memcpy4(to unsafe.Pointer, from unsafe.Pointer) {
+	s, f := (*[4]byte)(to), (*[4]byte)(from)
+	s[0] = f[0]
+	s[1] = f[1]
+	s[2] = f[2]
+	s[3] = f[3]
+}
+
+// copy 8 unaligned bytes w/o branch
+func memcpy8(to unsafe.Pointer, from unsafe.Pointer) {
+	s, f := (*[8]byte)(to), (*[8]byte)(from)
+	s[0] = f[0]
+	s[1] = f[1]
+	s[2] = f[2]
+	s[3] = f[3]
+	s[4] = f[4]
+	s[5] = f[5]
+	s[6] = f[6]
+	s[7] = f[7]
+}
+
+// copy 16 unaligned bytes w/o branch
+func memcpy16(to unsafe.Pointer, from unsafe.Pointer) {
+	s, f := (*[16]byte)(to), (*[16]byte)(from)
+	s[0] = f[0]
+	s[1] = f[1]
+	s[2] = f[2]
+	s[3] = f[3]
+	s[4] = f[4]
+	s[5] = f[5]
+	s[6] = f[6]
+	s[7] = f[7]
+	s[8] = f[8]
+	s[9] = f[9]
+	s[10] = f[10]
+	s[11] = f[11]
+	s[12] = f[12]
+	s[13] = f[13]
+	s[14] = f[14]
+	s[15] = f[15]
+}

--- a/msgp/json.go
+++ b/msgp/json.go
@@ -3,7 +3,6 @@ package msgp
 import (
 	"bufio"
 	"encoding/base64"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"io"
@@ -363,14 +362,14 @@ func rwString(dst jsWriter, src *Reader) (n int, err error) {
 		if err != nil {
 			return
 		}
-		read = int(binary.BigEndian.Uint16(p[1:]))
+		read = int(big.Uint16(p[1:]))
 		off = 3
 	case mstr32:
 		p, err = src.r.Peek(5)
 		if err != nil {
 			return
 		}
-		read = int(binary.BigEndian.Uint32(p[1:]))
+		read = int(big.Uint32(p[1:]))
 		off = 5
 	default:
 		err = TypeError{Method: StrType, Encoded: getType(lead)}

--- a/msgp/read.go
+++ b/msgp/read.go
@@ -1,7 +1,6 @@
 package msgp
 
 import (
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"github.com/philhofer/fwd"
@@ -31,7 +30,9 @@ func (a ArrayError) Error() string {
 	return fmt.Sprintf("msgp: wanted array of size %d; got %d", a.Wanted, a.Got)
 }
 
-// Type is a MessagePack wire type
+// Type is a MessagePack wire type,
+// including this package's built-in
+// extension types.
 type Type byte
 
 // MessagePack Types
@@ -314,14 +315,14 @@ func getNextSize(r *fwd.Reader) (int, int, error) {
 		if err != nil {
 			return 0, 0, err
 		}
-		return int(binary.BigEndian.Uint16(p[1:])) + 3, 0, nil
+		return int(big.Uint16(p[1:])) + 3, 0, nil
 
 	case mbin32, mstr32:
 		p, err = r.Peek(5)
 		if err != nil {
 			return 0, 0, err
 		}
-		return int(binary.BigEndian.Uint32(p[1:])) + 5, 0, nil
+		return int(big.Uint32(p[1:])) + 5, 0, nil
 
 	// variable extensions
 	// require 1 extra byte
@@ -338,14 +339,14 @@ func getNextSize(r *fwd.Reader) (int, int, error) {
 		if err != nil {
 			return 0, 0, err
 		}
-		return int(binary.BigEndian.Uint16(p[1:])) + 4, 0, nil
+		return int(big.Uint16(p[1:])) + 4, 0, nil
 
 	case mext32:
 		p, err = r.Peek(6)
 		if err != nil {
 			return 0, 0, err
 		}
-		return int(binary.BigEndian.Uint32(p[1:])) + 6, 0, nil
+		return int(big.Uint32(p[1:])) + 6, 0, nil
 
 	// arrays skip lead byte,
 	// size byte, N objects
@@ -354,14 +355,14 @@ func getNextSize(r *fwd.Reader) (int, int, error) {
 		if err != nil {
 			return 0, 0, err
 		}
-		return 3, int(binary.BigEndian.Uint16(p[1:])), nil
+		return 3, int(big.Uint16(p[1:])), nil
 
 	case marray32:
 		p, err = r.Peek(5)
 		if err != nil {
 			return 0, 0, err
 		}
-		return 5, int(binary.BigEndian.Uint32(p[1:])), nil
+		return 5, int(big.Uint32(p[1:])), nil
 
 	// maps skip lead byte,
 	// size byte, 2N objects
@@ -370,14 +371,14 @@ func getNextSize(r *fwd.Reader) (int, int, error) {
 		if err != nil {
 			return 0, 0, err
 		}
-		return 3, 2 * (int(binary.BigEndian.Uint16(p[1:]))), nil
+		return 3, 2 * (int(big.Uint16(p[1:]))), nil
 
 	case mmap32:
 		p, err = r.Peek(5)
 		if err != nil {
 			return 0, 0, err
 		}
-		return 5, 2 * (int(binary.BigEndian.Uint32(p[1:]))), nil
+		return 5, 2 * (int(big.Uint32(p[1:]))), nil
 
 	default:
 		return 0, 0, InvalidPrefixError(lead)
@@ -435,7 +436,7 @@ func (m *Reader) ReadMapHeader() (sz uint32, err error) {
 		if err != nil {
 			return
 		}
-		usz := binary.BigEndian.Uint16(p[1:])
+		usz := big.Uint16(p[1:])
 		sz = uint32(usz)
 		_, err = m.r.Skip(3)
 		return
@@ -444,7 +445,7 @@ func (m *Reader) ReadMapHeader() (sz uint32, err error) {
 		if err != nil {
 			return
 		}
-		sz = binary.BigEndian.Uint32(p[1:])
+		sz = big.Uint32(p[1:])
 		_, err = m.r.Skip(5)
 		return
 	default:
@@ -489,7 +490,7 @@ func (m *Reader) ReadArrayHeader() (sz uint32, err error) {
 		if err != nil {
 			return
 		}
-		usz := binary.BigEndian.Uint16(p[1:])
+		usz := big.Uint16(p[1:])
 		sz = uint32(usz)
 		_, err = m.r.Skip(3)
 		return
@@ -499,7 +500,7 @@ func (m *Reader) ReadArrayHeader() (sz uint32, err error) {
 		if err != nil {
 			return
 		}
-		sz = binary.BigEndian.Uint32(p[1:])
+		sz = big.Uint32(p[1:])
 		_, err = m.r.Skip(5)
 		return
 
@@ -546,7 +547,7 @@ func (m *Reader) ReadFloat64() (f float64, err error) {
 		err = TypeError{Method: Float64Type, Encoded: getType(p[0])}
 		return
 	}
-	copy((*(*[8]byte)(unsafe.Pointer(&f)))[:], p[1:])
+	memcpy8(unsafe.Pointer(&f), unsafe.Pointer(&p[1]))
 	_, err = m.r.Skip(9)
 	return
 }
@@ -562,7 +563,7 @@ func (m *Reader) ReadFloat32() (f float32, err error) {
 		err = TypeError{Method: Float32Type, Encoded: getType(p[0])}
 		return
 	}
-	copy((*(*[4]byte)(unsafe.Pointer(&f)))[:], p[1:])
+	memcpy4(unsafe.Pointer(&f), unsafe.Pointer(&p[1]))
 	_, err = m.r.Skip(5)
 	return
 }
@@ -612,7 +613,7 @@ func (m *Reader) ReadInt64() (i int64, err error) {
 		if err != nil {
 			return
 		}
-		i = int64(int8(p[1]))
+		i = int64(getMint8(p))
 		_, err = m.r.Skip(2)
 		return
 
@@ -621,7 +622,7 @@ func (m *Reader) ReadInt64() (i int64, err error) {
 		if err != nil {
 			return
 		}
-		i = int64((int16(p[1]) << 8) | int16(p[2]))
+		i = int64(getMint16(p))
 		_, err = m.r.Skip(3)
 		return
 
@@ -630,7 +631,7 @@ func (m *Reader) ReadInt64() (i int64, err error) {
 		if err != nil {
 			return
 		}
-		i = int64((int32(p[1]) << 24) | (int32(p[2]) << 16) | (int32(p[3]) << 8) | (int32(p[4])))
+		i = int64(getMint32(p))
 		_, err = m.r.Skip(5)
 		return
 
@@ -639,14 +640,7 @@ func (m *Reader) ReadInt64() (i int64, err error) {
 		if err != nil {
 			return
 		}
-		i |= int64(p[1]) << 56
-		i |= int64(p[2]) << 48
-		i |= int64(p[3]) << 40
-		i |= int64(p[4]) << 32
-		i |= int64(p[5]) << 24
-		i |= int64(p[6]) << 16
-		i |= int64(p[7]) << 8
-		i |= int64(p[8])
+		i = getMint64(p)
 		_, err = m.r.Skip(9)
 		return
 
@@ -726,7 +720,7 @@ func (m *Reader) ReadUint64() (u uint64, err error) {
 		if err != nil {
 			return
 		}
-		u = uint64(p[1])
+		u = uint64(getMuint8(p))
 		_, err = m.r.Skip(2)
 		return
 
@@ -735,8 +729,7 @@ func (m *Reader) ReadUint64() (u uint64, err error) {
 		if err != nil {
 			return
 		}
-		usz := binary.BigEndian.Uint16(p[1:])
-		u = uint64(usz)
+		u = uint64(getMuint16(p))
 		_, err = m.r.Skip(3)
 		return
 
@@ -745,8 +738,7 @@ func (m *Reader) ReadUint64() (u uint64, err error) {
 		if err != nil {
 			return
 		}
-		usz := binary.BigEndian.Uint32(p[1:])
-		u = uint64(usz)
+		u = uint64(getMuint32(p))
 		_, err = m.r.Skip(5)
 		return
 
@@ -755,7 +747,7 @@ func (m *Reader) ReadUint64() (u uint64, err error) {
 		if err != nil {
 			return
 		}
-		u = binary.BigEndian.Uint64(p[1:])
+		u = getMuint64(p)
 		_, err = m.r.Skip(9)
 		return
 
@@ -838,14 +830,14 @@ func (m *Reader) ReadBytes(scratch []byte) (b []byte, err error) {
 		if err != nil {
 			return
 		}
-		read = int(binary.BigEndian.Uint16(p[1:]))
+		read = int(big.Uint16(p[1:]))
 		off = 3
 	case mbin32:
 		p, err = m.r.Peek(5)
 		if err != nil {
 			return
 		}
-		read = int(binary.BigEndian.Uint32(p[1:]))
+		read = int(big.Uint32(p[1:]))
 		off = 5
 	default:
 		err = TypeError{Method: BinType, Encoded: getType(lead)}
@@ -910,14 +902,14 @@ func (m *Reader) ReadStringAsBytes(scratch []byte) (b []byte, err error) {
 		if err != nil {
 			return
 		}
-		read = int(binary.BigEndian.Uint16(p[1:]))
+		read = int(big.Uint16(p[1:]))
 		off = 3
 	case mstr32:
 		p, err = m.r.Peek(5)
 		if err != nil {
 			return
 		}
-		read = int(binary.BigEndian.Uint32(p[1:]))
+		read = int(big.Uint32(p[1:]))
 		off = 5
 	default:
 		err = TypeError{Method: StrType, Encoded: getType(lead)}
@@ -963,14 +955,14 @@ func (m *Reader) ReadString() (s string, err error) {
 		if err != nil {
 			return
 		}
-		read = int(binary.BigEndian.Uint16(p[1:]))
+		read = int(big.Uint16(p[1:]))
 		off = 3
 	case mstr32:
 		p, err = m.r.Peek(5)
 		if err != nil {
 			return
 		}
-		read = int(binary.BigEndian.Uint32(p[1:]))
+		read = int(big.Uint32(p[1:]))
 		off = 5
 	default:
 		err = TypeError{Method: StrType, Encoded: getType(lead)}
@@ -1002,7 +994,7 @@ func (m *Reader) ReadComplex64() (f complex64, err error) {
 		err = errExt(int8(p[1]), Complex64Extension)
 		return
 	}
-	copy((*(*[8]byte)(unsafe.Pointer(&f)))[:], p[2:])
+	memcpy8(unsafe.Pointer(&f), unsafe.Pointer(&p[2]))
 	_, err = m.r.Skip(10)
 	return
 }
@@ -1023,7 +1015,7 @@ func (m *Reader) ReadComplex128() (f complex128, err error) {
 		err = errExt(int8(p[1]), Complex128Extension)
 		return
 	}
-	copy((*(*[16]byte)(unsafe.Pointer(&f)))[:], p[2:])
+	memcpy16(unsafe.Pointer(&f), unsafe.Pointer(&p[2]))
 	_, err = m.r.Skip(18)
 	return
 }

--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -17,6 +17,8 @@ var (
 	ErrShortBytes = errors.New("msgp: too few bytes left to read object")
 )
 
+var big = binary.BigEndian
+
 // IsNil returns true if len(b)>0 and
 // the leading byte is a 'nil' MessagePack
 // byte; false otherwise
@@ -99,7 +101,7 @@ func ReadMapHeaderBytes(b []byte) (sz uint32, o []byte, err error) {
 			err = ErrShortBytes
 			return
 		}
-		sz = uint32(binary.BigEndian.Uint16(b[1:]))
+		sz = uint32(big.Uint16(b[1:]))
 		o = b[3:]
 		return
 
@@ -108,7 +110,7 @@ func ReadMapHeaderBytes(b []byte) (sz uint32, o []byte, err error) {
 			err = ErrShortBytes
 			return
 		}
-		sz = binary.BigEndian.Uint32(b[1:])
+		sz = big.Uint32(b[1:])
 		o = b[5:]
 		return
 
@@ -157,7 +159,7 @@ func ReadArrayHeaderBytes(b []byte) (sz uint32, o []byte, err error) {
 			err = ErrShortBytes
 			return
 		}
-		sz = uint32(binary.BigEndian.Uint16(b[1:]))
+		sz = uint32(big.Uint16(b[1:]))
 		o = b[3:]
 		return
 
@@ -166,7 +168,7 @@ func ReadArrayHeaderBytes(b []byte) (sz uint32, o []byte, err error) {
 			err = ErrShortBytes
 			return
 		}
-		sz = binary.BigEndian.Uint32(b[1:])
+		sz = big.Uint32(b[1:])
 		o = b[5:]
 		return
 
@@ -198,16 +200,28 @@ func ReadNilBytes(b []byte) ([]byte, error) {
 // - TypeError{} (not a float64)
 func ReadFloat64Bytes(b []byte) (f float64, o []byte, err error) {
 	if len(b) < 9 {
+		if len(b) >= 5 && b[0] == mfloat32 {
+			var tf float32
+			tf, o, err = ReadFloat32Bytes(b)
+			f = float64(tf)
+			return
+		}
 		err = ErrShortBytes
 		return
 	}
 
 	if b[0] != mfloat64 {
+		if b[0] == mfloat32 {
+			var tf float32
+			tf, o, err = ReadFloat32Bytes(b)
+			f = float64(tf)
+			return
+		}
 		err = TypeError{Method: Float64Type, Encoded: getType(b[0])}
 		return
 	}
 
-	copy((*(*[8]byte)(unsafe.Pointer(&f)))[:], b[1:])
+	memcpy8(unsafe.Pointer(&f), unsafe.Pointer(&b[1]))
 	o = b[9:]
 	return
 }
@@ -228,7 +242,7 @@ func ReadFloat32Bytes(b []byte) (f float32, o []byte, err error) {
 		return
 	}
 
-	copy((*(*[4]byte)(unsafe.Pointer(&f)))[:], b[1:])
+	memcpy4(unsafe.Pointer(&f), unsafe.Pointer(&b[1]))
 	o = b[5:]
 	return
 }
@@ -281,7 +295,7 @@ func ReadInt64Bytes(b []byte) (i int64, o []byte, err error) {
 			err = ErrShortBytes
 			return
 		}
-		i = int64(int8(b[1]))
+		i = int64(getMint8(b))
 		o = b[2:]
 		return
 
@@ -290,7 +304,7 @@ func ReadInt64Bytes(b []byte) (i int64, o []byte, err error) {
 			err = ErrShortBytes
 			return
 		}
-		i = int64((int16(b[1]) << 8) | int16(b[2]))
+		i = int64(getMint16(b))
 		o = b[3:]
 		return
 
@@ -299,7 +313,7 @@ func ReadInt64Bytes(b []byte) (i int64, o []byte, err error) {
 			err = ErrShortBytes
 			return
 		}
-		i = int64((int32(b[1]) << 24) | (int32(b[2]) << 16) | (int32(b[3]) << 8) | int32(b[4]))
+		i = int64(getMint32(b))
 		o = b[5:]
 		return
 
@@ -308,14 +322,7 @@ func ReadInt64Bytes(b []byte) (i int64, o []byte, err error) {
 			err = ErrShortBytes
 			return
 		}
-		i |= (int64(b[1]) << 56)
-		i |= (int64(b[2]) << 48)
-		i |= (int64(b[3]) << 40)
-		i |= (int64(b[4]) << 36)
-		i |= (int64(b[5]) << 24)
-		i |= (int64(b[6]) << 16)
-		i |= (int64(b[7]) << 8)
-		i |= (int64(b[8]))
+		i = getMint64(b)
 		o = b[9:]
 		return
 
@@ -409,7 +416,7 @@ func ReadUint64Bytes(b []byte) (u uint64, o []byte, err error) {
 			err = ErrShortBytes
 			return
 		}
-		u = uint64(b[1])
+		u = uint64(getMuint8(b))
 		o = b[2:]
 		return
 
@@ -418,7 +425,7 @@ func ReadUint64Bytes(b []byte) (u uint64, o []byte, err error) {
 			err = ErrShortBytes
 			return
 		}
-		u = uint64(binary.BigEndian.Uint16(b[1:]))
+		u = uint64(getMuint16(b))
 		o = b[3:]
 		return
 
@@ -427,7 +434,7 @@ func ReadUint64Bytes(b []byte) (u uint64, o []byte, err error) {
 			err = ErrShortBytes
 			return
 		}
-		u = uint64(binary.BigEndian.Uint32(b[1:]))
+		u = uint64(getMuint32(b))
 		o = b[5:]
 		return
 
@@ -436,7 +443,7 @@ func ReadUint64Bytes(b []byte) (u uint64, o []byte, err error) {
 			err = ErrShortBytes
 			return
 		}
-		u = binary.BigEndian.Uint64(b[1:])
+		u = getMuint64(b)
 		o = b[9:]
 		return
 
@@ -542,7 +549,7 @@ func readBytesBytes(b []byte, scratch []byte, zc bool) (v []byte, o []byte, err 
 			err = ErrShortBytes
 			return
 		}
-		read = int(binary.BigEndian.Uint16(b[1:]))
+		read = int(big.Uint16(b[1:]))
 		b = b[3:]
 
 	case mbin32:
@@ -550,7 +557,7 @@ func readBytesBytes(b []byte, scratch []byte, zc bool) (v []byte, o []byte, err 
 			err = ErrShortBytes
 			return
 		}
-		read = int(binary.BigEndian.Uint32(b[1:]))
+		read = int(big.Uint32(b[1:]))
 		b = b[5:]
 
 	default:
@@ -576,8 +583,7 @@ func readBytesBytes(b []byte, scratch []byte, zc bool) (v []byte, o []byte, err 
 		v = make([]byte, read)
 	}
 
-	n := copy(v, b)
-	o = b[n:]
+	o = b[copy(v, b):]
 	return
 }
 
@@ -624,7 +630,7 @@ func ReadStringZC(b []byte) (v []byte, o []byte, err error) {
 				err = ErrShortBytes
 				return
 			}
-			read = int(binary.BigEndian.Uint16(b[1:]))
+			read = int(big.Uint16(b[1:]))
 			b = b[3:]
 
 		case mstr32:
@@ -632,7 +638,7 @@ func ReadStringZC(b []byte) (v []byte, o []byte, err error) {
 				err = ErrShortBytes
 				return
 			}
-			read = int(binary.BigEndian.Uint32(b[1:]))
+			read = int(big.Uint32(b[1:]))
 			b = b[5:]
 
 		default:
@@ -685,7 +691,7 @@ func ReadComplex128Bytes(b []byte) (c complex128, o []byte, err error) {
 		err = errExt(int8(b[1]), Complex128Extension)
 		return
 	}
-	copy((*(*[16]byte)(unsafe.Pointer(&c)))[:], b[2:])
+	memcpy16(unsafe.Pointer(&c), unsafe.Pointer(&b[2]))
 	o = b[18:]
 	return
 }
@@ -713,7 +719,7 @@ func ReadComplex64Bytes(b []byte) (c complex64, o []byte, err error) {
 		err = errExt(int8(b[1]), Complex64Extension)
 		return
 	}
-	copy((*(*[8]byte)(unsafe.Pointer(&c)))[:], b[2:])
+	memcpy8(unsafe.Pointer(&c), unsafe.Pointer(&b[2]))
 	o = b[10:]
 	return
 }
@@ -1033,13 +1039,13 @@ func getSize(b []byte) (int, int, error) {
 		if len(b) < 3 {
 			return 0, 0, ErrShortBytes
 		}
-		return int(binary.BigEndian.Uint16(b[1:])) + 3, 0, nil
+		return int(big.Uint16(b[1:])) + 3, 0, nil
 
 	case mbin32, mstr32:
 		if len(b) < 5 {
 			return 0, 0, ErrShortBytes
 		}
-		return int(binary.BigEndian.Uint32(b[1:])) + 5, 0, nil
+		return int(big.Uint32(b[1:])) + 5, 0, nil
 
 	// variable extensions
 	// require 1 extra byte
@@ -1054,13 +1060,13 @@ func getSize(b []byte) (int, int, error) {
 		if len(b) < 4 {
 			return 0, 0, ErrShortBytes
 		}
-		return int(binary.BigEndian.Uint16(b[1:])) + 4, 0, nil
+		return int(big.Uint16(b[1:])) + 4, 0, nil
 
 	case mext32:
 		if len(b) < 6 {
 			return 0, 0, ErrShortBytes
 		}
-		return int(binary.BigEndian.Uint32(b[1:])) + 6, 0, nil
+		return int(big.Uint32(b[1:])) + 6, 0, nil
 
 	// arrays skip lead byte,
 	// size byte, N objects
@@ -1068,13 +1074,13 @@ func getSize(b []byte) (int, int, error) {
 		if len(b) < 3 {
 			return 0, 0, ErrShortBytes
 		}
-		return 3, int(binary.BigEndian.Uint16(b[1:])), nil
+		return 3, int(big.Uint16(b[1:])), nil
 
 	case marray32:
 		if len(b) < 5 {
 			return 0, 0, ErrShortBytes
 		}
-		return 5, int(binary.BigEndian.Uint32(b[1:])), nil
+		return 5, int(big.Uint32(b[1:])), nil
 
 	// maps skip lead byte,
 	// size byte, 2N objects
@@ -1082,13 +1088,13 @@ func getSize(b []byte) (int, int, error) {
 		if len(b) < 3 {
 			return 0, 0, ErrShortBytes
 		}
-		return 3, 2 * (int(binary.BigEndian.Uint16(b[1:]))), nil
+		return 3, 2 * (int(big.Uint16(b[1:]))), nil
 
 	case mmap32:
 		if len(b) < 5 {
 			return 0, 0, ErrShortBytes
 		}
-		return 5, 2 * (int(binary.BigEndian.Uint32(b[1:]))), nil
+		return 5, 2 * (int(big.Uint32(b[1:]))), nil
 
 	default:
 		return 0, 0, InvalidPrefixError(lead)

--- a/msgp/write_bytes_test.go
+++ b/msgp/write_bytes_test.go
@@ -89,7 +89,7 @@ func TestAppendInt64(t *testing.T) {
 		en.Flush()
 		bts = AppendInt64(bts[0:0], i)
 		if !bytes.Equal(buf.Bytes(), bts) {
-			t.Errorf("for int64 %d, encoder wrote %q; append wrote %q", buf.Bytes(), bts)
+			t.Errorf("for int64 %d, encoder wrote %q; append wrote %q", i, buf.Bytes(), bts)
 		}
 	}
 }
@@ -106,7 +106,7 @@ func TestAppendUint64(t *testing.T) {
 		en.Flush()
 		bts = AppendUint64(bts[0:0], u)
 		if !bytes.Equal(buf.Bytes(), bts) {
-			t.Errorf("for uint64 %d, encoder wrote %q; append wrote %q", buf.Bytes(), bts)
+			t.Errorf("for uint64 %d, encoder wrote %q; append wrote %q", u, buf.Bytes(), bts)
 		}
 	}
 }

--- a/msgp/write_test.go
+++ b/msgp/write_test.go
@@ -14,8 +14,8 @@ var (
 	tint32         = math.MaxInt16 + 100  // cannot be int16
 	tint64         = math.MaxInt32 + 100  // cannot be int32
 	tuint16 uint32 = 300                  // cannot be uint8
-	tuint32 uint32 = math.MaxUint16 + 100 // cannot be int16
-	tuint64 uint64 = math.MaxUint32 + 100 // cannot be int32
+	tuint32 uint32 = math.MaxUint16 + 100 // cannot be uint16
+	tuint64 uint64 = math.MaxUint32 + 100 // cannot be uint32
 )
 
 func RandBytes(sz int) []byte {


### PR DESCRIPTION
For moving `float32`, `float64`, `complex64`, and `complex128`, we can use inline-able (and branch-free) copy functions.
