### PR TITLE
Remove unnecessary import in generated tests

### DIFF
--- a/printer/print.go
+++ b/printer/print.go
@@ -84,7 +84,11 @@ func generate(file string, f *parse.FileSet, mode gen.Method) error {
 		if err != nil {
 			return err
 		}
-		err = writeImportHeader(testwr, "bytes", "github.com/tinylib/msgp/msgp", "testing")
+		if mode&(gen.Encode|gen.Decode) != 0 {
+			err = writeImportHeader(testwr, "bytes", "github.com/tinylib/msgp/msgp", "testing")
+		} else {
+			err = writeImportHeader(testwr, "github.com/tinylib/msgp/msgp", "testing")
+		}
 	}
 	return f.PrintTo(gen.NewPrinter(mode, outwr, testwr))
 }


### PR DESCRIPTION
The generated tests unconditionally import `bytes`. The bytes package seems to
be only used in Encode/Decode tests and benchmarks, so building tests generated
with `-io=false` fails due to unused import.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/88)
<!-- Reviewable:end -->
