### PR TITLE
Copy shim inlines (fix issue 168)

### DIFF
--- a/_generated/def.go
+++ b/_generated/def.go
@@ -115,6 +115,14 @@ type Things struct {
 	Oext  msgp.RawExtension                 `msg:"oext,extension"` // test extension reference
 }
 
+//msgp:shim SpecialID as:[]byte using:toBytes/fromBytes
+
+type SpecialID string
+type TestObj struct{ ID1, ID2 SpecialID }
+
+func toBytes(id SpecialID) []byte   { return []byte(string(id)) }
+func fromBytes(id []byte) SpecialID { return SpecialID(string(id)) }
+
 type MyEnum byte
 
 const (

--- a/_generated/gen_test.go
+++ b/_generated/gen_test.go
@@ -123,3 +123,15 @@ func Test1EncodeDecode(t *testing.T) {
 		t.Fatal("objects not equal")
 	}
 }
+
+func TestIssue168(t *testing.T) {
+	buf := bytes.Buffer{}
+	test := TestObj{}
+
+	msgp.Encode(&buf, &TestObj{ID1: "1", ID2: "2"})
+	msgp.Decode(&buf, &test)
+
+	if test.ID1 != "1" || test.ID2 != "2" {
+		t.Fatalf("got back %+v", test)
+	}
+}

--- a/parse/inline.go
+++ b/parse/inline.go
@@ -55,7 +55,9 @@ func (f *FileSet) findShim(id string, be *gen.BaseElem) {
 
 func (f *FileSet) nextShim(ref *gen.Elem, id string, be *gen.BaseElem) {
 	if (*ref).TypeName() == id {
-		*ref = be
+		vn := (*ref).Varname()
+		*ref = be.Copy()
+		(*ref).SetVarname(vn)
 	} else {
 		switch el := (*ref).(type) {
 		case *gen.Struct:


### PR DESCRIPTION
TL;DR `nextShim` needs to copy the base elem when it resolves shim types, because a shim could be used on more than one field in a struct (duh)

Fixes #168

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/169)
<!-- Reviewable:end -->
