### PR TITLE
switch root element when inlining

### DIFF
--- a/_generated/def.go
+++ b/_generated/def.go
@@ -207,4 +207,5 @@ type Wrapper struct {
 type Tree struct {
 	Children []Tree
 	Element  int
+	Parent   *Wrapper
 }

--- a/_generated/def.go
+++ b/_generated/def.go
@@ -199,3 +199,12 @@ type FileHandle struct {
 
 type CustomInt int
 type CustomBytes []byte
+
+type Wrapper struct {
+	Tree *Tree
+}
+
+type Tree struct {
+	Children []Tree
+	Element  int
+}

--- a/parse/inline.go
+++ b/parse/inline.go
@@ -119,10 +119,8 @@ func (f *FileSet) nextInline(ref *gen.Elem, root string) {
 					panic(fatalloop)
 				}
 
-				// inline bottom-up so as not to miss
-				// other inlining opportunities.
-				f.nextInline(&node, root)
 				*ref = node.Copy()
+				f.nextInline(ref, node.TypeName())
 			} else if !ok && !el.Resolved() {
 				// this is the point at which we're sure that
 				// we've got a type that isn't a primitive,


### PR DESCRIPTION
In `nextInline`, inline on the copy of the replacement *after* the replacement has taken place, and use the replacement type name as the new root element.

@glycerine 

Fixes #171

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/172)
<!-- Reviewable:end -->
