### PR TITLE
Make Marshal/Unmarshal of an empty msgp.Raw symmetric

### DIFF
--- a/_generated/gen_test.go
+++ b/_generated/gen_test.go
@@ -57,15 +57,21 @@ func BenchmarkFastDecode(b *testing.B) {
 }
 
 func (a *TestType) Equal(b *TestType) bool {
-	// compare times, then zero out those
+	// compare times, appended, then zero out those
 	// fields, perform a DeepEqual, and restore them
 	ta, tb := a.Time, b.Time
 	if !ta.Equal(tb) {
 		return false
 	}
+	aa, ab := a.Appended, b.Appended
+	if !bytes.Equal(aa, ab) {
+		return false
+	}
 	a.Time, b.Time = time.Time{}, time.Time{}
+	aa, ab = nil, nil
 	ok := reflect.DeepEqual(a, b)
 	a.Time, b.Time = ta, tb
+	a.Appended, b.Appended = aa, ab
 	return ok
 }
 
@@ -93,7 +99,7 @@ func Test1EncodeDecode(t *testing.T) {
 		},
 		Child:    nil,
 		Time:     time.Now(),
-		Appended: msgp.Raw([]byte{0xc0}), // 'nil'
+		Appended: msgp.Raw([]byte{}), // 'nil'
 	}
 
 	var buf bytes.Buffer

--- a/msgp/raw_test.go
+++ b/msgp/raw_test.go
@@ -83,3 +83,31 @@ func TestRaw(t *testing.T) {
 		t.Fatal("value of output and input of MarshalMsg are not equal.")
 	}
 }
+
+func TestNullRaw(t *testing.T) {
+	// Marshal/Unmarshal
+	var x, y Raw
+	if bts, err := x.MarshalMsg(nil); err != nil {
+		t.Fatal(err)
+	} else if _, err = y.UnmarshalMsg(bts); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(x, y) {
+		t.Fatal("compare")
+	}
+
+	// Encode/Decode
+	var buf bytes.Buffer
+	wr := NewWriter(&buf)
+	if err := x.EncodeMsg(wr); err != nil {
+		t.Fatal(err)
+	}
+	wr.Flush()
+	rd := NewReader(&buf)
+	if err := y.DecodeMsg(rd); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(x, y) {
+		t.Fatal("compare")
+	}
+}

--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -79,6 +79,9 @@ func (r *Raw) UnmarshalMsg(b []byte) ([]byte, error) {
 		return b, err
 	}
 	rlen := l - len(out)
+	if IsNil(b[:rlen]) {
+		rlen = 0
+	}
 	if cap(*r) < rlen {
 		*r = make(Raw, rlen)
 	} else {
@@ -104,7 +107,11 @@ func (r Raw) EncodeMsg(w *Writer) error {
 // next object on the wire.
 func (r *Raw) DecodeMsg(f *Reader) error {
 	*r = (*r)[:0]
-	return appendNext(f, (*[]byte)(r))
+	err := appendNext(f, (*[]byte)(r))
+	if IsNil(*r) {
+		*r = (*r)[:0]
+	}
+	return err
 }
 
 // Msgsize implements msgp.Sizer


### PR DESCRIPTION
Before this change Unmarshal of a Marshaled empty Raw would yield
a byte slice with a Nil marker in it. This change makes Unmarshal
consume the marker and return an empty slice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/197)
<!-- Reviewable:end -->
