### PR TITLE
Shim2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test-pkg: install
 	@go test -v ./_generated
 
 bench: install generate
-	@go test -v -bench . ./_generated
+	@go test -bench . ./_generated
 
 clean:
 	rm ./_generated/generated.go && rm ./_generated/generated_test.go

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ MessagePack Code Generator
 =======
 
 [![forthebadge](http://forthebadge.com/badges/uses-badges.svg)](http://forthebadge.com)
-[![forthebadge](http://forthebadge.com/badges/certified-snoop-lion.svg)](http://forthebadge.com)
+[![forthebadge](http://forthebadge.com/badges/ages-12.svg)](http://forthebadge.com)
 
 This is a code generation tool and serialization library for [MesssagePack](http://msgpack.org). It is targeted at the `go generate` [tool](http://tip.golang.org/cmd/go/#hdr-Generate_Go_files_by_processing_source). You can read more about MessagePack [in the wiki](http://github.com/philhofer/msgp/wiki), or at [msgpack.org](http://msgp.org).
 
@@ -29,29 +29,6 @@ need code generation.
 
 You can [read more about the code generation options here](http://github.com/philhofer/msgp/wiki/Using-the-Code-Generator).
 
-Once you have the appropriate methods generated, we can use the methods in `github.com/philhofer/msgp/msgp` to serialize and
-de-serialize the objects.
-
-For example, if we had generated methods for a `Person` struct:
-```go
-import (
-	"github.com/philhofer/msgp/msgp"
-	"os"
-)
-
-p := &Person{
-	Name: "Huck Finn",
-	Age: 14,
-}
-
-func main() {
-	// write 'p' to standard out
-    // (no need for buffering here; 
-    // Encode does it for you)
-    msgp.Encode(os.Stdout, p)
-}
-```
-
 ### Use
 
 Field names can be set in much the same way as the `encoding/json` package. For example:
@@ -70,11 +47,10 @@ By default, the code generator will satisfy `msgp.Sizer`, `msgp.Encodable`, `msg
 `msgp.Marshaler`, and `msgp.Unmarshaler`. Carefully-designed applications can use these methods to do
 marshalling/unmarshalling with zero allocations.
 
-One of the unique features of this package is the implementation of `*Reader` and `*Writer`, which
-are both buffered. The fact that these objects can manipulate the contents of their buffers directly
-means that encoding and decoding from streams can be nearly as fast as marshalling and unmarshalling. 
-Additionally, the fact that these are buffered means that they can be directly applied to a `net.Conn`
-or `*os.File`, for example.
+While `msgp.Marshaler` and `msgp.Unmarshaler` are quite similar to the standard library's
+`json.Marshaler` and `json.Unmarshaler`, `msgp.Encodable` and `msgp.Decodable` are useful for 
+stream serialization. (`*msgp.Writer` and `*msgp.Reader` are essentially protocol-aware versions
+of `*bufio.Writer` and `*bufio.Reader`, respectively.)
 
 ### Features
 
@@ -84,7 +60,8 @@ or `*os.File`, for example.
  - Identifier resolution (see below)
  - Native support for Go's `time.Time`, `complex64`, and `complex128` types 
  - Generation of both `[]byte`-oriented and `io.Reader/io.Writer`-oriented methods
- - Support for arbitrary type system extensions (see below)
+ - Support for arbitrary type system extensions
+ - Preprocessor directives
 
 Because of (limited) identifier resolution, the code generator will still yield the
 correct code for the following struct declaration:

--- a/_generated/def.go
+++ b/_generated/def.go
@@ -69,12 +69,61 @@ type Things struct {
 	Oext  msgp.RawExtension  `msg:"oext,extension"` // test extension reference
 }
 
+// test ignore directive (below)
+
+//msgp:ignore Empty
+
 type Empty struct{}
 
+type MyEnum byte
+
+const (
+	A MyEnum = iota
+	B
+	C
+	D
+	invalid
+)
+
+// test shim directive (below)
+
+//msgp:shim MyEnum as:string using:(MyEnum).String/myenumStr
+
+func (m MyEnum) String() string {
+	switch m {
+	case A:
+		return "A"
+	case B:
+		return "B"
+	case C:
+		return "C"
+	case D:
+		return "D"
+	default:
+		return "<invalid>"
+	}
+}
+
+func myenumStr(s string) MyEnum {
+	switch s {
+	case "A":
+		return A
+	case "B":
+		return B
+	case "C":
+		return C
+	case "D":
+		return D
+	default:
+		return invalid
+	}
+}
+
 type Custom struct {
-	Int map[string]CustomInt
-	Bts CustomBytes
-	Mp  map[string]*Embedded
+	Int  map[string]CustomInt `msg:"mapstrint"`
+	Bts  CustomBytes          `msg:"bts"`
+	Mp   map[string]*Embedded `msg:"mp"`
+	Enum MyEnum               `msg:"enum"` // test explicit enum shim
 }
 type CustomInt int
 type CustomBytes []byte

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -304,10 +304,12 @@ func (s StructField) String() string {
 }
 
 type BaseElem struct {
-	name    string
-	Value   Base
-	Ident   string // IDENT name if unresolved
-	Convert bool   // should we do an explicit conversion?
+	name         string
+	Value        Base
+	Ident        string // IDENT name if unresolved
+	Convert      bool   // should we do an explicit conversion?
+	ShimToBase   string // shim to base type
+	ShimFromBase string // shim from base type
 }
 
 func (s *BaseElem) Type() ElemType  { return BaseType }
@@ -332,6 +334,8 @@ func (s *BaseElem) SetVarname(a string) {
 			s.name = "&" + a
 		}
 		return
+
+		// if we're using a shim
 	}
 
 	s.name = a
@@ -346,6 +350,22 @@ func (s *BaseElem) TypeName() string {
 		return s.Ident
 	}
 	return s.BaseType()
+}
+
+// ToBase, used if Convert==true, is used as tmp = {{ToBase}}({{Varname}})
+func (s *BaseElem) ToBase() string {
+	if s.ShimToBase != "" {
+		return s.ShimToBase
+	}
+	return s.BaseType()
+}
+
+// FromBase, used if Convert==true, is used as {{Varname}} = {{FromBase}}(tmp)
+func (s *BaseElem) FromBase() string {
+	if s.ShimFromBase != "" {
+		return s.ShimFromBase
+	}
+	return s.Ident
 }
 
 // BaseName returns the string form of the
@@ -373,7 +393,7 @@ func (s *BaseElem) BaseType() string {
 	case Time:
 		return "time.Time"
 	case Ext:
-		return "enc.Extension"
+		return "msgp.Extension"
 
 	// everything else is base.String() with
 	// the first letter as lowercase

--- a/gen/elem_dec.tmpl
+++ b/gen/elem_dec.tmpl
@@ -106,7 +106,7 @@
 	{{else}}{{/* any other type */}}
 	{{if .Convert}}tmp, err = dc.Read{{.BaseName}}(){{else}}{{.Varname}}, err = dc.Read{{.BaseName}}(){{end}}
 	{{end}}
-	{{if .Convert}}{{.Varname}} = {{.Ident}}(tmp){{end}}
+	{{if .Convert}}{{.Varname}} = {{.FromBase}}(tmp){{end}}
 	if err != nil {
 		return
 	}

--- a/gen/elem_enc.tmpl
+++ b/gen/elem_enc.tmpl
@@ -13,7 +13,7 @@
 
 {{define "BaseTempl"}}
 	{{if .Convert}}
-	err = en.Write{{.BaseName}}({{.BaseType}}({{.Varname}}))
+	err = en.Write{{.BaseName}}({{.ToBase}}({{.Varname}}))
 	{{else if .IsIdent}}
 	err = {{.Varname}}.EncodeMsg(en)
 	{{else}}

--- a/gen/elem_unm.tmpl
+++ b/gen/elem_unm.tmpl
@@ -11,7 +11,7 @@
 	{{else}}{{/* any other type */}}
 	{{if .Convert}}tmp, bts, err = msgp.Read{{.BaseName}}Bytes(bts){{else}}{{.Varname}}, bts, err = msgp.Read{{.BaseName}}Bytes(bts){{end}}
 	{{end}}
-	{{if .Convert}}{{.Varname}} = {{.Ident}}(tmp){{end}}
+	{{if .Convert}}{{.Varname}} = {{.FromBase}}(tmp){{end}}
 	if err != nil {
 		return
 	}

--- a/gen/marshal_enc.tmpl
+++ b/gen/marshal_enc.tmpl
@@ -10,7 +10,7 @@
 
 {{define "BaseTempl"}}
 	{{if .Convert}}
-	o = msgp.Append{{.BaseName}}(o, {{.BaseType}}({{.Varname}}))
+	o = msgp.Append{{.BaseName}}(o, {{.ToBase}}({{.Varname}}))
 	{{else if .IsIdent}}
 	o, err = {{.Varname}}.MarshalMsg(o)
 	if err != nil {

--- a/gen/size_enc.tmpl
+++ b/gen/size_enc.tmpl
@@ -42,5 +42,14 @@
 {{end}}
 
 {{define "BaseTempl"}}
-{{if .IsIntf}}s += msgp.GuessSize({{.Varname}}){{else if .IsIdent}}s += {{.Varname}}.Msgsize(){{else if (or (eq .Value 1) (eq .Value 2))}}{{/* string or []byte */}}s += msgp.{{.BaseName}}PrefixSize + len({{.Varname}}){{else if .IsExt}}s += msgp.ExtensionSize({{.Varname}}){{else}}s += msgp.{{.BaseName}}Size{{end}}
+{{if .IsIntf}}s += msgp.GuessSize({{.Varname}})
+{{else if .IsIdent}}s += {{.Varname}}.Msgsize()
+{{else if (or (eq .Value 1) (eq .Value 2))}}{{/* string or []byte */}}
+{{if .Convert}}
+s += msgp.{{.BaseName}}PrefixSize + len({{.ToBase}}({{.Varname}}))
+{{else}}
+s += msgp.{{.BaseName}}PrefixSize + len({{.Varname}})
+{{end}}
+{{else if .IsExt}}s += msgp.ExtensionSize({{.Varname}})
+{{else}}s += msgp.{{.BaseName}}Size{{end}}
 {{end}}

--- a/main.go
+++ b/main.go
@@ -87,7 +87,6 @@ func DoAll(gopkg string, gofile string, marshal bool, encode bool, tests bool) e
 		return nil
 	}
 
-	// new file name is old file name + _gen.go
 	var isDir bool
 	if fInfo, err := os.Stat(gofile); err == nil && fInfo.IsDir() {
 		isDir = true
@@ -104,16 +103,21 @@ func DoAll(gopkg string, gofile string, marshal bool, encode bool, tests bool) e
 		return err
 	}
 
+	// use the parsed
+	// package name if it
+	// isn't set from $GOPACKAGE
 	if len(gopkg) == 0 {
 		gopkg = pkgName
 	}
 
+	// no need to continue if
+	// we don't need to generate anything
 	if len(elems) == 0 {
 		fmt.Println(chalk.Magenta.Color("No structs requiring code generation were found..."))
 		return nil
 	}
 
-	var newfile string
+	var newfile string // new file name
 	if out != "" {
 		newfile = out
 		if pre := strings.TrimPrefix(out, gofile); len(pre) > 0 &&
@@ -126,6 +130,7 @@ func DoAll(gopkg string, gofile string, marshal bool, encode bool, tests bool) e
 		if isDir {
 			gofile = filepath.Join(gofile, pkgName)
 		}
+		// new file name is old file name + _gen.go
 		newfile = strings.TrimSuffix(gofile, ".go") + "_gen.go"
 	}
 
@@ -181,9 +186,6 @@ func DoAll(gopkg string, gofile string, marshal bool, encode bool, tests bool) e
 		if !ok || p.Value.Type() != gen.StructType {
 			continue
 		}
-		// propogate names to
-		// child elements of struct
-		p.SetVarname("z")
 
 		if marshal {
 			// write MarshalMsg()

--- a/msgp/integers.go
+++ b/msgp/integers.go
@@ -139,6 +139,32 @@ func getMuint8(b []byte) (u uint8) {
 	return
 }
 
+/* -----------------------------
+		prefix utilities
+   ----------------------------- */
+
+// write prefix and uint8
+func prefixu8(b []byte, pre byte, sz uint8) {
+	b[0] = pre
+	b[1] = byte(sz)
+}
+
+// write prefix and big-endian uint16
+func prefixu16(b []byte, pre byte, sz uint16) {
+	b[0] = pre
+	b[1] = byte(sz >> 8)
+	b[2] = byte(sz)
+}
+
+// write prefix and big-endian uint32
+func prefixu32(b []byte, pre byte, sz uint32) {
+	b[0] = pre
+	b[1] = byte(sz >> 24)
+	b[2] = byte(sz >> 16)
+	b[3] = byte(sz >> 8)
+	b[4] = byte(sz)
+}
+
 /* ---------------------------
 	memory-copying utilities
 	WARNING: gross code ahead

--- a/msgp/write.go
+++ b/msgp/write.go
@@ -302,9 +302,7 @@ func (mw *Writer) WriteMapHeader(sz uint32) error {
 		if err != nil {
 			return err
 		}
-		mw.buf[o] = mmap16
-		mw.buf[o+1] = byte(sz >> 8)
-		mw.buf[o+2] = byte(sz)
+		prefixu16(mw.buf[o:], mmap16, uint16(sz))
 		return nil
 
 	default:
@@ -312,8 +310,7 @@ func (mw *Writer) WriteMapHeader(sz uint32) error {
 		if err != nil {
 			return err
 		}
-		mw.buf[o] = mmap32
-		big.PutUint32(mw.buf[o+1:], sz)
+		prefixu32(mw.buf[o:], mmap32, sz)
 		return nil
 	}
 }
@@ -330,16 +327,14 @@ func (mw *Writer) WriteArrayHeader(sz uint32) error {
 		if err != nil {
 			return err
 		}
-		mw.buf[o] = marray16
-		big.PutUint16(mw.buf[o+1:], uint16(sz))
+		prefixu16(mw.buf[o:], marray16, uint16(sz))
 		return nil
 	default:
 		o, err := mw.require(5)
 		if err != nil {
 			return err
 		}
-		mw.buf[o] = marray32
-		big.PutUint32(mw.buf[o+1:], sz)
+		prefixu32(mw.buf[o:], marray32, sz)
 		return nil
 	}
 }
@@ -488,15 +483,13 @@ func (mw *Writer) WriteBytes(b []byte) error {
 		if err != nil {
 			return err
 		}
-		mw.buf[o] = mbin16
-		big.PutUint16(mw.buf[o+1:], uint16(sz))
+		prefixu16(mw.buf[o:], mbin16, uint16(sz))
 	default:
 		o, err := mw.require(5)
 		if err != nil {
 			return err
 		}
-		mw.buf[o] = mbin32
-		big.PutUint32(mw.buf[o+1:], sz)
+		prefixu32(mw.buf[o:], mbin32, sz)
 	}
 
 	// write body
@@ -530,15 +523,13 @@ func (mw *Writer) WriteString(s string) error {
 		if err != nil {
 			return err
 		}
-		mw.buf[o] = mstr16
-		big.PutUint16(mw.buf[o+1:], uint16(sz))
+		prefixu16(mw.buf[o:], mstr16, uint16(sz))
 	default:
 		o, err := mw.require(5)
 		if err != nil {
 			return err
 		}
-		mw.buf[o] = mstr32
-		big.PutUint32(mw.buf[o+1:], sz)
+		prefixu32(mw.buf[o:], mstr32, sz)
 	}
 
 	// write body

--- a/parse/directives.go
+++ b/parse/directives.go
@@ -1,0 +1,84 @@
+package parse
+
+import (
+	"fmt"
+	"github.com/philhofer/msgp/gen"
+	"go/ast"
+	"strings"
+)
+
+// map of all recognized directives
+//
+// to add a directive, define a func([]string, *FileSet) error
+// and then add it to this list.
+var directives = map[string]func([]string, *FileSet) error{
+	"shim":   applyShim,
+	"ignore": ignore,
+}
+
+type shim struct {
+	tp   gen.Base
+	to   string // toShim function name
+	from string // fromShim function name
+}
+
+// find all comment lines that begin with //msgp:
+func yieldComments(c []*ast.CommentGroup) []string {
+	var out []string
+	for _, cg := range c {
+		for _, line := range cg.List {
+			if strings.HasPrefix(line.Text, "//msgp:") {
+				out = append(out, strings.TrimPrefix(line.Text, "//msgp:"))
+			}
+		}
+	}
+	return out
+}
+
+//msgp:shim {Type} as:{Newtype} using:{toFunc/fromFunc}
+func applyShim(text []string, f *FileSet) error {
+	if len(text) != 4 {
+		return fmt.Errorf("shim directive should have 3 arguments; found %d", len(text)-1)
+	}
+	if f.shims == nil {
+		f.shims = make(map[string]*shim)
+	}
+
+	name := text[1]
+	if _, ok := f.shims[name]; ok {
+		return fmt.Errorf("shim already exists for %s", name)
+	}
+	tp := pullIdent(strings.TrimPrefix(strings.TrimSpace(text[2]), "as:")) // parse as::{base}
+
+	usestr := strings.TrimPrefix(strings.TrimSpace(text[3]), "using:") // parse using::{method/method}
+
+	methods := strings.Split(usestr, "/")
+	if len(methods) != 2 {
+		return fmt.Errorf("expected 2 using::{} methods; found %d (%q)", len(methods), text[3])
+	}
+	infof("applying shim for %s -> %s ...\n", name, tp.String())
+	f.shims[name] = &shim{
+		tp:   tp,
+		to:   methods[0],
+		from: methods[1],
+	}
+	return nil
+}
+
+//msgp:ignore {TypeA} {TypeB}...
+func ignore(text []string, f *FileSet) error {
+	if len(text) < 2 {
+		return nil
+	}
+	for _, item := range text[1:] {
+		name := strings.TrimSpace(item)
+		for i, dec := range f.Specs {
+			if dec != nil && dec.Name != nil && name == dec.Name.Name {
+				// delete spec
+				f.Specs, f.Specs[i], f.Specs[len(f.Specs)-1] = f.Specs[:len(f.Specs)-1], f.Specs[len(f.Specs)-1], nil
+				infof("ignoring: %s...\n", name)
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
**Work-in-progress** feature request for #31.

This PR is a major overhaul of `/parse`, partly because I anticipate we will want to add more preprocessor directives in the future.

So, right now, there are two recognized "directives:"
##### shim

``` go
//msgp:shim MyEnum as:string using:(MyEnum).String/myenumStr

type MyEnum uint8

func (m MyEnum) String() { /* */ }

func myEnumStr(s string) MyEnum { /* */ }
```

`shim` uses a pair of conversion functions to convert one type to another in the generated code. Among other things, this allows for Go's `const`/`iota` blocks to be turned into strings during encoding.
##### ignore

``` go
//msgp:ignore TypeA TypeB TypeC
```

`ignore` just tells the generator not to generate code for the named types.
#### TODO
- Now would be a good time to make processing and generation run in parallel
- Maybe we want slightly different semantics for type conversions? Right now it only supports types that map to `gen.Base`.
