### PR TITLE
no longer panics with the following file

### DIFF
--- a/msgp/write.go
+++ b/msgp/write.go
@@ -689,7 +689,7 @@ func (mw *Writer) WriteIntf(v interface{}) error {
 }
 
 func (mw *Writer) writeMap(v reflect.Value) (err error) {
-	if v.Elem().Kind() != reflect.String {
+	if v.Type().Key().Kind() != reflect.String {
 		return errors.New("msgp: map keys must be strings")
 	}
 	ks := v.MapKeys()


### PR DESCRIPTION
In `msgp/write.go`, the code that uses reflection to ensure the type of the map key is a string has a small bug.

Consider the following code sample, which ought to execute without panicking. After the fix, this code works as expected.

```Go
package main

//go:generate msgp

import (
	"bytes"
	"fmt"
	"os"

	"github.com/tinylib/msgp/msgp"
)

type Feedback map[string]interface{}

func main() {
	deepMap := make(map[string]map[string]string)
	feedback := Feedback{"general": deepMap}

	bb := new(bytes.Buffer)
	if err := msgp.Encode(bb, feedback); err != nil {
		fmt.Fprintf(os.Stderr, "%s\n", err)
		os.Exit(1)
	}
	fmt.Printf("%#v\n", bb.Bytes())
}

// 1. Type `go generate main.go`.
// 2. Type `go run main.go main_gen.go`.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/181)
<!-- Reviewable:end -->
