### PR TITLE
Struct fields numeric labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # normal `go install`.
 
 # generated integration test files
-GGEN = ./_generated/generated.go ./_generated/generated_test.go
+GGEN = ./_generated/generated.go ./_generated/generated_test.go ./_generated/issue94_gen.go ./_generated/issue94_gen_test.go
 # generated unit test files
 MGEN = ./msgp/defgen_test.go
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ type Person struct {
 	unexported bool             // this field is also ignored
 }
 ```
+If you need to have numeric labels in your structs, you could set it in `msg:"(int/uint)value"` notation:
+```go
+type Person struct {
+	Name       string `msg:"(int)0x01"`
+	Address    string `msg:"(int)0x02"`
+	Age        int    `msg:"(int)0x03"`
+}
+```
+> Note that `uint` typed field labels will be serialized as `msgp.fixint` in case when label value is <= (1<<7)-1
 
 By default, the code generator will satisfy `msgp.Sizer`, `msgp.Encodable`, `msgp.Decodable`, 
 `msgp.Marshaler`, and `msgp.Unmarshaler`. Carefully-designed applications can use these methods to do

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ type Person struct {
 	unexported bool             // this field is also ignored
 }
 ```
-If you need to have numeric labels in your structs, you could set it in `msg:"(int/uint)value"` notation:
+If you need to have numeric labels for a struct fields, you could set it in `msg:"(int/uint)value"` notation:
 ```go
 type Person struct {
 	Name       string `msg:"(int)0x01"`
@@ -50,7 +50,7 @@ type Person struct {
 	Age        int    `msg:"(int)0x03"`
 }
 ```
-> Note that `uint` typed field labels will be serialized as `msgp.fixint` in case when label value is <= (1<<7)-1
+> Note that field labels with `uint` value will be serialized as `msgp.fixint` in case when label value is <= (1<<7)-1
 
 By default, the code generator will satisfy `msgp.Sizer`, `msgp.Encodable`, `msgp.Decodable`, 
 `msgp.Marshaler`, and `msgp.Unmarshaler`. Carefully-designed applications can use these methods to do

--- a/_generated/def.go
+++ b/_generated/def.go
@@ -53,6 +53,17 @@ type TestType struct {
 	Slice2   []string
 }
 
