### PR TITLE
Implement polymorphism via msgp:intercept directive

### DIFF
--- a/_generated/def.go
+++ b/_generated/def.go
@@ -194,7 +194,7 @@ type Custom struct {
 	Bts   CustomBytes          `msg:"bts"`
 	Mp    map[string]*Embedded `msg:"mp"`
 	Enums []MyEnum             `msg:"enums"` // test explicit enum shim
-	Some  FileHandle           `msg:file_handle`
+	Some  FileHandle           `msg:"file_handle"`
 }
 
 type Files []*os.File

--- a/_generated/intercept_defs.go
+++ b/_generated/intercept_defs.go
@@ -1,0 +1,257 @@
+package _generated
+
+import (
+	"fmt"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+//go:generate msgp
+
+//msgp:ignore testStructProvider
+type testStructProvider struct {
+	Events []string
+}
+
+var prv = &testStructProvider{}
+
+func resetStructProvider() {
+	prv = &testStructProvider{}
+}
+
+func TestStructProvider() *testStructProvider {
+	return prv
+}
+
+//msgp:intercept TestStructProvided using:TestStructProvider
+
+type TestStructProvided struct {
+	Foo string
+}
+
+type TestUsesStructProvided struct {
+	Foo *TestStructProvided
+}
+
+func (p *testStructProvider) DecodeMsg(dc *msgp.Reader) (t *TestStructProvided, err error) {
+	p.Events = append(p.Events, "decode")
+	t = new(TestStructProvided)
+	err = t.DecodeMsg(dc)
+	return
+}
+
+func (p *testStructProvider) UnmarshalMsg(bts []byte) (t *TestStructProvided, o []byte, err error) {
+	t = new(TestStructProvided)
+	p.Events = append(p.Events, "unmarshal")
+	o, err = t.UnmarshalMsg(bts)
+	return
+}
+
+func (p *testStructProvider) EncodeMsg(t *TestStructProvided, en *msgp.Writer) (err error) {
+	p.Events = append(p.Events, "encode")
+	return t.EncodeMsg(en)
+}
+
+func (p *testStructProvider) MarshalMsg(t *TestStructProvided, b []byte) (o []byte, err error) {
+	p.Events = append(p.Events, "marshal")
+	return t.MarshalMsg(b)
+}
+
+func (p *testStructProvider) Msgsize(t *TestStructProvided) (s int) {
+	p.Events = append(p.Events, "msgsize")
+	return t.Msgsize()
+}
+
+//msgp:ignore testStringProvided
+type testStringProvider struct {
+	Events []string
+}
+
+var stringPrv = &testStringProvider{}
+
+func resetStringProvider() {
+	stringPrv = &testStringProvider{}
+}
+
+func TestStringProvider() *testStringProvider {
+	return stringPrv
+}
+
+//msgp:intercept TestStringProvided using:TestStringProvider
+type TestStringProvided string
+
+type TestUsesStringProvided struct {
+	Foo TestStringProvided
+}
+
+func (p *testStringProvider) DecodeMsg(dc *msgp.Reader) (t TestStringProvided, err error) {
+	p.Events = append(p.Events, "decode")
+	var s string
+	s, err = dc.ReadString()
+	if err != nil {
+		return
+	}
+	t = TestStringProvided(s)
+	return
+}
+
+func (p *testStringProvider) UnmarshalMsg(bts []byte) (t TestStringProvided, o []byte, err error) {
+	p.Events = append(p.Events, "unmarshal")
+	var s string
+	s, o, err = msgp.ReadStringBytes(bts)
+	if err != nil {
+		return
+	}
+	t = TestStringProvided(s)
+	return
+}
+
+func (p *testStringProvider) EncodeMsg(t TestStringProvided, en *msgp.Writer) (err error) {
+	p.Events = append(p.Events, "encode")
+	return en.WriteString(string(t))
+}
+
+func (p *testStringProvider) MarshalMsg(t TestStringProvided, b []byte) (o []byte, err error) {
+	p.Events = append(p.Events, "marshal")
+	o = msgp.AppendString(b, string(t))
+	return
+}
+
+func (p *testStringProvider) Msgsize(t TestStringProvided) (s int) {
+	return msgp.StringPrefixSize + len(t)
+}
+
+//msgp:ignore testIntfStructProvider
+type testIntfStructProvider struct {
+	Events []string
+}
+
+var intfStructPrv = &testIntfStructProvider{}
+
+func resetIntfStructProvider() {
+	intfStructPrv = &testIntfStructProvider{}
+}
+
+func TestIntfStructProvider() *testIntfStructProvider {
+	return intfStructPrv
+}
+
+//msgp:intercept TestIntfStructProvided using:TestIntfStructProvider
+type TestIntfStructProvided interface {
+	msgp.Decodable
+	msgp.Encodable
+	msgp.MarshalSizer
+	msgp.Unmarshaler
+}
+
+type TestUsesIntfStructProvided struct {
+	Foo TestIntfStructProvided
+}
+
+type TestIntfA struct {
+	Foo string
+}
+
+type TestIntfB struct {
+	Bar string
+}
+
+func (p *testIntfStructProvider) DecodeMsg(dc *msgp.Reader) (t TestIntfStructProvided, err error) {
+	p.Events = append(p.Events, "decode")
+
+	if dc.IsNil() {
+		err = dc.ReadNil()
+	} else {
+		var s string
+		s, err = dc.ReadString()
+		if err != nil {
+			return
+		}
+		switch s {
+		case "a":
+			t = new(TestIntfA)
+		case "b":
+			t = new(TestIntfB)
+		default:
+			err = fmt.Errorf("unexpected type")
+			return
+		}
+		err = t.DecodeMsg(dc)
+	}
+	return
+}
+
+func (p *testIntfStructProvider) UnmarshalMsg(bts []byte) (t TestIntfStructProvided, o []byte, err error) {
+	p.Events = append(p.Events, "unmarshal")
+
+	o = bts
+	if msgp.IsNil(bts) {
+		o, err = msgp.ReadNilBytes(o)
+	} else {
+		var s string
+		s, o, err = msgp.ReadStringBytes(o)
+		if err != nil {
+			return
+		}
+		switch s {
+		case "a":
+			t = new(TestIntfA)
+		case "b":
+			t = new(TestIntfB)
+		default:
+			err = fmt.Errorf("unexpected type")
+			return
+		}
+		o, err = t.UnmarshalMsg(o)
+	}
+	return
+}
+
+func (p *testIntfStructProvider) EncodeMsg(t TestIntfStructProvided, en *msgp.Writer) (err error) {
+	p.Events = append(p.Events, "encode")
+	if t == nil {
+		return en.WriteNil()
+	} else {
+		var s string
+		switch t.(type) {
+		case *TestIntfA:
+			s = "a"
+		case *TestIntfB:
+			s = "b"
+		default:
+			err = fmt.Errorf("unexpected type %T", t)
+		}
+		if err = en.WriteString(s); err != nil {
+			return
+		}
+		return t.EncodeMsg(en)
+	}
+}
+
+func (p *testIntfStructProvider) MarshalMsg(t TestIntfStructProvided, b []byte) (o []byte, err error) {
+	p.Events = append(p.Events, "marshal")
+	o = b
+	if t == nil {
+		o = msgp.AppendNil(o)
+		return
+	} else {
+		var s string
+		switch t.(type) {
+		case *TestIntfA:
+			s = "a"
+		case *TestIntfB:
+			s = "b"
+		default:
+			err = fmt.Errorf("unexpected type %T", t)
+		}
+		o = msgp.AppendString(o, s)
+		return t.MarshalMsg(o)
+	}
+}
+
+func (p *testIntfStructProvider) Msgsize(t TestIntfStructProvided) (s int) {
+	if t == nil {
+		return msgp.NilSize
+	}
+	return t.Msgsize()
+}

--- a/_generated/intercept_defs.go
+++ b/_generated/intercept_defs.go
@@ -148,6 +148,14 @@ type TestUsesIntfStructProvided struct {
 	Foo TestIntfStructProvided
 }
 
+type TestUsesIntfStructProvidedSlice struct {
+	Foo []TestIntfStructProvided
+}
+
+type TestUsesIntfStructProvidedMap struct {
+	Foo map[string]TestIntfStructProvided
+}
+
 type TestIntfA struct {
 	Foo string
 }

--- a/_generated/intercept_test.go
+++ b/_generated/intercept_test.go
@@ -172,3 +172,71 @@ func TestInterceptInterfaceMarshalUnmarshal(t *testing.T) {
 		}
 	}
 }
