### PR TITLE
Constant propogation

### DIFF
--- a/msgp/write.go
+++ b/msgp/write.go
@@ -184,6 +184,17 @@ func (mw *Writer) require(n int) (int, error) {
 	return wl, nil
 }
 
+func (mw *Writer) Append(b ...byte) error {
+	if mw.avail() < len(b) {
+		err := mw.flush()
+		if err != nil {
+			return err
+		}
+	}
+	mw.wloc += copy(mw.buf[mw.wloc:], b)
+	return nil
+}
+
 // push one byte onto the buffer
 //
 // NOTE: this is a hot code path


### PR DESCRIPTION
Constant sizes and strings (e.g. struct map headers and struct map keys) can be encoded during compilation. This helps `AppendMsg` a lot and `EncodeMsg` a little. `Unmarshal` and `DecodeMsg` are unchanged.

```
benchmark                         old ns/op     new ns/op     delta
BenchmarkFastEncode               77.8          83.0          +6.68%
BenchmarkFastDecode               124           125           +0.81%
BenchmarkFilesMarshalMsg          77.2          76.5          -0.91%
BenchmarkFilesAppendMsg           17.2          17.2          +0.00%
BenchmarkFilesUnmarshal           14.2          13.5          -4.93%
BenchmarkFilesEncode              13.2          12.1          -8.33%
BenchmarkFilesDecode              21.4          20.7          -3.27%
BenchmarkEmbeddedMarshalMsg       354           255           -27.97%
BenchmarkEmbeddedAppendMsg        120           66.7          -44.42%
BenchmarkEmbeddedUnmarshal        214           205           -4.21%
BenchmarkEmbeddedEncode           127           95.2          -25.04%
BenchmarkEmbeddedDecode           258           250           -3.10%
BenchmarkXMarshalMsg              617           489           -20.75%
BenchmarkXAppendMsg               134           80.4          -40.00%
BenchmarkXUnmarshal               185           184           -0.54%
BenchmarkXEncode                  138           113           -18.12%
BenchmarkXDecode                  279           280           +0.36%
BenchmarkTestHiddenMarshalMsg     197           127           -35.53%
BenchmarkTestHiddenAppendMsg      69.1          37.6          -45.59%
BenchmarkTestHiddenUnmarshal      112           112           +0.00%
BenchmarkTestHiddenEncode         69.0          59.0          -14.49%
BenchmarkTestHiddenDecode         122           122           +0.00%
BenchmarkCustomMarshalMsg         441           285           -35.37%
BenchmarkCustomAppendMsg          183           96.6          -47.21%
BenchmarkCustomUnmarshal          285           285           +0.00%
BenchmarkCustomEncode             188           160           -14.89%
BenchmarkCustomDecode             355           351           -1.13%
BenchmarkThingsMarshalMsg         816           661           -19.00%
BenchmarkThingsAppendMsg          349           268           -23.21%
BenchmarkThingsUnmarshal          406           409           +0.74%
BenchmarkThingsEncode             355           314           -11.55%
BenchmarkThingsDecode             655           653           -0.31%
BenchmarkBlockMarshalMsg          241           238           -1.24%
BenchmarkBlockAppendMsg           29.3          29.4          +0.34%
BenchmarkBlockUnmarshal           17.4          17.4          +0.00%
BenchmarkBlockEncode              22.5          22.5          +0.00%
BenchmarkBlockDecode              31.9          31.7          -0.63%
BenchmarkFileHandleMarshalMsg     223           162           -27.35%
BenchmarkFileHandleAppendMsg      71.1          42.7          -39.94%
BenchmarkFileHandleUnmarshal      109           109           +0.00%
BenchmarkFileHandleEncode         68.7          59.2          -13.83%
BenchmarkFileHandleDecode         119           120           +0.84%
BenchmarkTestBenchMarshalMsg      287           261           -9.06%
BenchmarkTestBenchAppendMsg       102           99.3          -2.65%
BenchmarkTestBenchUnmarshal       142           142           +0.00%
BenchmarkTestBenchEncode          100           102           +2.00%
BenchmarkTestBenchDecode          151           149           -1.32%
BenchmarkTestTypeMarshalMsg       712           472           -33.71%
BenchmarkTestTypeAppendMsg        310           177           -42.90%
BenchmarkTestTypeUnmarshal        585           566           -3.25%
BenchmarkTestTypeEncode           320           259           -19.06%
BenchmarkTestTypeDecode           743           723           -2.69%
BenchmarkTestFastMarshalMsg       242           235           -2.89%
BenchmarkTestFastAppendMsg        84.4          81.3          -3.67%
BenchmarkTestFastUnmarshal        76.9          76.9          +0.00%
BenchmarkTestFastEncode           76.3          79.1          +3.67%
BenchmarkTestFastDecode           117           115           -1.71%
BenchmarkInsaneMarshalMsg         190           190           +0.00%
BenchmarkInsaneAppendMsg          61.3          61.3          +0.00%
BenchmarkInsaneUnmarshal          41.8          41.7          -0.24%
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/92)
<!-- Reviewable:end -->
