### PR TITLE
Сompatibility with msgppack-php

### DIFF
--- a/gen/elem.go
+++ b/gen/elem.go
@@ -317,12 +317,12 @@ func (s *Ptr) SetVarname(a string) {
 		if x.Value == IDENT {
 			x.SetVarname(a)
 		} else {
-			x.SetVarname("*" + a)
+			x.SetVarname("(*" + a+")")
 		}
 		return
 
 	default:
-		s.Value.SetVarname("*" + a)
+		s.Value.SetVarname("(*" + a+")")
 		return
 	}
 }

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -310,7 +310,7 @@ func (p *printer) mapAssign(m *Map) {
 	if !p.ok() {
 		return
 	}
-	p.printf("\n%s[%s] = %s", m.Varname(), m.Keyidx, m.Validx)
+	p.printf("\n(%s)[%s] = %s", m.Varname(), m.Keyidx, m.Validx)
 }
 
 // clear map keys

--- a/msgp/read.go
+++ b/msgp/read.go
@@ -555,6 +555,30 @@ func (m *Reader) ReadInt64() (i int64, err error) {
 		i = getMint64(p)
 		return
 
+	case muint8:
+		p, err = m.R.Next(2)
+		if err != nil {
+			return
+		}
+		i = int64(getMuint8(p))
+		return
+
+	case muint16:
+		p, err = m.R.Next(3)
+		if err != nil {
+			return
+		}
+		i = int64(getMuint16(p))
+		return
+
+	case muint32:
+		p, err = m.R.Next(5)
+		if err != nil {
+			return
+		}
+		i = int64(getMuint32(p))
+		return
+
 	default:
 		err = badPrefix(IntType, lead)
 		return
@@ -657,6 +681,39 @@ func (m *Reader) ReadUint64() (u uint64, err error) {
 		}
 		u = getMuint64(p)
 		return
+
+	case mint8:
+		p, err = m.R.Next(2)
+		if err != nil {
+			return
+		}
+		u = uint64(getMint8(p))
+		return
+
+	case mint16:
+		p, err = m.R.Next(3)
+		if err != nil {
+			return
+		}
+		u = uint64(getMint16(p))
+		return
+
+	case mint32:
+		p, err = m.R.Next(5)
+		if err != nil {
+			return
+		}
+		u = uint64(getMint32(p))
+		return
+
+	case mint64:
+		p, err = m.R.Next(9)
+		if err != nil {
+			return
+		}
+		u = getMuint64(p)
+		return
+
 
 	default:
 		err = badPrefix(UintType, lead)

--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -395,6 +395,33 @@ func ReadInt64Bytes(b []byte) (i int64, o []byte, err error) {
 		o = b[9:]
 		return
 
+	case muint8:
+		if l < 2 {
+			err = ErrShortBytes
+			return
+		}
+		i = int64(getMuint8(b))
+		o = b[2:]
+		return
+
+	case muint16:
+		if l < 3 {
+			err = ErrShortBytes
+			return
+		}
+		i = int64(getMuint16(b))
+		o = b[3:]
+		return
+
+	case muint32:
+		if l < 5 {
+			err = ErrShortBytes
+			return
+		}
+		i = int64(getMuint32(b))
+		o = b[5:]
+		return
+
 	default:
 		err = badPrefix(IntType, lead)
 		return
@@ -505,6 +532,42 @@ func ReadUint64Bytes(b []byte) (u uint64, o []byte, err error) {
 		return
 
 	case muint64:
+		if l < 9 {
+			err = ErrShortBytes
+			return
+		}
+		u = getMuint64(b)
+		o = b[9:]
+		return
+
+	case mint8:
+		if l < 2 {
+			err = ErrShortBytes
+			return
+		}
+		u = uint64(getMint8(b))
+		o = b[2:]
+		return
+
+	case mint16:
+		if l < 3 {
+			err = ErrShortBytes
+			return
+		}
+		u = uint64(getMint16(b))
+		o = b[3:]
+		return
+
+	case mint32:
+		if l < 5 {
+			err = ErrShortBytes
+			return
+		}
+		u = uint64(getMint32(b))
+		o = b[5:]
+		return
+
+	case mint64:
 		if l < 9 {
 			err = ErrShortBytes
 			return


### PR DESCRIPTION
1. Changes in read*.go compatibility with https://github.com/msgpack/msgpack-php
2. Changes in gen/elem.go && gen/spec.go fix it:

```
//go:generate msgp
package main

type SomeStruct map[string]string

type SomeMegaStruct struct {
    Struct1 *SomeStruct `msg:"struct-1"`
    Struct2 *SomeStruct `msg:"struct-2"`
}
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/137)

<!-- Reviewable:end -->