+
+func TestInterceptInterfaceSliceMarshalUnmarshal(t *testing.T) {
+	cases := []TestUsesIntfStructProvidedSlice{
+		{Foo: []TestIntfStructProvided{
+			&TestIntfA{Foo: "hello"},
+			&TestIntfB{Bar: "world"},
+		}},
+
+		// FIXME: empty slice unmarshals as nil, is this msgp?
+		// {Foo: []TestIntfStructProvided{}},
+	}
+
+	for _, in := range cases {
+		resetIntfStructProvider()
+
+		bts, err := in.MarshalMsg(nil)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		var out TestUsesIntfStructProvidedSlice
+		if _, err := (&out).UnmarshalMsg(bts); err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		if !reflect.DeepEqual(in, out) {
+			t.Fatalf("provided marshal/unmarshal failed")
+		}
+
+		if !reflect.DeepEqual([]string{"marshal", "marshal", "unmarshal", "unmarshal"}, TestIntfStructProvider().Events) {
+			t.Fatalf("unexpected events: %v", TestIntfStructProvider().Events)
+		}
+	}
+}
+
+func TestInterceptInterfaceMapMarshalUnmarshal(t *testing.T) {
+	cases := []TestUsesIntfStructProvidedMap{
+		{Foo: map[string]TestIntfStructProvided{
+			"a": &TestIntfA{Foo: "hello"},
+			"b": &TestIntfB{Bar: "world"},
+		}},
+
+		// FIXME: empty slice unmarshals as nil, is this msgp?
+		// {Foo: []TestIntfStructProvided{}},
+	}
+
+	for _, in := range cases {
+		resetIntfStructProvider()
+
+		bts, err := in.MarshalMsg(nil)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		var out TestUsesIntfStructProvidedMap
+		if _, err := (&out).UnmarshalMsg(bts); err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		if !reflect.DeepEqual(in, out) {
+			t.Fatalf("provided marshal/unmarshal failed")
+		}
+
+		if !reflect.DeepEqual([]string{"marshal", "marshal", "unmarshal", "unmarshal"}, TestIntfStructProvider().Events) {
+			t.Fatalf("unexpected events: %v", TestIntfStructProvider().Events)
+		}
+	}
+}

