### PR TITLE
constprop for fixed-size structs

### DIFF
--- a/_generated/def.go
+++ b/_generated/def.go
@@ -23,10 +23,18 @@ type Block [32]byte
 // tests edge-cases with
 // compiling size compilation.
 type X struct {
-	Values [32]byte    // should compile to 32*msgp.ByteSize; encoded as Bin
-	More   Block       // should be identical to the above
-	Others [][32]int32 // should compile to len(x.Others)*32*msgp.Int32Size
-	Matrix [][]int32   // should not optimize
+	Values    [32]byte    // should compile to 32*msgp.ByteSize; encoded as Bin
+	More      Block       // should be identical to the above
+	Others    [][32]int32 // should compile to len(x.Others)*32*msgp.Int32Size
+	Matrix    [][]int32   // should not optimize
+	ManyFixed []Fixed
+}
+
+// test fixed-size struct
+// size compilation
+type Fixed struct {
+	A float64
+	B bool
 }
 
 type TestType struct {


### PR DESCRIPTION
Fixes #99 by optimizing away size calculation for constant-sized structs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/100)
<!-- Reviewable:end -->
