### PR TITLE
Fix unused variable in msgsize when using convert shimmode

### DIFF
--- a/_generated/convert.go
+++ b/_generated/convert.go
@@ -21,6 +21,14 @@ type ConvertString struct {
 	String ConvertStringVal
 }
 
+type ConvertStringSlice struct {
+	Strings []ConvertStringVal
+}
+
+type ConvertStringMapValue struct {
+	Strings map[string]ConvertStringVal
+}
+
 //msgp:shim ConvertIntfVal as:interface{} using:fromConvertIntfVal/toConvertIntfVal mode:convert
 //msgp:ignore ConvertIntfVal
 

--- a/gen/size.go
+++ b/gen/size.go
@@ -188,6 +188,10 @@ func (s *sizeGen) gBase(b *BaseElem) {
 		s.state = add
 		vname := randIdent()
 		s.p.printf("\nvar %s %s", vname, b.BaseType())
+
+		// ensure we don't get "unused variable" warnings from outer slice iterations
+		s.p.printf("\n_ = %s", b.Varname())
+
 		s.p.printf("\ns += %s", basesizeExpr(b.Value, vname, b.BaseName()))
 		s.state = expr
 


### PR DESCRIPTION
Found a bug in the implementation for #67 where an unused variable was causing the generated code to choke on compile. Added a few extra test cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/193)
<!-- Reviewable:end -->
