### PR TITLE
add Raw type that implements all standard interfaces

### DIFF
--- a/_generated/def.go
+++ b/_generated/def.go
@@ -24,9 +24,10 @@ type TestType struct {
 		ValueA string `msg:"value_a"`
 		ValueB []byte `msg:"value_b"`
 	} `msg:"object"`
-	Child *TestType   `msg:"child"`
-	Time  time.Time   `msg:"time"`
-	Any   interface{} `msg:"any"`
+	Child    *TestType   `msg:"child"`
+	Time     time.Time   `msg:"time"`
+	Any      interface{} `msg:"any"`
+	Appended msgp.Raw    `msg:"appended"`
 }
 
 //msgp:tuple TestBench

--- a/_generated/gen_test.go
+++ b/_generated/gen_test.go
@@ -78,8 +78,9 @@ func Test1EncodeDecode(t *testing.T) {
 			ValueA: "here's the first inner value",
 			ValueB: []byte("here's the second inner value"),
 		},
-		Child: nil,
-		Time:  time.Now(),
+		Child:    nil,
+		Time:     time.Now(),
+		Appended: msgp.Raw([]byte{0xc0}), // 'nil'
 	}
 
 	var buf bytes.Buffer

--- a/msgp/raw_test.go
+++ b/msgp/raw_test.go
@@ -1,0 +1,85 @@
+package msgp
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+// all standard interfaces
+type allifaces interface {
+	Encodable
+	Decodable
+	Marshaler
+	Unmarshaler
+	Sizer
+}
+
+func TestRaw(t *testing.T) {
+	bts := make([]byte, 0, 512)
+	bts = AppendMapHeader(bts, 3)
+	bts = AppendString(bts, "key_one")
+	bts = AppendFloat64(bts, -1.0)
+	bts = AppendString(bts, "key_two")
+	bts = AppendString(bts, "value_two")
+	bts = AppendString(bts, "key_three")
+	bts = AppendTime(bts, time.Now())
+
+	var r Raw
+
+	// verify that Raw satisfies
+	// the interfaces we want it to
+	var _ allifaces = &r
+
+	// READ TESTS
+
+	extra, err := r.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal("error from UnmarshalMsg:", err)
+	}
+	if len(extra) != 0 {
+		t.Errorf("expected 0 bytes left; found %d", len(extra))
+	}
+	if !bytes.Equal([]byte(r), bts) {
+		t.Fatal("value of raw and input slice are not equal after UnmarshalMsg")
+	}
+
+	r = r[:0]
+
+	var buf bytes.Buffer
+	buf.Write(bts)
+
+	rd := NewReader(&buf)
+
+	err = r.DecodeMsg(rd)
+	if err != nil {
+		t.Fatal("error from DecodeMsg:", err)
+	}
+
+	if !bytes.Equal([]byte(r), bts) {
+		t.Fatal("value of raw and input slice are not equal after DecodeMsg")
+	}
+
+	// WRITE TESTS
+
+	buf.Reset()
+	wr := NewWriter(&buf)
+	err = r.EncodeMsg(wr)
+	if err != nil {
+		t.Fatal("error from EncodeMsg:", err)
+	}
+
+	wr.Flush()
+	if !bytes.Equal(buf.Bytes(), bts) {
+		t.Fatal("value of buf.Bytes() and input slice are not equal after EncodeMsg")
+	}
+
+	var outsl []byte
+	outsl, err = r.MarshalMsg(outsl)
+	if err != nil {
+		t.Fatal("error from MarshalMsg:", err)
+	}
+	if !bytes.Equal(outsl, bts) {
+		t.Fatal("value of output and input of MarshalMsg are not equal.")
+	}
+}

--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -49,6 +49,81 @@ func IsNil(b []byte) bool {
 	return false
 }
 
+// Raw is raw MessagePack.
+// Raw allows you to read and write
+// data without interpreting its contents.
+type Raw []byte
+
+// MarshalMsg implements msgp.Marshaler.
+// It appends the raw contents of 'raw'
+// to the provided byte slice.
+func (r Raw) MarshalMsg(b []byte) ([]byte, error) {
+	o := Require(b, len(r))
+	i := len(o)
+	o = o[:i+len(r)]
+	copy(o[i:], []byte(r))
+	return r, nil
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler.
+// It sets the contents of *Raw to be the next
+// object in the provided byte slice.
+func (r *Raw) UnmarshalMsg(b []byte) ([]byte, error) {
+	l := len(b)
+	out, err := Skip(b)
+	if err != nil {
+		return b, err
+	}
+	rlen := l - len(out)
+	if cap(*r) < rlen {
+		*r = make(Raw, rlen)
+	} else {
+		*r = (*r)[0:rlen]
+	}
+	copy(*r, b[:rlen])
+	return out, nil
+}
+
+// EncodeMsg implements msgp.Encodable.
+// It writes the raw bytes to the writer.
+func (r Raw) EncodeMsg(w *Writer) error {
+	_, err := w.Write([]byte(r))
+	return err
+}
+
+// DecodeMsg implements msgp.Decodable.
+// It sets the value of *Raw to be the
+// next object on the wire.
+func (r *Raw) DecodeMsg(f *Reader) error {
+	*r = (*r)[:0]
+	return appendNext(f, (*[]byte)(r))
+}
+
+// MsgSize implements msgp.Sizer
+func (r Raw) Msgsize() int {
+	return len(r)
+}
+
+func appendNext(f *Reader, d *[]byte) error {
+	amt, o, err := getNextSize(f.r)
+	if err != nil {
+		return err
+	}
+	var i int
+	*d, i = ensure(*d, int(amt))
+	_, err = f.r.ReadFull((*d)[i:])
+	if err != nil {
+		return err
+	}
+	for u := uintptr(0); u < o; u++ {
+		err = appendNext(f, d)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // ReadMapHeaderBytes reads a map header size
 // from 'b' and returns the remaining bytes.
 // Possible errors:

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -471,10 +471,18 @@ func (fs *FileSet) parseExpr(e ast.Expr) gen.Elem {
 		return nil
 
 	case *ast.SelectorExpr:
-		// special case for time.Time; others go to Ident
+		// special case for time.Time and msgp.Raw
 		if im, ok := e.X.(*ast.Ident); ok {
 			if e.Sel.Name == "Time" && im.Name == "time" {
 				return &gen.BaseElem{Value: gen.Time}
+
+			} else if e.Sel.Name == "Raw" && im.Name == "msgp" {
+				fs.Identities["msgp.Raw"] = gen.IDENT
+				fs.processed["msgp.Raw"] = set
+				return &gen.BaseElem{
+					Value: gen.IDENT,
+					Ident: "msgp.Raw",
+				}
 			} else {
 				return &gen.BaseElem{
 					Value: gen.IDENT,


### PR DESCRIPTION
Title is self-evident.

This feature makes it easy to process data incrementally. For example:
```go
type Container struct {
    Title string   `msg:"title"`
    Body  msgp.Raw `msg:"body"`
}
```

I anticipate this pattern will be used for `synapse` middleware.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/49)
<!-- Reviewable:end -->
