### PR TITLE
Make pointer-to-slice decoding work

### DIFF
--- a/_generated/def.go
+++ b/_generated/def.go
@@ -51,6 +51,7 @@ type TestType struct {
 	Num      msgp.Number `msg:"num"`
 	Slice1   []string
 	Slice2   []string
+	SlicePtr *[]string
 }
 
 //msgp:tuple Object

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -278,7 +278,12 @@ type Slice struct {
 func (s *Slice) SetVarname(a string) {
 	s.common.SetVarname(a)
 	s.Index = randIdent()
-	s.Els.SetVarname(fmt.Sprintf("%s[%s]", s.Varname(), s.Index))
+	varName := s.Varname()
+	if varName[0] == '*' {
+		// Pointer-to-slice requires parenthesis for slicing.
+		varName = "(" + varName + ")"
+	}
+	s.Els.SetVarname(fmt.Sprintf("%s[%s]", varName, s.Index))
 }
 
 func (s *Slice) TypeName() string {

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -319,7 +319,7 @@ func (p *printer) clearMap(name string) {
 }
 
 func (p *printer) resizeSlice(size string, s *Slice) {
-	p.printf("\nif cap(%[1]s) >= int(%[2]s) { %[1]s = %[1]s[:%[2]s] } else { %[1]s = make(%[3]s, %[2]s) }", s.Varname(), size, s.TypeName())
+	p.printf("\nif cap(%[1]s) >= int(%[2]s) { %[1]s = (%[1]s)[:%[2]s] } else { %[1]s = make(%[3]s, %[2]s) }", s.Varname(), size, s.TypeName())
 }
 
 func (p *printer) arrayCheck(want string, got string) {


### PR DESCRIPTION
Previously, the generated code was invalid because of the
operator precedence of * being lower than [.

The fix wraps the varname in parenthesis to avoid the problem.

This fixes the generated code for the following:

```go
package x

//go:generate msgp

type X struct {
	A int
}

type Y struct {
	Xs *[]X
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/162)
<!-- Reviewable:end -->
