### PR TITLE
Add support for rune

### DIFF
--- a/_generated/def.go
+++ b/_generated/def.go
@@ -1,9 +1,10 @@
 package _generated
 
 import (
-	"github.com/tinylib/msgp/msgp"
 	"os"
 	"time"
+
+	"github.com/tinylib/msgp/msgp"
 )
 
 //go:generate msgp -o generated.go
@@ -50,6 +51,8 @@ type TestType struct {
 	Any      interface{} `msg:"any"`
 	Appended msgp.Raw    `msg:"appended"`
 	Num      msgp.Number `msg:"num"`
+	Byte     byte
+	Rune     rune
 	Slice1   []string
 	Slice2   []string
 	SlicePtr *[]string

--- a/_generated/gen_test.go
+++ b/_generated/gen_test.go
@@ -2,10 +2,11 @@ package _generated
 
 import (
 	"bytes"
-	"github.com/tinylib/msgp/msgp"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/tinylib/msgp/msgp"
 )
 
 // benchmark encoding a small, "fast" type.

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -84,6 +84,7 @@ const (
 	Uint32
 	Uint64
 	Byte
+	Rune
 	Int
 	Int8
 	Int16
@@ -112,6 +113,7 @@ var primitives = map[string]Primitive{
 	"uint32":         Uint32,
 	"uint64":         Uint64,
 	"byte":           Byte,
+	"rune":           Rune,
 	"int":            Int,
 	"int8":           Int8,
 	"int16":          Int16,
@@ -564,6 +566,8 @@ func (k Primitive) String() string {
 		return "Uint64"
 	case Byte:
 		return "Byte"
+	case Rune:
+		return "Rune"
 	case Int:
 		return "Int"
 	case Int8:

--- a/msgp/read.go
+++ b/msgp/read.go
@@ -782,6 +782,19 @@ func (m *Reader) ReadByte() (b byte, err error) {
 	return
 }
 
+// ReadRune is analogous to ReadInt32.
+// ReadRune is a protected method name in golang, go vet warns about this.
+func (m *Reader) ReadRune() (r rune, err error) {
+	var in int64
+	in, err = m.ReadInt64()
+	if in > math.MaxInt32 || in < math.MinInt32 {
+		err = IntOverflow{Value: in, FailedBitsize: 32}
+		return
+	}
+	r = rune(in)
+	return
+}
+
 // ReadBytes reads a MessagePack 'bin' object
 // from the reader and returns its value. It may
 // use 'scratch' for storage if it is non-nil.

--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -581,6 +581,11 @@ func ReadByteBytes(b []byte) (byte, []byte, error) {
 	return ReadUint8Bytes(b)
 }
 
+// ReadRuneBytes is analogous to ReadInt32Bytes
+func ReadRuneBytes(b []byte) (rune, []byte, error) {
+	return ReadInt32Bytes(b)
+}
+
 // ReadBytesBytes reads a 'bin' object
 // from 'b' and returns its vaue and
 // the remaining bytes in 'b'.

--- a/msgp/size.go
+++ b/msgp/size.go
@@ -17,6 +17,7 @@ const (
 	Int32Size      = 5
 	Uint8Size      = 2
 	ByteSize       = Uint8Size
+	RuneSize       = Int32Size
 	Uint16Size     = 3
 	Uint32Size     = 5
 	Uint64Size     = Int64Size

--- a/msgp/write.go
+++ b/msgp/write.go
@@ -400,6 +400,9 @@ func (mw *Writer) WriteUint64(u uint64) error {
 // WriteByte is analogous to WriteUint8
 func (mw *Writer) WriteByte(u byte) error { return mw.WriteUint8(uint8(u)) }
 
+// WriteRune is analogous to WriteInt32
+func (mw *Writer) WriteRune(u rune) error { return mw.WriteInt32(int32(u)) }
+
 // WriteUint8 writes a uint8 to the writer
 func (mw *Writer) WriteUint8(u uint8) error { return mw.WriteUint64(uint64(u)) }
 

--- a/msgp/write_bytes.go
+++ b/msgp/write_bytes.go
@@ -165,6 +165,9 @@ func AppendUint8(b []byte, u uint8) []byte { return AppendUint64(b, uint64(u)) }
 // AppendByte is analogous to AppendUint8
 func AppendByte(b []byte, u byte) []byte { return AppendUint8(b, uint8(u)) }
 
+// AppendRune is analogous to AppendInt32
+func AppendRune(b []byte, u rune) []byte { return AppendInt32(b, int32(u)) }
+
 // AppendUint16 appends a uint16 to the slice
 func AppendUint16(b []byte, u uint16) []byte { return AppendUint64(b, uint64(u)) }
 


### PR DESCRIPTION
I'm getting a `non-local identifier: rune` error when trying to generate a struct that has a `rune` as a field. This PR fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/188)
<!-- Reviewable:end -->
