### PR TITLE
Add comment to generated Msgsize function

### DIFF
--- a/gen/size.go
+++ b/gen/size.go
@@ -79,6 +79,8 @@ func (s *sizeGen) Execute(p Elem) error {
 		return nil
 	}
 
+	s.p.comment("Msgsize returns the number of bytes occupied by the serialized message")
+
 	s.p.printf("\nfunc (%s %s) Msgsize() (s int) {", p.Varname(), imutMethodReceiver(p))
 	s.state = assign
 	next(s, p)

--- a/gen/size.go
+++ b/gen/size.go
@@ -79,7 +79,7 @@ func (s *sizeGen) Execute(p Elem) error {
 		return nil
 	}
 
-	s.p.comment("Msgsize returns the number of bytes occupied by the serialized message")
+	s.p.comment("Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message")
 
 	s.p.printf("\nfunc (%s %s) Msgsize() (s int) {", p.Varname(), imutMethodReceiver(p))
 	s.state = assign


### PR DESCRIPTION
This avoids the error message raised by golint:

> .Msgsize should have comment or be unexported

https://github.com/golang/lint/blob/c7bacac2b21ca01afa1dee0acf64df3ce047c28f/lint.go#L777

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/161)
<!-- Reviewable:end -->
