### PR TITLE
Add some explicit type declarations to fix 32bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: go
 
 go:
   - 1.4
+  - 1.5
   - tip
+
+env:
+  - GIMME_ARCH=amd64
+  - GIMME_ARCH=386
 
 script: "make travis"

--- a/Makefile
+++ b/Makefile
@@ -46,4 +46,10 @@ get-deps:
 all: install $(GGEN) $(MGEN)
 
 # travis CI enters here
-travis: get-deps test
+travis:
+	go get -d -t ./...
+	go build -o "$${GOPATH%%:*}/bin/msgp" .
+	go generate ./msgp
+	go generate ./_generated
+	go test ./msgp
+	go test ./_generated

--- a/msgp/write_bytes_test.go
+++ b/msgp/write_bytes_test.go
@@ -14,7 +14,7 @@ func TestIssue116(t *testing.T) {
 		t.Fatal(err)
 	}
 	if i != math.MinInt64 {
-		t.Errorf("put %d in and got %d out", math.MinInt64, i)
+		t.Errorf("put %d in and got %d out", int64(math.MinInt64), i)
 	}
 
 	var buf bytes.Buffer
@@ -27,7 +27,7 @@ func TestIssue116(t *testing.T) {
 		t.Fatal(err)
 	}
 	if i != math.MinInt64 {
-		t.Errorf("put %d in and got %d out", math.MinInt64, i)
+		t.Errorf("put %d in and got %d out", int64(math.MinInt64), i)
 	}
 }
 

--- a/msgp/write_test.go
+++ b/msgp/write_test.go
@@ -9,10 +9,10 @@ import (
 )
 
 var (
-	tint8          = 126                  // cannot be most fix* types
-	tint16         = 150                  // cannot be int8
-	tint32         = math.MaxInt16 + 100  // cannot be int16
-	tint64         = math.MaxInt32 + 100  // cannot be int32
+	tint8   int8   = 126                  // cannot be most fix* types
+	tint16  int16  = 150                  // cannot be int8
+	tint32  int32  = math.MaxInt16 + 100  // cannot be int16
+	tint64  int64  = math.MaxInt32 + 100  // cannot be int32
 	tuint16 uint32 = 300                  // cannot be uint8
 	tuint32 uint32 = math.MaxUint16 + 100 // cannot be uint16
 	tuint64 uint64 = math.MaxUint32 + 100 // cannot be uint32


### PR DESCRIPTION
Happy to rebase/amend/modify/adjust as desired. :+1:

This allows 32bit compilation/testing to succeed, which otherwise fails like this:
```console
root@6a350063d957:/go/src/github.com/tinylib/msgp# go test ./msgp 
# github.com/tinylib/msgp/msgp
msgp/write_bytes_test.go:17: constant -9223372036854775808 overflows int
msgp/write_bytes_test.go:30: constant -9223372036854775808 overflows int
msgp/write_test.go:15: constant 2147483747 overflows int
FAIL	github.com/tinylib/msgp/msgp [build failed]
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/135)
<!-- Reviewable:end -->
