### PR TITLE
handle 0xff (negative fixed int -1) when setting up sizes

### DIFF
--- a/msgp/elsize.go
+++ b/msgp/elsize.go
@@ -48,8 +48,8 @@ func init() {
 	}
 
 	// nfixint
-	for i := mnfixint; i < 0xff; i++ {
-		sizes[i] = bytespec{size: 1, extra: constsize, typ: IntType}
+	for i := uint16(mnfixint); i < 0x100; i++ {
+		sizes[uint8(i)] = bytespec{size: 1, extra: constsize, typ: IntType}
 	}
 
 	// fixstr gets constsize,


### PR DESCRIPTION
In the `init()` for elsize.go there is a loop that sets up sizes for recognized negative fixed int types, but it does not add an entry for `0xff` (negative fixed integer -1) because the loop is written as 
`for i := mnfixint; i < 0xff; i++`.  

This fixes that bug — without it msgp will produce "msgp: unrecognized type prefix 0xff" (InvalidPrefixError) when trying to read msgpack data with negative fixed integer value -1.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/76)
<!-- Reviewable:end -->