+type TestNumericLabels struct {
+	One string `msg:"(int)0x01"`
+	Two string `msg:"(uint)0xffffffffffffffff"`
+}
+
+type TestOnlyIntLabels struct {
+	A string `msg:"(int)0xfa"`
+	B string `msg:"(int)0xfb"`
+	C string `msg:"(int)0xfc"`
+}
+
 //msgp:tuple Object
 type Object struct {
 	ObjectNo string   `msg:"objno"`

--- a/gen/decode.go
+++ b/gen/decode.go
@@ -7,33 +7,24 @@ import (
 
 func decode(w io.Writer) *decodeGen {
 	return &decodeGen{
-		p:        printer{w: w},
-		hasfield: false,
+		p: printer{w: w},
 	}
 }
 
 type decodeGen struct {
 	passes
-	p        printer
-	hasfield bool
+	fields
+	p printer
 }
 
 func (d *decodeGen) Method() Method { return Decode }
-
-func (d *decodeGen) needsField() {
-	if d.hasfield {
-		return
-	}
-	d.p.print("\nvar field []byte; _ = field")
-	d.hasfield = true
-}
 
 func (d *decodeGen) Execute(p Elem) error {
 	p = d.applyall(p)
 	if p == nil {
 		return nil
 	}
-	d.hasfield = false
+	d.fields.drop()
 	if !d.p.ok() {
 		return d.p.err
 	}

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -396,9 +396,9 @@ func (s *Struct) Complexity() int {
 }
 
 type StructField struct {
-	FieldTag  string // the string inside the `msg:""` tag
-	FieldName string // the name of the struct field
-	FieldElem Elem   // the field type
+	FieldTag  interface{} // the label of the struct field in msgpack
+	FieldName string      // the name of the struct field
+	FieldElem Elem        // the field type
 }
 
 // BaseElem is an element that

--- a/gen/encode.go
+++ b/gen/encode.go
@@ -2,8 +2,9 @@ package gen
 
 import (
 	"fmt"
-	"github.com/tinylib/msgp/msgp"
 	"io"
+
+	"github.com/tinylib/msgp/msgp"
 )
 
 func encode(w io.Writer) *encodeGen {
@@ -101,19 +102,7 @@ func (e *encodeGen) appendraw(bts []byte) {
 }
 
 func (e *encodeGen) structmap(s *Struct) {
-	nfields := len(s.Fields)
-	data := msgp.AppendMapHeader(nil, uint32(nfields))
-	e.p.printf("\n// map header, size %d", nfields)
-	e.Fuse(data)
-	for i := range s.Fields {
-		if !e.p.ok() {
-			return
-		}
-		data = msgp.AppendString(nil, s.Fields[i].FieldTag)
-		e.p.printf("\n// write %q", s.Fields[i].FieldTag)
-		e.Fuse(data)
-		next(e, s.Fields[i].FieldElem)
-	}
+	genStructFieldsSerializer(e, e.p, s.Fields)
 }
 
 func (e *encodeGen) gMap(m *Map) {

--- a/gen/marshal.go
+++ b/gen/marshal.go
@@ -2,8 +2,9 @@ package gen
 
 import (
 	"fmt"
-	"github.com/tinylib/msgp/msgp"
 	"io"
+
+	"github.com/tinylib/msgp/msgp"
 )
 
 func marshal(w io.Writer) *marshalGen {
@@ -96,21 +97,7 @@ func (m *marshalGen) tuple(s *Struct) {
 }
 
 func (m *marshalGen) mapstruct(s *Struct) {
-	data := make([]byte, 0, 64)
-	data = msgp.AppendMapHeader(data, uint32(len(s.Fields)))
-	m.p.printf("\n// map header, size %d", len(s.Fields))
-	m.Fuse(data)
-	for i := range s.Fields {
-		if !m.p.ok() {
-			return
-		}
-		data = msgp.AppendString(nil, s.Fields[i].FieldTag)
-
-		m.p.printf("\n// string %q", s.Fields[i].FieldTag)
-		m.Fuse(data)
-
-		next(m, s.Fields[i].FieldElem)
-	}
+	genStructFieldsSerializer(m, m.p, s.Fields)
 }
 
 // append raw data

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -315,7 +315,7 @@ func groupFieldsByType(fields []StructField) map[msgp.Type][]StructField {
 		switch f.FieldTag.(type) {
 		case int, int8, int16, int32, int64:
 			t = msgp.IntType
-		case uint, uint8, byte, uint16, uint32, uint64:
+		case uint, uint8, uint16, uint32, uint64:
 			t = msgp.UintType
 		case string:
 			t = msgp.StrType

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -389,10 +389,8 @@ func switchFieldKeys(t traversalAssigner, p printer, fields []StructField, label
 			return
 		}
 	}
-
 	p.print("\ndefault:")
 	t.skipAndCheck()
-
 	p.closeblock() // close switch
 }
 

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -3,9 +3,14 @@ package gen
 import (
 	"fmt"
 	"io"
+	"math"
+
+	"github.com/tinylib/msgp/msgp"
 )
 
 const (
+	field       = "field"
+	typ         = "typ"
 	errcheck    = "\nif err != nil { return }"
 	lenAsUint32 = "uint32(len(%s))"
 	literalFmt  = "%s"
@@ -13,7 +18,7 @@ const (
 	quotedFmt   = `"%s"`
 	mapHeader   = "MapHeader"
 	arrayHeader = "ArrayHeader"
-	mapKey      = "MapKeyPtr"
+	mapKey      = "MapKey"
 	stringTyp   = "String"
 	u32         = "uint32"
 )
@@ -197,6 +202,161 @@ type traversal interface {
 	gPtr(*Ptr)
 	gBase(*BaseElem)
 	gStruct(*Struct)
+}
+
+type assigner interface {
+	assignAndCheck(name, base string)
+	nextTypeAndCheck(name string)
+	skipAndCheck()
+}
+
+type fuser interface {
+	Fuse([]byte)
+}
+
+type traversalAssigner interface {
+	traversal
+	assigner
+}
+
+type traversalFuser interface {
+	traversal
+	fuser
+}
+
+func genStructFieldsSerializer(t traversalFuser, p printer, fields []StructField) {
+	data := msgp.AppendMapHeader(nil, uint32(len(fields)))
+	p.printf("\n// map header, size %d", len(fields))
+	t.Fuse(data)
+	for _, f := range fields {
+		if !p.ok() {
+			return
+		}
+
+		data, p.err = msgp.AppendIntf(nil, f.FieldTag)
+		p.printf(
+			"\n// write struct field key %q = %v; declared as type %T, eventually become msgp.%s",
+			f.FieldName, f.FieldTag, f.FieldTag, msgp.NextType(data),
+		)
+		t.Fuse(data)
+
+		next(t, f.FieldElem)
+	}
+}
+
+func genStructFieldsParser(t traversalAssigner, p printer, fields []StructField) {
+	sz := randIdent()
+	p.declare(sz, u32)
+	t.assignAndCheck(sz, mapHeader)
+
+	p.printf("\nfor %s > 0 {\n%s--", sz, sz)
+
+	groups := groupFieldsByType(fields)
+	hasUint := len(groups[msgp.UintType]) > 0
+	hasInt := len(groups[msgp.IntType]) > 0
+	hasStr := len(groups[msgp.StrType]) > 0
+
+	if !hasUint && !hasInt { // there are no numerically labeled fields, so parse every field label as string
+		p.declare(field, "[]byte")
+		t.assignAndCheck(field, mapKey)
+		switchFieldKeysStr(t, p, fields)
+	} else {
+		// switch on inferred type of next field
+		p.declare(typ, "msgp.Type")
+		t.nextTypeAndCheck(typ)
+		p.printf("\nswitch %s {", typ)
+
+		if hasUint {
+			p.print("\ncase msgp.UintType:")
+			p.declare(field, "uint64")
+			t.assignAndCheck(field, "Uint64")
+			switchFieldKeys(t, p, groups[msgp.UintType])
+
+			// Append to int fields also uint fields that do not overflow int64.
+			// This is necessary because uint field with value <= (1<<7)-1 could be serialized as fixint.
+			// and become a msgp.IntType. This is done for best compatibility with other libraries
+			// (and with other languages). That is, some endpoint could serialize uint16 key with value <= (1<<7)-1 as
+			// real msgpack uint16, but also could serialize it like fixint.
+			for _, f := range groups[msgp.UintType] {
+				v := f.FieldTag.(uint64)
+				if v <= math.MaxInt64 {
+					groups[msgp.IntType] = append(groups[msgp.IntType], f)
+					hasInt = true
+				}
+			}
+		}
+		if hasInt {
+			p.print("\ncase msgp.IntType:")
+			p.declare(field, "int64")
+			t.assignAndCheck(field, "Int64")
+			switchFieldKeys(t, p, groups[msgp.IntType])
+		}
+		if hasStr {
+			// double case is done for backward compatibility with previous implementation
+			p.print("\ncase msgp.StrType, msgp.BinType:")
+			p.declare(field, "[]byte")
+			t.assignAndCheck(field, mapKey)
+			switchFieldKeysStr(t, p, groups[msgp.StrType])
+		}
+
+		p.print("\ndefault:")
+		t.skipAndCheck()
+
+		p.closeblock() // close switch
+	}
+
+	p.closeblock() // close loop
+}
+
+func groupFieldsByType(fields []StructField) map[msgp.Type][]StructField {
+	groups := make(map[msgp.Type][]StructField, len(fields))
+	for _, f := range fields {
+		var t msgp.Type
+		switch f.FieldTag.(type) {
+		case int, int8, int16, int32, int64:
+			t = msgp.IntType
+		case uint, uint8, byte, uint16, uint32, uint64:
+			t = msgp.UintType
+		case string:
+			t = msgp.StrType
+		default:
+			panic(fmt.Errorf("field %q has unknown tag type %T", f.FieldName, f.FieldTag))
+		}
+		groups[t] = append(groups[t], f)
+	}
+	return groups
+}
+
+func switchFieldKeysStr(t traversalAssigner, p printer, fields []StructField) {
+	p.printf("\nswitch msgp.UnsafeString(%s) {", field)
+	for _, f := range fields {
+		p.printf("\ncase \"%s\":", f.FieldTag)
+		next(t, f.FieldElem)
+		if !p.ok() {
+			return
+		}
+	}
+
+	p.print("\ndefault:")
+	t.skipAndCheck()
+
+	p.closeblock() // close switch
+}
+
+func switchFieldKeys(t traversalAssigner, p printer, fields []StructField) {
+	p.printf("\nswitch %s {", field)
+	for _, f := range fields {
+		p.printf("\ncase %v:", f.FieldTag)
+		next(t, f.FieldElem)
+		if !p.ok() {
+			return
+		}
+	}
+
+	p.print("\ndefault:")
+	t.skipAndCheck()
+
+	p.closeblock() // close switch
 }
 
 // type-switch dispatch to the correct

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -19,14 +19,6 @@ type unmarshalGen struct {
 
 func (u *unmarshalGen) Method() Method { return Unmarshal }
 
-func (u *unmarshalGen) needsField() {
-	if u.hasfield {
-		return
-	}
-	u.p.print("\nvar field []byte; _ = field")
-	u.hasfield = true
-}
-
 func (u *unmarshalGen) Execute(p Elem) error {
 	u.hasfield = false
 	if !u.p.ok() {
@@ -51,7 +43,24 @@ func (u *unmarshalGen) assignAndCheck(name string, base string) {
 	if !u.p.ok() {
 		return
 	}
-	u.p.printf("\n%s, bts, err = msgp.Read%sBytes(bts)", name, base)
+	if base == mapKey {
+		u.p.printf("\n%s, bts, err = msgp.ReadMapKeyZC(bts)", name)
+	} else {
+		u.p.printf("\n%s, bts, err = msgp.Read%sBytes(bts)", name, base)
+	}
+	u.p.print(errcheck)
+}
+
+func (u *unmarshalGen) nextTypeAndCheck(name string) {
+	if !u.p.ok() {
+		return
+	}
+	u.p.printf("\n%s = msgp.NextType(bts)", name)
+	u.p.print(errcheck)
+}
+
+func (u *unmarshalGen) skipAndCheck() {
+	u.p.print("\nbts, err = msgp.Skip(bts)")
 	u.p.print(errcheck)
 }
 
@@ -68,7 +77,6 @@ func (u *unmarshalGen) gStruct(s *Struct) {
 }
 
 func (u *unmarshalGen) tuple(s *Struct) {
-
 	// open block
 	sz := randIdent()
 	u.p.declare(sz, u32)
@@ -83,25 +91,7 @@ func (u *unmarshalGen) tuple(s *Struct) {
 }
 
 func (u *unmarshalGen) mapstruct(s *Struct) {
-	u.needsField()
-	sz := randIdent()
-	u.p.declare(sz, u32)
-	u.assignAndCheck(sz, mapHeader)
-
-	u.p.printf("\nfor %s > 0 {", sz)
-	u.p.printf("\n%s--; field, bts, err = msgp.ReadMapKeyZC(bts)", sz)
-	u.p.print(errcheck)
-	u.p.print("\nswitch msgp.UnsafeString(field) {")
-	for i := range s.Fields {
-		if !u.p.ok() {
-			return
-		}
-		u.p.printf("\ncase \"%s\":", s.Fields[i].FieldTag)
-		next(u, s.Fields[i].FieldElem)
-	}
-	u.p.print("\ndefault:\nbts, err = msgp.Skip(bts)")
-	u.p.print(errcheck)
-	u.p.print("\n}\n}") // close switch and for loop
+	genStructFieldsParser(u, u.p, s.Fields)
 }
 
 func (u *unmarshalGen) gBase(b *BaseElem) {

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -13,14 +13,14 @@ func unmarshal(w io.Writer) *unmarshalGen {
 
 type unmarshalGen struct {
 	passes
-	p        printer
-	hasfield bool
+	fields
+	p printer
 }
 
 func (u *unmarshalGen) Method() Method { return Unmarshal }
 
 func (u *unmarshalGen) Execute(p Elem) error {
-	u.hasfield = false
+	u.fields.drop()
 	if !u.p.ok() {
 		return u.p.err
 	}

--- a/msgp/file_test.go
+++ b/msgp/file_test.go
@@ -5,10 +5,11 @@ package msgp_test
 import (
 	"bytes"
 	"crypto/rand"
-	"github.com/tinylib/msgp/msgp"
 	prand "math/rand"
 	"os"
 	"testing"
+
+	"github.com/tinylib/msgp/msgp"
 )
 
 type rawBytes []byte

--- a/msgp/read.go
+++ b/msgp/read.go
@@ -376,6 +376,7 @@ func (m *Reader) ReadMapKeyPtr() ([]byte, error) {
 			return nil, err
 		}
 		read = int(big.Uint32(p[1:]))
+
 	default:
 		return nil, badPrefix(StrType, lead)
 	}

--- a/parse/directives.go
+++ b/parse/directives.go
@@ -2,9 +2,10 @@ package parse
 
 import (
 	"fmt"
-	"github.com/tinylib/msgp/gen"
 	"go/ast"
 	"strings"
+
+	"github.com/tinylib/msgp/gen"
 )
 
 const linePrefix = "//msgp:"

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -348,7 +348,7 @@ func (fs *FileSet) getField(f *ast.Field) []gen.StructField {
 			return nil
 		}
 
-		if tags[0][0] == '(' { // field key type casting
+		if len(tags[0]) > 2 && tags[0][0] == '(' { // field key type casting
 			var err error
 
 			pair := strings.Split(tags[0][1:], ")")

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -370,13 +370,12 @@ func (fs *FileSet) getField(f *ast.Field) []gen.StructField {
 				}
 
 			default:
-				sf[0].FieldTag = val
+				panic(fmt.Sprintf("unsupported field %q cast annotation: type %s is not acceptable", f.Names[0].Name, cast))
 			}
-
 			if err != nil {
 				panic(fmt.Sprintf("could not parse field %q annotation: %s", f.Names[0].Name, err))
 			}
-		} else {
+		} else if tags[0] != "" {
 			sf[0].FieldTag = tags[0]
 		}
 

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -343,12 +343,14 @@ func (fs *FileSet) getField(f *ast.Field) []gen.StructField {
 		if len(tags) == 2 && tags[1] == "extension" {
 			extension = true
 		}
+
 		// ignore "-" fields
 		if tags[0] == "-" {
 			return nil
 		}
 
-		if len(tags[0]) > 2 && tags[0][0] == '(' { // field key type casting
+		// field label type casting
+		if len(tags[0]) > 2 && tags[0][0] == '(' {
 			var err error
 
 			pair := strings.Split(tags[0][1:], ")")
@@ -378,7 +380,6 @@ func (fs *FileSet) getField(f *ast.Field) []gen.StructField {
 		} else if tags[0] != "" {
 			sf[0].FieldTag = tags[0]
 		}
-
 	}
 
 	ex := fs.parseExpr(f.Type)

--- a/printer/print.go
+++ b/printer/print.go
@@ -3,13 +3,14 @@ package printer
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+
 	"github.com/tinylib/msgp/gen"
 	"github.com/tinylib/msgp/parse"
 	"github.com/ttacon/chalk"
 	"golang.org/x/tools/imports"
-	"io"
-	"io/ioutil"
-	"strings"
 )
 
 func infof(s string, v ...interface{}) {


### PR DESCRIPTION
Hello! 

This pull request is about [this issue](https://github.com/tinylib/msgp/issues/159).

I think it could be useful. Some integration protocols use scheme, when map keys are numerical (`int` or `uint`), for example, to reduce network usage and other performance needs.

Regards,
Sergey.