### PR TITLE
	Add (*Reader).CopyNext(w) (int64, error)

### DIFF
--- a/msgp/errors.go
+++ b/msgp/errors.go
@@ -140,3 +140,19 @@ func (e *ErrUnsupportedType) Error() string { return fmt.Sprintf("msgp: type %q 
 
 // Resumable returns 'true' for ErrUnsupportedType
 func (e *ErrUnsupportedType) Resumable() bool { return true }
+
+// ReadNextError is returned the buffer passed to ReadNext is not large enough.
+type ReadNextError struct {
+	Got    uintptr
+	Wanted uintptr
+}
+
+// Error implements the error interface
+func (err ReadNextError) Error() string {
+	return fmt.Sprintf("msgp: slice not big enough (%d < %d)",
+		err.Got, err.Wanted)
+}
+
+// Resumable is always 'false' for ReadNextError, since we may be inside a
+// recursive call which has already partially consumed the stream.
+func (err ReadNextError) Resumable() bool { return false }

--- a/msgp/errors.go
+++ b/msgp/errors.go
@@ -140,19 +140,3 @@ func (e *ErrUnsupportedType) Error() string { return fmt.Sprintf("msgp: type %q 
 
 // Resumable returns 'true' for ErrUnsupportedType
 func (e *ErrUnsupportedType) Resumable() bool { return true }
-
-// ReadNextError is returned the buffer passed to ReadNext is not large enough.
-type ReadNextError struct {
-	Got    uintptr
-	Wanted uintptr
-}
-
-// Error implements the error interface
-func (err ReadNextError) Error() string {
-	return fmt.Sprintf("msgp: slice not big enough (%d < %d)",
-		err.Got, err.Wanted)
-}
-
-// Resumable is always 'false' for ReadNextError, since we may be inside a
-// recursive call which has already partially consumed the stream.
-func (err ReadNextError) Resumable() bool { return false }

--- a/msgp/read.go
+++ b/msgp/read.go
@@ -154,30 +154,34 @@ func (m *Reader) CopyNext(w io.Writer) (int64, error) {
 		return 0, err
 	}
 
+	var n int64
 	// Opportunistic optimization: if we can fit the whole thing in the m.R
 	// buffer, then just get a pointer to that, and pass it to w.Write,
 	// avoiding an allocation.
-	buf, err := m.R.Next(int(sz))
-	n := int64(len(buf))
-	if err != nil {
+	if int(sz) <= m.R.BufferSize() {
+		var nn int
+		var buf []byte
+		buf, err = m.R.Next(int(sz))
+		if err != nil {
+			if err == io.ErrUnexpectedEOF {
+				err = ErrShortBytes
+			}
+			return 0, err
+		}
+		nn, err = w.Write(buf)
+		n += int64(nn)
+	} else {
 		// Fall back to io.CopyN.
 		// May avoid allocating if w is a ReaderFrom (e.g. bytes.Buffer)
 		n, err = io.CopyN(w, m.R, int64(sz))
-		if err != nil {
-			return 0, err
+		if err == io.ErrUnexpectedEOF {
+			err = ErrShortBytes
 		}
-		// Fallthrough
-	} else {
-		// Intentional "else no error" branch due to fallthrough above.
-		// Just write the buffer.
-		var nInt int
-		nInt, err = w.Write(buf)
-		n = int64(nInt)
-		if err != nil {
-			return 0, err
-		} else if n != int64(sz) {
-			return n, io.ErrShortWrite
-		}
+	}
+	if err != nil {
+		return n, err
+	} else if n < int64(sz) {
+		return n, io.ErrShortWrite
 	}
 
 	// for maps and slices, read elements

--- a/msgp/read.go
+++ b/msgp/read.go
@@ -1,7 +1,6 @@
 package msgp
 
 import (
-	"fmt"
 	"io"
 	"math"
 	"sync"
@@ -145,39 +144,6 @@ type Reader struct {
 // Read implements `io.Reader`
 func (m *Reader) Read(p []byte) (int, error) {
 	return m.R.Read(p)
-}
-
-// ReadNext reads the raw bytes for the next object on the wire into p.
-// If p is not large enough, an error is returned. See GetNextSize.
-func (m *Reader) ReadNext(p []byte) (int, error) {
-	sz, o, err := getNextSize(m.R)
-	if err != nil {
-		return 0, err
-	}
-	if uintptr(cap(p)) < sz {
-		return 0, ReadNextError{uintptr(len(p)), uintptr(sz)}
-	}
-	n, err := m.R.ReadFull(p[:sz])
-	if err != nil {
-		return 0, err
-	}
-	if uintptr(n) != sz {
-		return 0, fmt.Errorf("wrong # bytes read (%d != %d)", n, int64(sz))
-	}
-
-	p = p[n:n:cap(p)]
-	tot := n
-
-	// for maps and slices, read elements
-	for x := uintptr(0); x < o; x++ {
-		n, err = m.ReadNext(p)
-		if err != nil {
-			return 0, err
-		}
-		p = p[n:n:cap(p)]
-		tot += n
-	}
-	return tot, nil
 }
 
 // CopyNext reads the next object from m without decoding it and writes it to w.

--- a/msgp/read.go
+++ b/msgp/read.go
@@ -169,7 +169,7 @@ func (m *Reader) CopyNext(w io.Writer) (int64, error) {
 		// Fallthrough
 	} else {
 		// Intentional "else no error" branch due to fallthrough above.
-		// Otherwise,
+		// Just write the buffer.
 		var nInt int
 		nInt, err = w.Write(buf)
 		n = int64(nInt)
@@ -178,7 +178,6 @@ func (m *Reader) CopyNext(w io.Writer) (int64, error) {
 		} else if n != int64(sz) {
 			return n, io.ErrShortWrite
 		}
-
 	}
 
 	// for maps and slices, read elements

--- a/msgp/read_test.go
+++ b/msgp/read_test.go
@@ -722,3 +722,93 @@ func BenchmarkSkip(b *testing.B) {
 		}
 	}
 }
+
+func TestReadNext(t *testing.T) {
+	var buf bytes.Buffer
+	en := NewWriter(&buf)
+
+	en.WriteMapHeader(6)
+
+	en.WriteString("thing_one")
+	en.WriteString("value_one")
+
+	en.WriteString("thing_two")
+	en.WriteFloat64(3.14159)
+
+	en.WriteString("some_bytes")
+	en.WriteBytes([]byte("nkl4321rqw908vxzpojnlk2314rqew098-s09123rdscasd"))
+
+	en.WriteString("the_time")
+	en.WriteTime(time.Now())
+
+	en.WriteString("what?")
+	en.WriteBool(true)
+
+	en.WriteString("ext")
+	en.WriteExtension(&RawExtension{Type: 55, Data: []byte("raw data!!!")})
+
+	en.Flush()
+
+	// Read from a copy of the original buf.
+	de := NewReader(bytes.NewReader(buf.Bytes()))
+	p := make([]byte, 0, len(buf.Bytes()))
+	n, err := de.ReadNext(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(buf.Bytes(), p[:n]) {
+		t.Fatalf("not equal! %v, %v", buf.Bytes(), p[:n])
+	}
+}
+
+func TestCopyNext(t *testing.T) {
+	var buf bytes.Buffer
+	en := NewWriter(&buf)
+
+	en.WriteMapHeader(6)
+
+	en.WriteString("thing_one")
+	en.WriteString("value_one")
+
+	en.WriteString("thing_two")
+	en.WriteFloat64(3.14159)
+
+	en.WriteString("some_bytes")
+	en.WriteBytes([]byte("nkl4321rqw908vxzpojnlk2314rqew098-s09123rdscasd"))
+
+	en.WriteString("the_time")
+	en.WriteTime(time.Now())
+
+	en.WriteString("what?")
+	en.WriteBool(true)
+
+	en.WriteString("ext")
+	en.WriteExtension(&RawExtension{Type: 55, Data: []byte("raw data!!!")})
+
+	en.Flush()
+
+	// Read from a copy of the original buf.
+	de := NewReader(bytes.NewReader(buf.Bytes()))
+
+	w := new(bytes.Buffer)
+
+	n, err := de.CopyNext(w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != int64(buf.Len()) {
+		t.Fatalf("CopyNext returned the wrong value (%d != %d)",
+			n, buf.Len())
+	}
+
+	// p := make([]byte, 0, len(buf.Bytes()))
+	// n, err := de.ReadNext(p)
+	// if err != nil {
+	// t.Fatal(err)
+	// }
+
+	if !bytes.Equal(buf.Bytes(), w.Bytes()) {
+		t.Fatalf("not equal! %v, %v", buf.Bytes(), w.Bytes())
+	}
+}

--- a/msgp/read_test.go
+++ b/msgp/read_test.go
@@ -763,12 +763,6 @@ func TestCopyNext(t *testing.T) {
 			n, buf.Len())
 	}
 
-	// p := make([]byte, 0, len(buf.Bytes()))
-	// n, err := de.ReadNext(p)
-	// if err != nil {
-	// t.Fatal(err)
-	// }
-
 	if !bytes.Equal(buf.Bytes(), w.Bytes()) {
 		t.Fatalf("not equal! %v, %v", buf.Bytes(), w.Bytes())
 	}

--- a/msgp/read_test.go
+++ b/msgp/read_test.go
@@ -723,45 +723,6 @@ func BenchmarkSkip(b *testing.B) {
 	}
 }
 
-func TestReadNext(t *testing.T) {
-	var buf bytes.Buffer
-	en := NewWriter(&buf)
-
-	en.WriteMapHeader(6)
-
-	en.WriteString("thing_one")
-	en.WriteString("value_one")
-
-	en.WriteString("thing_two")
-	en.WriteFloat64(3.14159)
-
-	en.WriteString("some_bytes")
-	en.WriteBytes([]byte("nkl4321rqw908vxzpojnlk2314rqew098-s09123rdscasd"))
-
-	en.WriteString("the_time")
-	en.WriteTime(time.Now())
-
-	en.WriteString("what?")
-	en.WriteBool(true)
-
-	en.WriteString("ext")
-	en.WriteExtension(&RawExtension{Type: 55, Data: []byte("raw data!!!")})
-
-	en.Flush()
-
-	// Read from a copy of the original buf.
-	de := NewReader(bytes.NewReader(buf.Bytes()))
-	p := make([]byte, 0, len(buf.Bytes()))
-	n, err := de.ReadNext(p)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !bytes.Equal(buf.Bytes(), p[:n]) {
-		t.Fatalf("not equal! %v, %v", buf.Bytes(), p[:n])
-	}
-}
-
 func TestCopyNext(t *testing.T) {
 	var buf bytes.Buffer
 	en := NewWriter(&buf)


### PR DESCRIPTION
It is useful to be able to efficiently copy objects without
decoding them.

My use case is filtering when I already know the indices of
the objects I want to keep, and for rewriting a dictionary
of objects as a column of objects.

This commit:

1. Exports `GetNextSize`.
2. Adds a method `ReadNext(p)` to `*Reader`.

I wasn't sure about exporting `GetNextSize`, but I can't see the
harm in it, and it may be useful for finer-grained control in
the copying.

I also experimented with a `NextReader() io.Reader` method which
returned `io.LimitReader(m.R, GetNextSize())`, but for my use case
this was twice as slow and also did not handle nested objects.
In principle that might be useful for very large simple objects,
but is not included in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/167)
<!-- Reviewable:end -->
