### PR TITLE
Break dependency on "testing" package

### DIFF
--- a/msgp/circular.go
+++ b/msgp/circular.go
@@ -1,20 +1,21 @@
 package msgp
 
-import (
-	"testing"
-)
+type timer interface {
+	StartTimer()
+	StopTimer()
+}
 
 // EndlessReader is an io.Reader
 // that loops over the same data
 // endlessly. It is used for benchmarking.
 type EndlessReader struct {
-	tb     *testing.B
+	tb     timer
 	data   []byte
 	offset int
 }
 
 // NewEndlessReader returns a new endless reader
-func NewEndlessReader(b []byte, tb *testing.B) *EndlessReader {
+func NewEndlessReader(b []byte, tb timer) *EndlessReader {
 	return &EndlessReader{tb: tb, data: b, offset: 0}
 }
 


### PR DESCRIPTION
Importing the "testing" standard library package automatically registers the `testing` [commandline flags](http://golang.org/src/testing/testing.go#L170). This side effect cluttered up the output of --help for any program that imported msgp.

I replaced the dependency on testing.B with an interface containing the required methods.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/106)
<!-- Reviewable:end -->
