### PR TITLE
use runtime.Caller to decipher template dir

### DIFF
--- a/gen/decode.go
+++ b/gen/decode.go
@@ -6,6 +6,8 @@ import (
 	"go/format"
 	"io"
 	"os"
+	"path/filepath"
+	"runtime"
 	"text/template"
 )
 
@@ -21,14 +23,8 @@ var (
 )
 
 func init() {
-	gopath := os.Getenv("GOPATH")
-	if gopath == "" {
-		fmt.Println("msgp/gen: FATAL: GOPATH not set; can't locate templates")
-		os.Exit(1)
-	}
-
-	// TODO: there may be a better way to locate the template files...
-	prefix := gopath + "/src/github.com/philhofer/msgp/gen/"
+	_, prefix, _, _ := runtime.Caller(0)
+	prefix = filepath.Dir(prefix) + "/"
 
 	decTemplate = template.Must(template.ParseFiles(prefix+"decode.tmpl", prefix+"elem_dec.tmpl"))
 	encTemplate = template.Must(template.ParseFiles(prefix+"encode.tmpl", prefix+"elem_enc.tmpl"))


### PR DESCRIPTION
msgp fails when GOPATH has multiple entries

A better way to grab the base path of the tmpl files is to start from the path of the current go file. runtime.Caller exposes this.

Fixes #36
