### PR TITLE
Shim rune instead of WriteRune

### DIFF
--- a/_generated/def.go
+++ b/_generated/def.go
@@ -46,14 +46,19 @@ type TestType struct {
 		ValueA string `msg:"value_a"`
 		ValueB []byte `msg:"value_b"`
 	} `msg:"object"`
-	Child    *TestType   `msg:"child"`
-	Time     time.Time   `msg:"time"`
-	Any      interface{} `msg:"any"`
-	Appended msgp.Raw    `msg:"appended"`
-	Num      msgp.Number `msg:"num"`
-	Slice1   []string
-	Slice2   []string
-	SlicePtr *[]string
+	Child      *TestType   `msg:"child"`
+	Time       time.Time   `msg:"time"`
+	Any        interface{} `msg:"any"`
+	Appended   msgp.Raw    `msg:"appended"`
+	Num        msgp.Number `msg:"num"`
+	Byte       byte
+	Rune       rune
+	RunePtr    *rune
+	RunePtrPtr **rune
+	RuneSlice  []rune
+	Slice1     []string
+	Slice2     []string
+	SlicePtr   *[]string
 }
 
 //msgp:tuple Object

--- a/_generated/def_test.go
+++ b/_generated/def_test.go
@@ -1,0 +1,76 @@
+package _generated
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestRuneEncodeDecode(t *testing.T) {
+	tt := &TestType{}
+	r := 'r'
+	rp := &r
+	tt.Rune = r
+	tt.RunePtr = &r
+	tt.RunePtrPtr = &rp
+	tt.RuneSlice = []rune{'a', 'b', '😳'}
+
+	var buf bytes.Buffer
+	wrt := msgp.NewWriter(&buf)
+	if err := tt.EncodeMsg(wrt); err != nil {
+		t.Errorf("%v", err)
+	}
+	wrt.Flush()
+
+	var out TestType
+	rdr := msgp.NewReader(&buf)
+	if err := (&out).DecodeMsg(rdr); err != nil {
+		t.Errorf("%v", err)
+	}
+	if r != out.Rune {
+		t.Errorf("rune mismatch: expected %c found %c", r, out.Rune)
+	}
+	if r != *out.RunePtr {
+		t.Errorf("rune ptr mismatch: expected %c found %c", r, *out.RunePtr)
+	}
+	if r != **out.RunePtrPtr {
+		t.Errorf("rune ptr ptr mismatch: expected %c found %c", r, **out.RunePtrPtr)
+	}
+	if !reflect.DeepEqual(tt.RuneSlice, out.RuneSlice) {
+		t.Errorf("rune slice mismatch")
+	}
+}
+
+func TestRuneMarshalUnmarshal(t *testing.T) {
+	tt := &TestType{}
+	r := 'r'
+	rp := &r
+	tt.Rune = r
+	tt.RunePtr = &r
+	tt.RunePtrPtr = &rp
+	tt.RuneSlice = []rune{'a', 'b', '😳'}
+
+	bts, err := tt.MarshalMsg(nil)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	var out TestType
+	if _, err := (&out).UnmarshalMsg(bts); err != nil {
+		t.Errorf("%v", err)
+	}
+	if r != out.Rune {
+		t.Errorf("rune mismatch: expected %c found %c", r, out.Rune)
+	}
+	if r != *out.RunePtr {
+		t.Errorf("rune ptr mismatch: expected %c found %c", r, *out.RunePtr)
+	}
+	if r != **out.RunePtrPtr {
+		t.Errorf("rune ptr ptr mismatch: expected %c found %c", r, **out.RunePtrPtr)
+	}
+	if !reflect.DeepEqual(tt.RuneSlice, out.RuneSlice) {
+		t.Errorf("rune slice mismatch")
+	}
+}

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -112,6 +112,7 @@ var primitives = map[string]Primitive{
 	"uint32":         Uint32,
 	"uint64":         Uint64,
 	"byte":           Byte,
+	"rune":           Int32,
 	"int":            Int,
 	"int8":           Int8,
 	"int16":          Int16,

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -94,18 +94,6 @@ func File(name string, unexported bool) (*FileSet, error) {
 // are known to the parser. additional method-specific
 // directives remain in f.Directives
 func (f *FileSet) applyDirectives() {
-	{ // shim rune to int32
-		name := "rune"
-		be := gen.Ident("int32")
-		be.Alias(name)
-		be.ShimToBase = "rune"
-		be.ShimFromBase = "int32"
-		be.ShimMode = gen.Cast
-		f.findShim(name, be)
-
-		delete(f.Identities, name)
-	}
-
 	newdirs := make([]string, 0, len(f.Directives))
 	for _, d := range f.Directives {
 		chunks := strings.Split(d, " ")

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -94,6 +94,18 @@ func File(name string, unexported bool) (*FileSet, error) {
 // are known to the parser. additional method-specific
 // directives remain in f.Directives
 func (f *FileSet) applyDirectives() {
+	{ // shim rune to int32
+		name := "rune"
+		be := gen.Ident("int32")
+		be.Alias(name)
+		be.ShimToBase = "rune"
+		be.ShimFromBase = "int32"
+		be.ShimMode = gen.Cast
+		f.findShim(name, be)
+
+		delete(f.Identities, name)
+	}
+
 	newdirs := make([]string, 0, len(f.Directives))
 	for _, d := range f.Directives {
 		chunks := strings.Split(d, " ")


### PR DESCRIPTION
Here's v2 of the fix for handling runes. It works, it generates inline int32 casts just like it should, but the error still appears in the log:

    def.go: TestType: Rune: non-local identifier: rune
    def.go: TestType: RunePtr: non-local identifier: rune
    def.go: TestType: RunePtrPtr: non-local identifier: rune
    def.go: TestType: RuneSlice: non-local identifier: rune

I'll poke around now and see if I can silence the warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/189)
<!-- Reviewable:end -->
