### PR TITLE
Hotfix #65

### DIFF
--- a/_generated/def.go
+++ b/_generated/def.go
@@ -2,6 +2,7 @@ package _generated
 
 import (
 	"github.com/tinylib/msgp/msgp"
+	"os"
 	"time"
 )
 
@@ -98,6 +99,17 @@ const (
 
 //msgp:shim MyEnum as:string using:(MyEnum).String/myenumStr
 
+//msgp:shim *os.File as:string using:filetostr/filefromstr
+
+func filetostr(f *os.File) string {
+	return f.Name()
+}
+
+func filefromstr(s string) *os.File {
+	f, _ := os.Open(s)
+	return f
+}
+
 func (m MyEnum) String() string {
 	switch m {
 	case A:
@@ -135,6 +147,7 @@ type Custom struct {
 	Bts   CustomBytes          `msg:"bts"`
 	Mp    map[string]*Embedded `msg:"mp"`
 	Enums []MyEnum             `msg:"enums"` // test explicit enum shim
+	File  *os.File             `msg:file`
 }
 
 type CustomInt int

--- a/gen/decode.go
+++ b/gen/decode.go
@@ -30,6 +30,9 @@ func (d *decodeGen) Execute(p Elem) error {
 	if !d.p.ok() {
 		return d.p.err
 	}
+	if !p.Printable() {
+		return nil
+	}
 
 	d.p.comment("DecodeMsg implements msgp.Decodable")
 
@@ -191,12 +194,11 @@ func (d *decodeGen) gPtr(p *Ptr) {
 	if !d.p.ok() {
 		return
 	}
-	vname := p.Varname()
 	d.p.print("\nif dc.IsNil() {")
 	d.p.print("\nerr = dc.ReadNil()")
 	d.p.print(errcheck)
-	d.p.printf("\n%s = nil\n} else {", vname)
-	d.p.printf("\nif %s == nil { %s = new(%s); }", vname, vname, p.Value.TypeName())
+	d.p.printf("\n%s = nil\n} else {", p.Varname())
+	d.p.initPtr(p)
 	next(d, p.Value)
 	d.p.closeblock()
 }

--- a/gen/encode.go
+++ b/gen/encode.go
@@ -17,6 +17,9 @@ func (e *encodeGen) Execute(p Elem) error {
 	if !e.p.ok() {
 		return e.p.err
 	}
+	if !p.Printable() {
+		return nil
+	}
 
 	e.p.comment("EncodeMsg implements msgp.Encodable")
 

--- a/gen/marshal.go
+++ b/gen/marshal.go
@@ -12,6 +12,9 @@ func (m *marshalGen) Execute(p Elem) error {
 	if !m.p.ok() {
 		return m.p.err
 	}
+	if !p.Printable() {
+		return nil
+	}
 
 	m.p.comment("MarshalMsg implements msgp.Marshaler")
 

--- a/gen/size.go
+++ b/gen/size.go
@@ -55,6 +55,9 @@ func (s *sizeGen) Execute(p Elem) error {
 	if !s.p.ok() {
 		return s.p.err
 	}
+	if !p.Printable() {
+		return nil
+	}
 
 	s.p.printf("\nfunc (%s %s) Msgsize() (s int) {", p.Varname(), methodReceiver(p))
 	s.state = assign

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -220,6 +220,13 @@ func (p *printer) print(format string) {
 	}
 }
 
+func (p *printer) initPtr(pt *Ptr) {
+	if pt.Needsinit() {
+		vname := pt.Varname()
+		p.printf("\nif %s == nil { %s = new(%s); }", vname, vname, pt.Value.TypeName())
+	}
+}
+
 func (p *printer) ok() bool { return p.err == nil }
 
 func tobaseConvert(b *BaseElem) string {

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -22,6 +22,9 @@ func (u *unmarshalGen) Execute(p Elem) error {
 	if !u.p.ok() {
 		return u.p.err
 	}
+	if !p.Printable() {
+		return nil
+	}
 
 	u.p.comment("UnmarshalMsg implements msgp.Unmarshaler")
 
@@ -172,9 +175,8 @@ func (u *unmarshalGen) gMap(m *Map) {
 }
 
 func (u *unmarshalGen) gPtr(p *Ptr) {
-	vname := p.Varname()
-	u.p.printf("\nif msgp.IsNil(bts) { bts, err = msgp.ReadNilBytes(bts); if err != nil { return }; %s = nil; } else { ", vname)
-	u.p.printf("\nif %s == nil { %s = new(%s) }", vname, vname, p.Value.TypeName())
+	u.p.printf("\nif msgp.IsNil(bts) { bts, err = msgp.ReadNilBytes(bts); if err != nil { return }; %s = nil; } else { ", p.Varname())
+	u.p.initPtr(p)
 	next(u, p.Value)
 	u.p.closeblock()
 }

--- a/parse/directives.go
+++ b/parse/directives.go
@@ -42,6 +42,10 @@ func applyShim(text []string, f *FileSet) error {
 
 	name := text[1]
 	be := gen.Ident(strings.TrimPrefix(strings.TrimSpace(text[2]), "as:")) // parse as::{base}
+	if name[0] == '*' {
+		name = name[1:]
+		be.Needsref(true)
+	}
 	be.Alias(name)
 
 	usestr := strings.TrimPrefix(strings.TrimSpace(text[3]), "using:") // parse using::{method/method}


### PR DESCRIPTION
Mark nodes with '.' in identity names as unprintable. Also, allow pointer-typed shims. Fixes #65.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/66)
<!-- Reviewable:end -->
