### PR TITLE
Fix build errors caused when using goapp on mac

### DIFF
--- a/msgp/file.go
+++ b/msgp/file.go
@@ -1,4 +1,5 @@
-// +build linux,!appengine darwin dragonfly freebsd netbsd openbsd
+// +build linux darwin dragonfly freebsd netbsd openbsd
+// +build !appengine
 
 package msgp
 


### PR DESCRIPTION
I am facing the following build errors when building for appengine by using `goapp` on Mac:

```
$ goapp build github.com/tinylib/msgp/msgp
# github.com/tinylib/msgp/msgp
msgp/file_port.go:13: MarshalSizer redeclared in this block
	previous declaration at msgp/file.go:44
msgp/file_port.go:18: ReadFile redeclared in this block
	previous declaration at msgp/file.go:23
msgp/file_port.go:31: WriteFile redeclared in this block
	previous declaration at msgp/file.go:70
```

This PR is for fixing the errors and I could see this library works well with my appengine application on both local development server on Mac and the actual appengine standard environment on cloud along with this fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/170)
<!-- Reviewable:end -->