--- a/_generated/intercept_test.go
+++ b/_generated/intercept_test.go
@@ -1,0 +1,174 @@
+package _generated
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestInterceptEncodeDecodeStruct(t *testing.T) {
+	resetStructProvider()
+
+	in := TestUsesStructProvided{Foo: &TestStructProvided{Foo: "hi"}}
+
+	var buf bytes.Buffer
+	wrt := msgp.NewWriter(&buf)
+	if err := in.EncodeMsg(wrt); err != nil {
+		t.Errorf("%v", err)
+	}
+	wrt.Flush()
+
+	var out TestUsesStructProvided
+	rdr := msgp.NewReader(&buf)
+	if err := (&out).DecodeMsg(rdr); err != nil {
+		t.Errorf("%v", err)
+	}
+
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("provided encode decode failed")
+	}
+
+	if !reflect.DeepEqual([]string{"encode", "decode"}, TestStructProvider().Events) {
+		t.Fatalf("unexpected events: %v", TestStructProvider().Events)
+	}
+}
+
+func TestInterceptMarshalUnmarshalStruct(t *testing.T) {
+	resetStructProvider()
+
+	in := TestUsesStructProvided{Foo: &TestStructProvided{Foo: "hi"}}
+
+	bts, err := in.MarshalMsg(nil)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	var out TestUsesStructProvided
+	if _, err := (&out).UnmarshalMsg(bts); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("provided unmarshal failed")
+	}
+
+	if !reflect.DeepEqual([]string{"msgsize", "marshal", "unmarshal"}, TestStructProvider().Events) {
+		t.Fatalf("unexpected events: %v", TestStructProvider().Events)
+	}
+}
+
+func TestInterceptEncodeDecodeString(t *testing.T) {
+	resetStringProvider()
+
+	in := TestUsesStringProvided{Foo: TestStringProvided("hi")}
+
+	var buf bytes.Buffer
+	wrt := msgp.NewWriter(&buf)
+	if err := in.EncodeMsg(wrt); err != nil {
+		t.Errorf("%v", err)
+	}
+	wrt.Flush()
+
+	var out TestUsesStringProvided
+	rdr := msgp.NewReader(&buf)
+	if err := (&out).DecodeMsg(rdr); err != nil {
+		t.Errorf("%v", err)
+	}
+
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("provided encode decode failed")
+	}
+
+	if !reflect.DeepEqual([]string{"encode", "decode"}, TestStringProvider().Events) {
+		t.Fatalf("unexpected events: %v", TestStringProvider().Events)
+	}
+}
+
+func TestInterceptMarshalUnmarshalString(t *testing.T) {
+	resetStringProvider()
+
+	in := TestUsesStringProvided{Foo: TestStringProvided("hi")}
+
+	bts, err := in.MarshalMsg(nil)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	var out TestUsesStringProvided
+	if _, err := (&out).UnmarshalMsg(bts); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("provided unmarshal failed")
+	}
+
+	if !reflect.DeepEqual([]string{"marshal", "unmarshal"}, TestStringProvider().Events) {
+		t.Fatalf("unexpected events, found: %v", TestStringProvider().Events)
+	}
+}
+
+func TestInterceptInterfaceEncodeDecode(t *testing.T) {
+	cases := []TestUsesIntfStructProvided{
+		{Foo: &TestIntfA{Foo: "hello"}},
+		{Foo: &TestIntfB{Bar: "world"}},
+		{Foo: nil},
+	}
+
+	for _, in := range cases {
+		resetIntfStructProvider()
+
+		var buf bytes.Buffer
+		wrt := msgp.NewWriter(&buf)
+		if err := in.EncodeMsg(wrt); err != nil {
+			t.Errorf("%v", err)
+		}
+		wrt.Flush()
+
+		var out TestUsesIntfStructProvided
+		rdr := msgp.NewReader(&buf)
+		if err := (&out).DecodeMsg(rdr); err != nil {
+			t.Errorf("%v", err)
+		}
+
+		if !reflect.DeepEqual(in, out) {
+			t.Fatalf("provided encode decode failed")
+		}
+
+		if !reflect.DeepEqual([]string{"encode", "decode"}, TestIntfStructProvider().Events) {
+			t.Fatalf("unexpected events: %v", TestIntfStructProvider().Events)
+		}
+	}
+}
+
+func TestInterceptInterfaceMarshalUnmarshal(t *testing.T) {
+	cases := []TestUsesIntfStructProvided{
+		{Foo: &TestIntfA{Foo: "hello"}},
+		{Foo: &TestIntfB{Bar: "world"}},
+		{Foo: nil},
+	}
+
+	for _, in := range cases {
+		resetIntfStructProvider()
+
+		bts, err := in.MarshalMsg(nil)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		var out TestUsesIntfStructProvided
+		if _, err := (&out).UnmarshalMsg(bts); err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		if !reflect.DeepEqual(in, out) {
+			t.Fatalf("provided marshal/unmarshal failed")
+		}
+
+		if !reflect.DeepEqual([]string{"marshal", "unmarshal"}, TestIntfStructProvider().Events) {
+			t.Fatalf("unexpected events: %v", TestIntfStructProvider().Events)
+		}
+	}
+}

