### PR TITLE
Always generate msgp.Sizer if -marshal is true.

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func main() {
 		mode |= (gen.Encode | gen.Decode | gen.Size)
 	}
 	if *marshal {
-		mode |= (gen.Marshal | gen.Unmarshal)
+		mode |= (gen.Marshal | gen.Unmarshal | gen.Size)
 	}
 	if *tests {
 		mode |= gen.Test


### PR DESCRIPTION
MarshalMsg() depends on Msgsize() but that is only generated when `-io=true`.

Fixes #86

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/87)
<!-- Reviewable:end -->
