### PR TITLE
Fixed width array length constants other than uint32 can now compared to array headers

### DIFF
--- a/_generated/def.go
+++ b/_generated/def.go
@@ -216,3 +216,30 @@ type Tree struct {
 	Element  int
 	Parent   *Wrapper
 }
+
+// Ensure all different widths of integer can be used as constant keys.
+const (
+	ConstantInt    int    = 8
+	ConstantInt8   int8   = 8
+	ConstantInt16  int16  = 8
+	ConstantInt32  int32  = 8
+	ConstantInt64  int64  = 8
+	ConstantUint   uint   = 8
+	ConstantUint8  uint8  = 8
+	ConstantUint16 uint16 = 8
+	ConstantUint32 uint32 = 8
+	ConstantUint64 uint64 = 8
+)
+
+type ArrayConstants struct {
+	ConstantInt    [ConstantInt]string
+	ConstantInt8   [ConstantInt8]string
+	ConstantInt16  [ConstantInt16]string
+	ConstantInt32  [ConstantInt32]string
+	ConstantInt64  [ConstantInt64]string
+	ConstantUint   [ConstantUint]string
+	ConstantUint8  [ConstantUint8]string
+	ConstantUint16 [ConstantUint16]string
+	ConstantUint32 [ConstantUint32]string
+	ConstantUint64 [ConstantUint64]string
+}

--- a/_generated/def.go
+++ b/_generated/def.go
@@ -242,4 +242,6 @@ type ArrayConstants struct {
 	ConstantUint16 [ConstantUint16]string
 	ConstantUint32 [ConstantUint32]string
 	ConstantUint64 [ConstantUint64]string
+	ConstantHex    [0x16]string
+	ConstantOctal  [07]string
 }

--- a/gen/decode.go
+++ b/gen/decode.go
@@ -203,7 +203,7 @@ func (d *decodeGen) gArray(a *Array) {
 	sz := randIdent()
 	d.p.declare(sz, u32)
 	d.assignAndCheck(sz, arrayHeader)
-	d.p.arrayCheck(a.Size, sz)
+	d.p.arrayCheck(coerceArraySize(a.Size), sz)
 
 	d.p.rangeBlock(a.Index, a.Varname(), d, a.Els)
 }

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -3,7 +3,6 @@ package gen
 import (
 	"fmt"
 	"math/rand"
-	"strconv"
 	"strings"
 )
 
@@ -614,18 +613,6 @@ func writeStructFields(s []StructField, name string) {
 // can declare array lengths as any constant integer width, which breaks when
 // attempting a direct comparison to an array header's uint32.
 //
-// If we have a string at this point, it represents a constant which could have
-// any integer width so we must coerce it to uint32 to guarantee it is
-// comparable.
-//
 func coerceArraySize(asz string) string {
-	if _, err := strconv.ParseInt(asz, 10, 64); err == nil {
-		return asz
-	}
-	if strings.HasPrefix(asz, "0x") {
-		if _, err := strconv.ParseInt(asz[2:], 16, 64); err == nil {
-			return asz
-		}
-	}
 	return fmt.Sprintf("uint32(%s)", asz)
 }

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -3,6 +3,7 @@ package gen
 import (
 	"fmt"
 	"math/rand"
+	"strconv"
 	"strings"
 )
 
@@ -604,4 +605,22 @@ func writeStructFields(s []StructField, name string) {
 	for i := range s {
 		s[i].FieldElem.SetVarname(fmt.Sprintf("%s.%s", name, s[i].FieldName))
 	}
+}
+
+// coerceArraySize ensures we can compare constant array lengths.
+//
+// msgpack array headers are 32 bit unsigned, which is reflected in the
+// ArrayHeader implementation in this library using uint32. On the Go side, we
+// can declare array lengths as any constant integer width, which breaks when
+// attempting a direct comparison to an array header's uint32.
+//
+// If we have a string at this point, it represents a constant which could have
+// any integer width so we must coerce it to uint32 to guarantee it is
+// comparable.
+//
+func coerceArraySize(asz string) string {
+	if _, err := strconv.ParseInt(asz, 10, 64); err != nil {
+		asz = fmt.Sprintf("uint32(%s)", asz)
+	}
+	return asz
 }

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -619,8 +619,13 @@ func writeStructFields(s []StructField, name string) {
 // comparable.
 //
 func coerceArraySize(asz string) string {
-	if _, err := strconv.ParseInt(asz, 10, 64); err != nil {
-		asz = fmt.Sprintf("uint32(%s)", asz)
+	if _, err := strconv.ParseInt(asz, 10, 64); err == nil {
+		return asz
 	}
-	return asz
+	if strings.HasPrefix(asz, "0x") {
+		if _, err := strconv.ParseInt(asz[2:], 16, 64); err == nil {
+			return asz
+		}
+	}
+	return fmt.Sprintf("uint32(%s)", asz)
 }

--- a/gen/encode.go
+++ b/gen/encode.go
@@ -162,7 +162,7 @@ func (e *encodeGen) gArray(a *Array) {
 		return
 	}
 
-	e.writeAndCheck(arrayHeader, literalFmt, a.Size)
+	e.writeAndCheck(arrayHeader, literalFmt, coerceArraySize(a.Size))
 	e.p.rangeBlock(a.Index, a.Varname(), e, a.Els)
 }
 

--- a/gen/marshal.go
+++ b/gen/marshal.go
@@ -156,7 +156,7 @@ func (m *marshalGen) gArray(a *Array) {
 		return
 	}
 
-	m.rawAppend(arrayHeader, literalFmt, a.Size)
+	m.rawAppend(arrayHeader, literalFmt, coerceArraySize(a.Size))
 	m.p.rangeBlock(a.Index, a.Varname(), m, a.Els)
 }
 

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -162,7 +162,7 @@ func (u *unmarshalGen) gArray(a *Array) {
 	sz := randIdent()
 	u.p.declare(sz, u32)
 	u.assignAndCheck(sz, arrayHeader)
-	u.p.arrayCheck(a.Size, sz)
+	u.p.arrayCheck(coerceArraySize(a.Size), sz)
 	u.p.rangeBlock(a.Index, a.Varname(), u, a.Els)
 }
 


### PR DESCRIPTION
I ran into a problem where using an integer width other than uint32 for array length constants was causing an error in the generator:

```go
const Bar int = 8
type Foo struct {
    Hello [Bar]string
}
```

This would yield errors like the following:

```
# github.com/tinylib/msgp/_generated
_generated/generated.go:1849:12: invalid operation: zigk != Bar (mismatched types uint32 and int)
_generated/generated.go:1850:33: cannot use Bar (type int) as type uint32 in field value
_generated/generated.go:1877:27: cannot use Bar (type int) as type uint32 in argument to en.WriteArrayHeader
_generated/generated.go:1896:28: cannot use Bar (type int) as type uint32 in argument to msgp.AppendArrayHeader
_generated/generated.go:1925:12: invalid operation: zuop != Bar (mismatched types uint32 and int)
_generated/generated.go:1926:33: cannot use Bar (type int) as type uint32 in field value
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/195)
<!-- Reviewable:end -->