--- a/gen/decode.go
+++ b/gen/decode.go
@@ -133,7 +133,11 @@ func (d *decodeGen) gBase(b *BaseElem) {
 			d.p.printf("\n%s, err = dc.ReadBytes(%s)", vname, vname)
 		}
 	case IDENT:
-		d.p.printf("\nerr = %s.DecodeMsg(dc)", vname)
+		if b.Provider() != "" {
+			d.p.printf("\n%s, err = %s().DecodeMsg(dc)", vname, b.Provider())
+		} else {
+			d.p.printf("\nerr = %s.DecodeMsg(dc)", vname)
+		}
 	case Ext:
 		d.p.printf("\nerr = dc.ReadExtension(%s)", vname)
 	default:

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -11,6 +11,12 @@ const (
 	idxLen   = 3
 )
 
+// interface checks
+var (
+	_ Intercepted = &BaseElem{}
+	_ Intercepted = &Struct{}
+)
+
 // generate a random identifier name
 func randIdent() string {
 	bts := make([]byte, idxLen)
@@ -136,6 +142,7 @@ var builtins = map[string]struct{}{
 type common struct{ vname, alias string }
 
 func (c *common) SetVarname(s string) { c.vname = s }
+func (c *common) Printable() bool     { return true }
 func (c *common) Varname() string     { return c.vname }
 func (c *common) Alias(typ string)    { c.alias = typ }
 func (c *common) hidden()             {}
@@ -179,6 +186,8 @@ type Elem interface {
 	// complexity of element (greater than
 	// or equal to 1.)
 	Complexity() int
+
+	Printable() bool
 
 	hidden()
 }
@@ -353,17 +362,49 @@ func (s *Ptr) Copy() Elem {
 func (s *Ptr) Complexity() int { return 1 + s.Value.Complexity() }
 
 func (s *Ptr) Needsinit() bool {
+	if IsIntercepted(s.Value) {
+		return false
+	}
 	if be, ok := s.Value.(*BaseElem); ok && be.needsref {
 		return false
 	}
 	return true
 }
 
+type IntfElem struct {
+	common
+	provider string // struct is intercepted
+}
+
+func (s *IntfElem) Printable() bool { return false }
+
+func (s *IntfElem) Provider() string { return s.provider }
+
+func (s *IntfElem) SetProvider(p string) { s.provider = p }
+
+func (s *IntfElem) TypeName() string {
+	return s.common.alias
+}
+
+func (s *IntfElem) Copy() Elem {
+	z := *s
+	return &z
+}
+
+func (s *IntfElem) Complexity() int {
+	return 1
+}
+
 type Struct struct {
 	common
-	Fields  []StructField // field list
-	AsTuple bool          // write as an array instead of a map
+	Fields   []StructField // field list
+	AsTuple  bool          // write as an array instead of a map
+	provider string        // struct is intercepted
 }
+
+func (s *Struct) Provider() string { return s.provider }
+
+func (s *Struct) SetProvider(p string) { s.provider = p }
 
 func (s *Struct) TypeName() string {
 	if s.common.alias != "" {
@@ -424,11 +465,16 @@ type BaseElem struct {
 	ShimFromBase string    // shim from base type, or empty
 	Value        Primitive // Type of element
 	Convert      bool      // should we do an explicit conversion?
+	provider     string    // base elem is intercepted
 	mustinline   bool      // must inline; not printable
 	needsref     bool      // needs reference for shim
 }
 
 func (s *BaseElem) Printable() bool { return !s.mustinline }
+
+func (s *BaseElem) Provider() string { return s.provider }
+
+func (s *BaseElem) SetProvider(p string) { s.provider = p }
 
 func (s *BaseElem) Alias(typ string) {
 	s.common.Alias(typ)
@@ -604,4 +650,16 @@ func writeStructFields(s []StructField, name string) {
 	for i := range s {
 		s[i].FieldElem.SetVarname(fmt.Sprintf("%s.%s", name, s[i].FieldName))
 	}
+}
+
+type Intercepted interface {
+	Provider() string
+	SetProvider(s string)
+}
+
+func IsIntercepted(e Elem) bool {
+	if p, ok := e.(Intercepted); ok {
+		return p.Provider() != ""
+	}
+	return false
 }

--- a/gen/encode.go
+++ b/gen/encode.go
@@ -184,7 +184,11 @@ func (e *encodeGen) gBase(b *BaseElem) {
 	}
 
 	if b.Value == IDENT { // unknown identity
-		e.p.printf("\nerr = %s.EncodeMsg(en)", vname)
+		if b.Provider() != "" {
+			e.p.printf("\nerr = %s().EncodeMsg(%s, en)", b.Provider(), vname)
+		} else {
+			e.p.printf("\nerr = %s.EncodeMsg(en)", vname)
+		}
 		e.p.print(errcheck)
 	} else { // typical case
 		e.writeAndCheck(b.BaseName(), literalFmt, vname)

--- a/gen/marshal.go
+++ b/gen/marshal.go
@@ -192,7 +192,11 @@ func (m *marshalGen) gBase(b *BaseElem) {
 	switch b.Value {
 	case IDENT:
 		echeck = true
-		m.p.printf("\no, err = %s.MarshalMsg(o)", vname)
+		if b.Provider() != "" {
+			m.p.printf("\no, err = %s().MarshalMsg(%s, o)", b.Provider(), vname)
+		} else {
+			m.p.printf("\no, err = %s.MarshalMsg(o)", vname)
+		}
 	case Intf, Ext:
 		echeck = true
 		m.p.printf("\no, err = msgp.Append%s(o, %s)", b.BaseName(), vname)

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -128,7 +128,11 @@ func (u *unmarshalGen) gBase(b *BaseElem) {
 	case Ext:
 		u.p.printf("\nbts, err = msgp.ReadExtensionBytes(bts, %s)", lowered)
 	case IDENT:
-		u.p.printf("\nbts, err = %s.UnmarshalMsg(bts)", lowered)
+		if b.Provider() != "" {
+			u.p.printf("\n%s, bts, err = %s().UnmarshalMsg(bts)", lowered, b.Provider())
+		} else {
+			u.p.printf("\nbts, err = %s.UnmarshalMsg(bts)", lowered)
+		}
 	default:
 		u.p.printf("\n%s, bts, err = msgp.Read%sBytes(bts)", refname, b.BaseName())
 	}

--- a/msgp/edit.go
+++ b/msgp/edit.go
@@ -1,8 +1,6 @@
 package msgp
 
-import (
-	"math"
-)
+import "math"
 
 // Locate returns a []byte pointing to the field
 // in a messagepack map with the provided key. (The returned []byte

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -256,11 +256,14 @@ func (f *FileSet) PrintTo(p *gen.Printer) error {
 	for _, name := range names {
 		el := f.Identities[name]
 		el.SetVarname("z")
-		pushstate(el.TypeName())
-		err := p.Print(el)
-		popstate()
-		if err != nil {
-			return err
+
+		if el.Printable() {
+			pushstate(el.TypeName())
+			err := p.Print(el)
+			popstate()
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -292,6 +295,7 @@ func (fs *FileSet) getTypeSpecs(f *ast.File) {
 						*ast.ArrayType,
 						*ast.StarExpr,
 						*ast.MapType,
+						*ast.InterfaceType,
 						*ast.Ident:
 						fs.Specs[ts.Name.Name] = ts.Type
 
@@ -538,8 +542,9 @@ func (fs *FileSet) parseExpr(e ast.Expr) gen.Elem {
 		// support `interface{}`
 		if len(e.Methods.List) == 0 {
 			return &gen.BaseElem{Value: gen.Intf}
+		} else {
+			return &gen.IntfElem{}
 		}
-		return nil
 
 	default: // other types not supported
 		return nil


### PR DESCRIPTION
Here's an attempt at #184. I have had about 4 or 5 goes at this now, this is the only way I've found that went in even remotely cleanly. I tried doing it with extensions, then found the warning against that in #35. I tried extending ShimMode at least twice, but that was a total mess. This is the first time I've tried something that didn't feel like I was committing an act of vandalism!

Using this, we can delegate to a function to provide a stand-in that can decode, encode, marshal and unmarshal instead of calling it on the type itself. Interface types can be supported, as well as typed primitives.

There's no interface type for the mapper so we can retain type safety. You can just implement as much or as little as the code generator requires, based on what you ask it to generate. 

```go
//msgp:intercept MyIntf using:DefaultMyIntfMapper

type Thingy struct {
    Foo MyIntf
}

type MyIntf interface {}

func DefaultMyIntfMapper() myIntfMapper { return &myIntfMapper{} }

type myIntfMapper struct {}

func (p *myIntfMapper) DecodeMsg(dc *msgp.Reader) (t MyIntf, err error) {}
func (p *myIntfMapper) UnmarshalMsg(bts []byte) (t MyIntf, o []byte, err error) {}
func (p *myIntfMapper) EncodeMsg(t MyIntf, en *msgp.Writer) (err error) {}
func (p *myIntfMapper) MarshalMsg(t MyIntf, b []byte) (o []byte, err error) {}
func (p *myIntfMapper) Msgsize(t MyIntf) (s int) {}
```

The use is demonstrated in the `_generated/intercept_defs.go` and `_generated/intercept_test.go` files. I know I haven't got a complete set of tests here, but I need to think of more scenarios. I just thought I'd open this for discussion before I go test-case crazy just in case this approach is not one that would be acceptable.

I added a dummy element for interfaces that gets skipped by the printer but that was only to quiet the warning that gets raised: `intercept_defs.go: TestUsesIntfStructProvided: Foo: non-local identifier: TestIntfStructProvided`, if there's a better way to sort that out that involves fewer changes to the Elem hierarchy I'd be grateful for a tip, I didn't see one.

I know it looks like a big patch, but the overwhelming majority of it is tests!