### PR TITLE
fix AppendIntf missing pointer direction #132

### DIFF
--- a/msgp/write_bytes.go
+++ b/msgp/write_bytes.go
@@ -399,7 +399,12 @@ func AppendIntf(b []byte, i interface{}) ([]byte, error) {
 			}
 		}
 		return b, nil
-
+	case reflect.Ptr:
+		if v.IsNil() {
+			return AppendNil(b), err
+		}
+		b, err = AppendIntf(b, v.Elem().Interface())
+		return b, err
 	default:
 		return b, &ErrUnsupportedType{T: v.Type()}
 	}


### PR DESCRIPTION
```go
package t
//go:generate msgp -o t.go

import "testing"

type I struct {
        I interface{}
}

func TestInterfaceInt(t *testing.T) {

        b := 5
        i := &I{&b}
        _, err := i.MarshalMsg(nil)
        if err != nil {
                t.Error(err)
        }
}
```