### PR TITLE
Field context information in error messages

### DIFF
--- a/_generated/convert_test.go
+++ b/_generated/convert_test.go
@@ -12,8 +12,8 @@ func TestConvertFromEncodeError(t *testing.T) {
 	var buf bytes.Buffer
 	w := msgp.NewWriter(&buf)
 	err := e.EncodeMsg(w)
-	if err != errConvertFrom {
-		t.Fatalf("expected conversion error, found %v", err.Error())
+	if msgp.Cause(err) != errConvertFrom {
+		t.Fatalf("expected conversion error, found '%v'", err.Error())
 	}
 }
 
@@ -30,7 +30,8 @@ func TestConvertToEncodeError(t *testing.T) {
 
 	r := msgp.NewReader(&buf)
 	err = (&out).DecodeMsg(r)
-	if err != errConvertTo {
+
+	if msgp.Cause(err) != errConvertTo {
 		t.Fatalf("expected conversion error, found %v", err.Error())
 	}
 }
@@ -39,7 +40,7 @@ func TestConvertFromMarshalError(t *testing.T) {
 	e := ConvertErr{ConvertErrVal(fromFailStr)}
 	var b []byte
 	_, err := e.MarshalMsg(b)
-	if err != errConvertFrom {
+	if msgp.Cause(err) != errConvertFrom {
 		t.Fatalf("expected conversion error, found %v", err.Error())
 	}
 }
@@ -53,7 +54,7 @@ func TestConvertToMarshalError(t *testing.T) {
 	}
 
 	_, err = (&out).UnmarshalMsg(b)
-	if err != errConvertTo {
+	if msgp.Cause(err) != errConvertTo {
 		t.Fatalf("expected conversion error, found %v", err.Error())
 	}
 }

--- a/_generated/def.go
+++ b/_generated/def.go
@@ -194,7 +194,7 @@ type Custom struct {
 	Bts   CustomBytes          `msg:"bts"`
 	Mp    map[string]*Embedded `msg:"mp"`
 	Enums []MyEnum             `msg:"enums"` // test explicit enum shim
-	Some  FileHandle           `msg:file_handle`
+	Some  FileHandle           `msg:"file_handle"`
 }
 
 type Files []*os.File

--- a/_generated/errorwrap.go
+++ b/_generated/errorwrap.go
@@ -1,0 +1,60 @@
+package _generated
+
+//go:generate msgp
+
+// The leaves of interest in this crazy structs are strings. The test case
+// looks for strings in the serialised msgpack and makes them unreadable.
+
+type ErrorCtxMapChild struct {
+	Val string
+}
+
+type ErrorCtxAsMap struct {
+	Val      string
+	Child    *ErrorCtxMapChild
+	Children []*ErrorCtxMapChild
+	Map      map[string]string
+
+	Nest struct {
+		Val      string
+		Child    *ErrorCtxMapChild
+		Children []*ErrorCtxMapChild
+		Map      map[string]string
+
+		Nest struct {
+			Val      string
+			Child    *ErrorCtxMapChild
+			Children []*ErrorCtxMapChild
+			Map      map[string]string
+		}
+	}
+}
+
+//msgp:tuple ErrorCtxTupleChild
+
+type ErrorCtxTupleChild struct {
+	Val string
+}
+
+//msgp:tuple ErrorCtxAsTuple
+
+type ErrorCtxAsTuple struct {
+	Val      string
+	Child    *ErrorCtxTupleChild
+	Children []*ErrorCtxTupleChild
+	Map      map[string]string
+
+	Nest struct {
+		Val      string
+		Child    *ErrorCtxTupleChild
+		Children []*ErrorCtxTupleChild
+		Map      map[string]string
+
+		Nest struct {
+			Val      string
+			Child    *ErrorCtxTupleChild
+			Children []*ErrorCtxTupleChild
+			Map      map[string]string
+		}
+	}
+}

--- a/_generated/errorwrap.go
+++ b/_generated/errorwrap.go
@@ -9,11 +9,16 @@ type ErrorCtxMapChild struct {
 	Val string
 }
 
+type ErrorCtxMapChildNotInline struct {
+	Val1, Val2, Val3, Val4, Val5 string
+}
+
 type ErrorCtxAsMap struct {
-	Val      string
-	Child    *ErrorCtxMapChild
-	Children []*ErrorCtxMapChild
-	Map      map[string]string
+	Val          string
+	Child        *ErrorCtxMapChild
+	Children     []*ErrorCtxMapChild
+	ComplexChild *ErrorCtxMapChildNotInline
+	Map          map[string]string
 
 	Nest struct {
 		Val      string
@@ -36,13 +41,20 @@ type ErrorCtxTupleChild struct {
 	Val string
 }
 
+//msgp:tuple ErrorCtxTupleChildNotInline
+
+type ErrorCtxTupleChildNotInline struct {
+	Val1, Val2, Val3, Val4, Val5 string
+}
+
 //msgp:tuple ErrorCtxAsTuple
 
 type ErrorCtxAsTuple struct {
-	Val      string
-	Child    *ErrorCtxTupleChild
-	Children []*ErrorCtxTupleChild
-	Map      map[string]string
+	Val          string
+	Child        *ErrorCtxTupleChild
+	Children     []*ErrorCtxTupleChild
+	ComplexChild *ErrorCtxTupleChildNotInline
+	Map          map[string]string
 
 	Nest struct {
 		Val      string

--- a/_generated/errorwrap_test.go
+++ b/_generated/errorwrap_test.go
@@ -1,0 +1,301 @@
+package _generated
+
+import (
+	"bytes"
+	"io"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+func fillErrorCtxAsMap() *ErrorCtxAsMap {
+	v := &ErrorCtxAsMap{}
+	v.Val = "foo"
+	v.Child = &ErrorCtxMapChild{Val: "foo"}
+	v.Children = []*ErrorCtxMapChild{{Val: "foo"}, {Val: "bar"}}
+	v.Map = map[string]string{"foo": "bar", "baz": "qux"}
+	v.Nest.Val = "foo"
+	v.Nest.Child = &ErrorCtxMapChild{Val: "foo"}
+	v.Nest.Children = []*ErrorCtxMapChild{{Val: "foo"}, {Val: "bar"}}
+	v.Nest.Map = map[string]string{"foo": "bar", "baz": "qux"}
+	v.Nest.Nest.Val = "foo"
+	v.Nest.Nest.Child = &ErrorCtxMapChild{Val: "foo"}
+	v.Nest.Nest.Children = []*ErrorCtxMapChild{{Val: "foo"}, {Val: "bar"}}
+	v.Nest.Nest.Map = map[string]string{"foo": "bar", "baz": "qux"}
+	return v
+}
+
+func fillErrorCtxAsTuple() *ErrorCtxAsTuple {
+	v := &ErrorCtxAsTuple{}
+	v.Val = "foo"
+	v.Child = &ErrorCtxTupleChild{Val: "foo"}
+	v.Children = []*ErrorCtxTupleChild{{Val: "foo"}, {Val: "bar"}}
+	v.Map = map[string]string{"foo": "bar", "baz": "qux"}
+	v.Nest.Val = "foo"
+	v.Nest.Child = &ErrorCtxTupleChild{Val: "foo"}
+	v.Nest.Children = []*ErrorCtxTupleChild{{Val: "foo"}, {Val: "bar"}}
+	v.Nest.Map = map[string]string{"foo": "bar", "baz": "qux"}
+	v.Nest.Nest.Val = "foo"
+	v.Nest.Nest.Child = &ErrorCtxTupleChild{Val: "foo"}
+	v.Nest.Nest.Children = []*ErrorCtxTupleChild{{Val: "foo"}, {Val: "bar"}}
+	v.Nest.Nest.Map = map[string]string{"foo": "bar", "baz": "qux"}
+	return v
+}
+
+type outBuf struct {
+	*bytes.Buffer
+	dodgifyString int
+	strIdx        int
+}
+
+func (o *outBuf) Write(b []byte) (n int, err error) {
+	ilen := len(b)
+	if msgp.NextType(b) == msgp.StrType {
+		if o.strIdx == o.dodgifyString {
+			// Fool msgp into thinking this value is a fixint. msgp will throw
+			// a type error for this value.
+			b[0] = 1
+		}
+		o.strIdx++
+	}
+	_, err = o.Buffer.Write(b)
+	return ilen, err
+}
+
+type strCounter int
+
+func (o *strCounter) Write(b []byte) (n int, err error) {
+	if msgp.NextType(b) == msgp.StrType {
+		*o++
+	}
+	return len(b), nil
+}
+
+func countStrings(bts []byte) int {
+	r := msgp.NewReader(bytes.NewReader(bts))
+	strCounter := strCounter(0)
+	for {
+		_, err := r.CopyNext(&strCounter)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			panic(err)
+		}
+	}
+	return int(strCounter)
+}
+
+func marshalErrorCtx(m msgp.Marshaler) []byte {
+	bts, err := m.MarshalMsg(nil)
+	if err != nil {
+		panic(err)
+	}
+	return bts
+}
+
+// dodgifyMsgpString will wreck the nth string in the msgpack blob
+// so that it raises an error when decoded or unmarshaled.
+func dodgifyMsgpString(bts []byte, idx int) []byte {
+	r := msgp.NewReader(bytes.NewReader(bts))
+	out := &outBuf{Buffer: &bytes.Buffer{}, dodgifyString: idx}
+	for {
+		_, err := r.CopyNext(out)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			panic(err)
+		}
+	}
+	return out.Bytes()
+}
+
+func TestErrorCtxAsMapUnmarshal(t *testing.T) {
+	bts := marshalErrorCtx(fillErrorCtxAsMap())
+	cnt := countStrings(bts)
+
+	var as []string
+	for i := 0; i < cnt; i++ {
+		dodgeBts := dodgifyMsgpString(bts, i)
+
+		var ec ErrorCtxAsMap
+		_, err := (&ec).UnmarshalMsg(dodgeBts)
+		words := strings.Split(err.Error(), " ")
+		last := words[len(words)-1]
+		as = append(as, last)
+	}
+
+	// Map key iteration order is not consistent
+	sort.Strings(expectedAsMap)
+	sort.Strings(as)
+
+	if !reflect.DeepEqual(expectedAsMap, as) {
+		t.Fatal()
+	}
+}
+
+func TestErrorCtxAsMapDecode(t *testing.T) {
+	bts := marshalErrorCtx(fillErrorCtxAsMap())
+	cnt := countStrings(bts)
+
+	var as []string
+	for i := 0; i < cnt; i++ {
+		dodgeBts := dodgifyMsgpString(bts, i)
+
+		r := msgp.NewReader(bytes.NewReader(dodgeBts))
+		var ec ErrorCtxAsMap
+		err := (&ec).DecodeMsg(r)
+		words := strings.Split(err.Error(), " ")
+		last := words[len(words)-1]
+		as = append(as, last)
+	}
+
+	// Map key iteration order is not consistent
+	sort.Strings(expectedAsMap)
+	sort.Strings(as)
+
+	if !reflect.DeepEqual(expectedAsMap, as) {
+		t.Fatal()
+	}
+}
+
+func TestErrorCtxAsTupleUnmarshal(t *testing.T) {
+	bts := marshalErrorCtx(fillErrorCtxAsTuple())
+	cnt := countStrings(bts)
+
+	var as []string
+	for i := 0; i < cnt; i++ {
+		dodgeBts := dodgifyMsgpString(bts, i)
+
+		var ec ErrorCtxAsTuple
+		_, err := (&ec).UnmarshalMsg(dodgeBts)
+		words := strings.Split(err.Error(), " ")
+		last := words[len(words)-1]
+		as = append(as, last)
+	}
+
+	// Map key iteration order is not consistent
+	sort.Strings(expectedAsTuple)
+	sort.Strings(as)
+
+	if !reflect.DeepEqual(expectedAsTuple, as) {
+		t.Fatal()
+	}
+}
+
+func TestErrorCtxAsTupleDecode(t *testing.T) {
+	bts := marshalErrorCtx(fillErrorCtxAsTuple())
+	cnt := countStrings(bts)
+
+	var as []string
+	for i := 0; i < cnt; i++ {
+		dodgeBts := dodgifyMsgpString(bts, i)
+
+		r := msgp.NewReader(bytes.NewReader(dodgeBts))
+		var ec ErrorCtxAsTuple
+		err := (&ec).DecodeMsg(r)
+		words := strings.Split(err.Error(), " ")
+		last := words[len(words)-1]
+		as = append(as, last)
+	}
+
+	// Map key iteration order is not consistent
+	sort.Strings(expectedAsTuple)
+	sort.Strings(as)
+
+	if !reflect.DeepEqual(expectedAsTuple, as) {
+		t.Fatal()
+	}
+}
+
+var expectedAsTuple = []string{
+	"ErrorCtxAsTuple/Val",
+	"ErrorCtxAsTuple/Child/Val",
+	"ErrorCtxAsTuple/Children/0/Val",
+	"ErrorCtxAsTuple/Children/1/Val",
+	"ErrorCtxAsTuple/Map",
+	"ErrorCtxAsTuple/Map/baz",
+	"ErrorCtxAsTuple/Map",
+	"ErrorCtxAsTuple/Map/foo",
+	"ErrorCtxAsTuple/Nest",
+	"ErrorCtxAsTuple/Nest/Val",
+	"ErrorCtxAsTuple/Nest",
+	"ErrorCtxAsTuple/Nest/Child/Val",
+	"ErrorCtxAsTuple/Nest",
+	"ErrorCtxAsTuple/Nest/Children/0/Val",
+	"ErrorCtxAsTuple/Nest/Children/1/Val",
+	"ErrorCtxAsTuple/Nest",
+	"ErrorCtxAsTuple/Nest/Map",
+	"ErrorCtxAsTuple/Nest/Map/foo",
+	"ErrorCtxAsTuple/Nest/Map",
+	"ErrorCtxAsTuple/Nest/Map/baz",
+	"ErrorCtxAsTuple/Nest",
+	"ErrorCtxAsTuple/Nest/Nest",
+	"ErrorCtxAsTuple/Nest/Nest/Val",
+	"ErrorCtxAsTuple/Nest/Nest",
+	"ErrorCtxAsTuple/Nest/Nest/Child/Val",
+	"ErrorCtxAsTuple/Nest/Nest",
+	"ErrorCtxAsTuple/Nest/Nest/Children/0/Val",
+	"ErrorCtxAsTuple/Nest/Nest/Children/1/Val",
+	"ErrorCtxAsTuple/Nest/Nest",
+	"ErrorCtxAsTuple/Nest/Nest/Map",
+	"ErrorCtxAsTuple/Nest/Nest/Map/foo",
+	"ErrorCtxAsTuple/Nest/Nest/Map",
+	"ErrorCtxAsTuple/Nest/Nest/Map/baz",
+}
+
+// there are a lot of extra errors in here at the struct level because we are
+// not discriminating between dodgy struct field map key strings and
+// values. dodgy struct field map keys have no field context available when
+// they are read.
+var expectedAsMap = []string{
+	"ErrorCtxAsMap",
+	"ErrorCtxAsMap/Val",
+	"ErrorCtxAsMap",
+	"ErrorCtxAsMap/Child",
+	"ErrorCtxAsMap/Child/Val",
+	"ErrorCtxAsMap",
+	"ErrorCtxAsMap/Children/0",
+	"ErrorCtxAsMap/Children/0/Val",
+	"ErrorCtxAsMap/Children/1",
+	"ErrorCtxAsMap/Children/1/Val",
+	"ErrorCtxAsMap",
+	"ErrorCtxAsMap/Map",
+	"ErrorCtxAsMap/Map/foo",
+	"ErrorCtxAsMap/Map",
+	"ErrorCtxAsMap/Map/baz",
+	"ErrorCtxAsMap",
+	"ErrorCtxAsMap/Nest",
+	"ErrorCtxAsMap/Nest/Val",
+	"ErrorCtxAsMap/Nest",
+	"ErrorCtxAsMap/Nest/Child",
+	"ErrorCtxAsMap/Nest/Child/Val",
+	"ErrorCtxAsMap/Nest",
+	"ErrorCtxAsMap/Nest/Children/0",
+	"ErrorCtxAsMap/Nest/Children/0/Val",
+	"ErrorCtxAsMap/Nest/Children/1",
+	"ErrorCtxAsMap/Nest/Children/1/Val",
+	"ErrorCtxAsMap/Nest",
+	"ErrorCtxAsMap/Nest/Map",
+	"ErrorCtxAsMap/Nest/Map/foo",
+	"ErrorCtxAsMap/Nest/Map",
+	"ErrorCtxAsMap/Nest/Map/baz",
+	"ErrorCtxAsMap/Nest",
+	"ErrorCtxAsMap/Nest/Nest",
+	"ErrorCtxAsMap/Nest/Nest/Val",
+	"ErrorCtxAsMap/Nest/Nest",
+	"ErrorCtxAsMap/Nest/Nest/Child",
+	"ErrorCtxAsMap/Nest/Nest/Child/Val",
+	"ErrorCtxAsMap/Nest/Nest",
+	"ErrorCtxAsMap/Nest/Nest/Children/0",
+	"ErrorCtxAsMap/Nest/Nest/Children/0/Val",
+	"ErrorCtxAsMap/Nest/Nest/Children/1",
+	"ErrorCtxAsMap/Nest/Nest/Children/1/Val",
+	"ErrorCtxAsMap/Nest/Nest",
+	"ErrorCtxAsMap/Nest/Nest/Map",
+	"ErrorCtxAsMap/Nest/Nest/Map/baz",
+	"ErrorCtxAsMap/Nest/Nest/Map",
+	"ErrorCtxAsMap/Nest/Nest/Map/foo",
+}

--- a/gen/decode.go
+++ b/gen/decode.go
@@ -44,7 +44,6 @@ func (d *decodeGen) Execute(p Elem) error {
 	}
 
 	d.ctx = &Context{}
-	d.ctx.PushString(p.TypeName())
 
 	d.p.comment("DecodeMsg implements msgp.Decodable")
 

--- a/gen/decode.go
+++ b/gen/decode.go
@@ -16,6 +16,7 @@ type decodeGen struct {
 	passes
 	p        printer
 	hasfield bool
+	ctx      *Context
 }
 
 func (d *decodeGen) Method() Method { return Decode }
@@ -41,6 +42,9 @@ func (d *decodeGen) Execute(p Elem) error {
 	if !IsPrintable(p) {
 		return nil
 	}
+
+	d.ctx = &Context{}
+	d.ctx.PushString(p.TypeName())
 
 	d.p.comment("DecodeMsg implements msgp.Decodable")
 
@@ -68,7 +72,7 @@ func (d *decodeGen) assignAndCheck(name string, typ string) {
 		return
 	}
 	d.p.printf("\n%s, err = dc.Read%s()", name, typ)
-	d.p.print(errcheck)
+	d.p.wrapErrCheck(d.ctx.ArgsStr())
 }
 
 func (d *decodeGen) structAsTuple(s *Struct) {
@@ -82,7 +86,9 @@ func (d *decodeGen) structAsTuple(s *Struct) {
 		if !d.p.ok() {
 			return
 		}
+		d.ctx.PushString(s.Fields[i].FieldName)
 		next(d, s.Fields[i].FieldElem)
+		d.ctx.Pop()
 	}
 }
 
@@ -96,14 +102,17 @@ func (d *decodeGen) structAsMap(s *Struct) {
 	d.assignAndCheck("field", mapKey)
 	d.p.print("\nswitch msgp.UnsafeString(field) {")
 	for i := range s.Fields {
+		d.ctx.PushString(s.Fields[i].FieldName)
 		d.p.printf("\ncase \"%s\":", s.Fields[i].FieldTag)
 		next(d, s.Fields[i].FieldElem)
+		d.ctx.Pop()
 		if !d.p.ok() {
 			return
 		}
 	}
 	d.p.print("\ndefault:\nerr = dc.Skip()")
-	d.p.print(errcheck)
+	d.p.wrapErrCheck(d.ctx.ArgsStr())
+
 	d.p.closeblock() // close switch
 	d.p.closeblock() // close for loop
 }
@@ -143,7 +152,7 @@ func (d *decodeGen) gBase(b *BaseElem) {
 			d.p.printf("\n%s, err = dc.Read%s()", vname, bname)
 		}
 	}
-	d.p.print(errcheck)
+	d.p.wrapErrCheck(d.ctx.ArgsStr())
 
 	// close block for 'tmp'
 	if b.Convert {
@@ -151,7 +160,7 @@ func (d *decodeGen) gBase(b *BaseElem) {
 			d.p.printf("\n%s = %s(%s)\n}", vname, b.FromBase(), tmp)
 		} else {
 			d.p.printf("\n%s, err = %s(%s)\n}", vname, b.FromBase(), tmp)
-			d.p.print(errcheck)
+			d.p.wrapErrCheck(d.ctx.ArgsStr())
 		}
 	}
 }
@@ -173,8 +182,10 @@ func (d *decodeGen) gMap(m *Map) {
 	d.p.declare(m.Keyidx, "string")
 	d.p.declare(m.Validx, m.Value.TypeName())
 	d.assignAndCheck(m.Keyidx, stringTyp)
+	d.ctx.PushVar(m.Keyidx)
 	next(d, m.Value)
 	d.p.mapAssign(m)
+	d.ctx.Pop()
 	d.p.closeblock()
 }
 
@@ -186,7 +197,7 @@ func (d *decodeGen) gSlice(s *Slice) {
 	d.p.declare(sz, u32)
 	d.assignAndCheck(sz, arrayHeader)
 	d.p.resizeSlice(sz, s)
-	d.p.rangeBlock(s.Index, s.Varname(), d, s.Els)
+	d.p.rangeBlock(d.ctx, s.Index, s.Varname(), d, s.Els)
 }
 
 func (d *decodeGen) gArray(a *Array) {
@@ -197,15 +208,14 @@ func (d *decodeGen) gArray(a *Array) {
 	// special case if we have [const]byte
 	if be, ok := a.Els.(*BaseElem); ok && (be.Value == Byte || be.Value == Uint8) {
 		d.p.printf("\nerr = dc.ReadExactBytes((%s)[:])", a.Varname())
-		d.p.print(errcheck)
+		d.p.wrapErrCheck(d.ctx.ArgsStr())
 		return
 	}
 	sz := randIdent()
 	d.p.declare(sz, u32)
 	d.assignAndCheck(sz, arrayHeader)
 	d.p.arrayCheck(coerceArraySize(a.Size), sz)
-
-	d.p.rangeBlock(a.Index, a.Varname(), d, a.Els)
+	d.p.rangeBlock(d.ctx, a.Index, a.Varname(), d, a.Els)
 }
 
 func (d *decodeGen) gPtr(p *Ptr) {
@@ -214,7 +224,7 @@ func (d *decodeGen) gPtr(p *Ptr) {
 	}
 	d.p.print("\nif dc.IsNil() {")
 	d.p.print("\nerr = dc.ReadNil()")
-	d.p.print(errcheck)
+	d.p.wrapErrCheck(d.ctx.ArgsStr())
 	d.p.printf("\n%s = nil\n} else {", p.Varname())
 	d.p.initPtr(p)
 	next(d, p.Value)

--- a/gen/encode.go
+++ b/gen/encode.go
@@ -59,7 +59,6 @@ func (e *encodeGen) Execute(p Elem) error {
 	}
 
 	e.ctx = &Context{}
-	e.ctx.PushString(p.TypeName())
 
 	e.p.comment("EncodeMsg implements msgp.Encodable")
 

--- a/gen/marshal.go
+++ b/gen/marshal.go
@@ -39,7 +39,6 @@ func (m *marshalGen) Execute(p Elem) error {
 	}
 
 	m.ctx = &Context{}
-	m.ctx.PushString(p.TypeName())
 
 	m.p.comment("MarshalMsg implements msgp.Marshaler")
 

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -42,7 +42,6 @@ func (u *unmarshalGen) Execute(p Elem) error {
 	}
 
 	u.ctx = &Context{}
-	u.ctx.PushString(p.TypeName())
 
 	u.p.comment("UnmarshalMsg implements msgp.Unmarshaler")
 

--- a/msgp/errors.go
+++ b/msgp/errors.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 )
 
+const resumableDefault = false
+
 var (
 	// ErrShortBytes is returned when the
 	// slice being decoded is too short to
@@ -26,8 +28,91 @@ type Error interface {
 	// Resumable returns whether
 	// or not the error means that
 	// the stream of data is malformed
-	// and  the information is unrecoverable.
+	// and the information is unrecoverable.
 	Resumable() bool
+}
+
+// contextError allows msgp Error instances to be enhanced with additional
+// context about their origin.
+type contextError interface {
+	Error
+
+	// withContext must not modify the error instance - it must clone and
+	// return a new error with the context added.
+	withContext(ctx string) error
+}
+
+// Cause returns the underlying cause of an error that has been wrapped
+// with additional context.
+func Cause(e error) error {
+	out := e
+	if e, ok := e.(errWrapped); ok && e.cause != nil {
+		out = e.cause
+	}
+	return out
+}
+
+// Resumable returns whether or not the error means that the stream of data is
+// malformed and the information is unrecoverable.
+func Resumable(e error) bool {
+	if e, ok := e.(Error); ok {
+		return e.Resumable()
+	}
+	return resumableDefault
+}
+
+// WrapError wraps an error with additional context that allows the part of the
+// serialized type that caused the problem to be identified. Underlying errors
+// can be retrieved using Cause()
+//
+// The input error is not modified - a new error should be returned.
+//
+// ErrShortBytes is not wrapped with any context due to backward compatibility
+// issues with the public API.
+//
+func WrapError(err error, ctx ...interface{}) error {
+	switch e := err.(type) {
+	case errShort:
+		return e
+	case contextError:
+		return e.withContext(ctxString(ctx))
+	default:
+		return errWrapped{cause: err, ctx: ctxString(ctx)}
+	}
+}
+
+// ctxString converts the incoming interface{} slice into a single string.
+func ctxString(ctx []interface{}) string {
+	out := ""
+	for idx, cv := range ctx {
+		if idx > 0 {
+			out += "/"
+		}
+		out += fmt.Sprintf("%v", cv)
+	}
+	return out
+}
+
+// errWrapped allows arbitrary errors passed to WrapError to be enhanced with
+// context and unwrapped with Cause()
+type errWrapped struct {
+	cause error
+	ctx   string
+}
+
+func (e errWrapped) Error() string {
+	if e.ctx != "" {
+		return fmt.Sprintf("%s at %s", e.cause, e.ctx)
+	} else {
+		return e.cause.Error()
+	}
+}
+
+func (e errWrapped) Resumable() bool {
+	if e, ok := e.cause.(Error); ok {
+		return e.Resumable()
+	}
+	return resumableDefault
 }
 
 type errShort struct{}
@@ -35,10 +120,21 @@ type errShort struct{}
 func (e errShort) Error() string   { return "msgp: too few bytes left to read object" }
 func (e errShort) Resumable() bool { return false }
 
-type errFatal struct{}
+type errFatal struct {
+	ctx string
+}
 
-func (f errFatal) Error() string   { return "msgp: fatal decoding error (unreachable code)" }
+func (f errFatal) Error() string {
+	out := "msgp: fatal decoding error (unreachable code)"
+	if f.ctx != "" {
+		out += " at " + f.ctx
+	}
+	return out
+}
+
 func (f errFatal) Resumable() bool { return false }
+
+func (f errFatal) withContext(ctx string) error { f.ctx = ctx; return f }
 
 // ArrayError is an error returned
 // when decoding a fix-sized array
@@ -46,15 +142,22 @@ func (f errFatal) Resumable() bool { return false }
 type ArrayError struct {
 	Wanted uint32
 	Got    uint32
+	ctx    string
 }
 
 // Error implements the error interface
 func (a ArrayError) Error() string {
-	return fmt.Sprintf("msgp: wanted array of size %d; got %d", a.Wanted, a.Got)
+	out := fmt.Sprintf("msgp: wanted array of size %d; got %d", a.Wanted, a.Got)
+	if a.ctx != "" {
+		out += " at " + a.ctx
+	}
+	return out
 }
 
 // Resumable is always 'true' for ArrayErrors
 func (a ArrayError) Resumable() bool { return true }
+
+func (a ArrayError) withContext(ctx string) error { a.ctx = ctx; return a }
 
 // IntOverflow is returned when a call
 // would downcast an integer to a type
@@ -62,6 +165,7 @@ func (a ArrayError) Resumable() bool { return true }
 type IntOverflow struct {
 	Value         int64 // the value of the integer
 	FailedBitsize int   // the bit size that the int64 could not fit into
+	ctx           string
 }
 
 // Error implements the error interface
@@ -72,12 +176,15 @@ func (i IntOverflow) Error() string {
 // Resumable is always 'true' for overflows
 func (i IntOverflow) Resumable() bool { return true }
 
+func (i IntOverflow) withContext(ctx string) error { i.ctx = ctx; return i }
+
 // UintOverflow is returned when a call
 // would downcast an unsigned integer to a type
 // with too few bits to hold its value
 type UintOverflow struct {
 	Value         uint64 // value of the uint
 	FailedBitsize int    // the bit size that couldn't fit the value
+	ctx           string
 }
 
 // Error implements the error interface
@@ -88,21 +195,31 @@ func (u UintOverflow) Error() string {
 // Resumable is always 'true' for overflows
 func (u UintOverflow) Resumable() bool { return true }
 
+func (u UintOverflow) withContext(ctx string) error { u.ctx = ctx; return u }
+
 // A TypeError is returned when a particular
 // decoding method is unsuitable for decoding
 // a particular MessagePack value.
 type TypeError struct {
 	Method  Type // Type expected by method
 	Encoded Type // Type actually encoded
+
+	ctx string
 }
 
 // Error implements the error interface
 func (t TypeError) Error() string {
-	return fmt.Sprintf("msgp: attempted to decode type %q with method for %q", t.Encoded, t.Method)
+	out := fmt.Sprintf("msgp: attempted to decode type %q with method for %q", t.Encoded, t.Method)
+	if t.ctx != "" {
+		out += " at " + t.ctx
+	}
+	return out
 }
 
 // Resumable returns 'true' for TypeErrors
 func (t TypeError) Resumable() bool { return true }
+
+func (t TypeError) withContext(ctx string) error { t.ctx = ctx; return t }
 
 // returns either InvalidPrefixError or
 // TypeError depending on whether or not
@@ -133,10 +250,24 @@ func (i InvalidPrefixError) Resumable() bool { return false }
 // to a function that takes `interface{}`.
 type ErrUnsupportedType struct {
 	T reflect.Type
+
+	ctx string
 }
 
 // Error implements error
-func (e *ErrUnsupportedType) Error() string { return fmt.Sprintf("msgp: type %q not supported", e.T) }
+func (e *ErrUnsupportedType) Error() string {
+	out := fmt.Sprintf("msgp: type %q not supported", e.T)
+	if e.ctx != "" {
+		out += " at " + e.ctx
+	}
+	return out
+}
 
 // Resumable returns 'true' for ErrUnsupportedType
 func (e *ErrUnsupportedType) Resumable() bool { return true }
+
+func (e *ErrUnsupportedType) withContext(ctx string) error {
+	o := *e
+	o.ctx = ctx
+	return &o
+}

--- a/msgp/errors.go
+++ b/msgp/errors.go
@@ -93,6 +93,14 @@ func ctxString(ctx []interface{}) string {
 	return out
 }
 
+func addCtx(ctx, add string) string {
+	if ctx != "" {
+		return add + "/" + ctx
+	} else {
+		return add
+	}
+}
+
 // errWrapped allows arbitrary errors passed to WrapError to be enhanced with
 // context and unwrapped with Cause()
 type errWrapped struct {
@@ -134,7 +142,7 @@ func (f errFatal) Error() string {
 
 func (f errFatal) Resumable() bool { return false }
 
-func (f errFatal) withContext(ctx string) error { f.ctx = ctx; return f }
+func (f errFatal) withContext(ctx string) error { f.ctx = addCtx(f.ctx, ctx); return f }
 
 // ArrayError is an error returned
 // when decoding a fix-sized array
@@ -157,7 +165,7 @@ func (a ArrayError) Error() string {
 // Resumable is always 'true' for ArrayErrors
 func (a ArrayError) Resumable() bool { return true }
 
-func (a ArrayError) withContext(ctx string) error { a.ctx = ctx; return a }
+func (a ArrayError) withContext(ctx string) error { a.ctx = addCtx(a.ctx, ctx); return a }
 
 // IntOverflow is returned when a call
 // would downcast an integer to a type
@@ -176,7 +184,7 @@ func (i IntOverflow) Error() string {
 // Resumable is always 'true' for overflows
 func (i IntOverflow) Resumable() bool { return true }
 
-func (i IntOverflow) withContext(ctx string) error { i.ctx = ctx; return i }
+func (i IntOverflow) withContext(ctx string) error { i.ctx = addCtx(i.ctx, ctx); return i }
 
 // UintOverflow is returned when a call
 // would downcast an unsigned integer to a type
@@ -195,7 +203,7 @@ func (u UintOverflow) Error() string {
 // Resumable is always 'true' for overflows
 func (u UintOverflow) Resumable() bool { return true }
 
-func (u UintOverflow) withContext(ctx string) error { u.ctx = ctx; return u }
+func (u UintOverflow) withContext(ctx string) error { u.ctx = addCtx(u.ctx, ctx); return u }
 
 // A TypeError is returned when a particular
 // decoding method is unsuitable for decoding
@@ -219,7 +227,7 @@ func (t TypeError) Error() string {
 // Resumable returns 'true' for TypeErrors
 func (t TypeError) Resumable() bool { return true }
 
-func (t TypeError) withContext(ctx string) error { t.ctx = ctx; return t }
+func (t TypeError) withContext(ctx string) error { t.ctx = addCtx(t.ctx, ctx); return t }
 
 // returns either InvalidPrefixError or
 // TypeError depending on whether or not
@@ -268,6 +276,6 @@ func (e *ErrUnsupportedType) Resumable() bool { return true }
 
 func (e *ErrUnsupportedType) withContext(ctx string) error {
 	o := *e
-	o.ctx = ctx
+	o.ctx = addCtx(o.ctx, ctx)
 	return &o
 }

--- a/msgp/errors_test.go
+++ b/msgp/errors_test.go
@@ -1,0 +1,80 @@
+package msgp
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestWrapVanillaErrorWithNoAdditionalContext(t *testing.T) {
+	err := errors.New("test")
+	w := WrapError(err)
+	if w == err {
+		t.Fatal()
+	}
+	if w.Error() != err.Error() {
+		t.Fatal()
+	}
+	if w.(errWrapped).Resumable() {
+		t.Fatal()
+	}
+}
+
+func TestWrapVanillaErrorWithAdditionalContext(t *testing.T) {
+	err := errors.New("test")
+	w := WrapError(err, "foo", "bar")
+	if w == err {
+		t.Fatal()
+	}
+	if w.Error() == err.Error() {
+		t.Fatal()
+	}
+	if w.(Error).Resumable() {
+		t.Fatal()
+	}
+	if !strings.HasPrefix(w.Error(), err.Error()) {
+		t.Fatal()
+	}
+	rest := w.Error()[len(err.Error()):]
+	if rest != " at foo/bar" {
+		t.Fatal()
+	}
+}
+
+func TestWrapResumableError(t *testing.T) {
+	err := ArrayError{}
+	w := WrapError(err)
+	if !w.(Error).Resumable() {
+		t.Fatal()
+	}
+}
+
+func TestCause(t *testing.T) {
+	for idx, err := range []error{
+		errors.New("test"),
+		ArrayError{},
+		&ErrUnsupportedType{},
+	} {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			cerr := WrapError(err, "test")
+			if cerr == err {
+				t.Fatal()
+			}
+			if Cause(err) != err {
+				t.Fatal()
+			}
+		})
+	}
+}
+
+func TestCauseShortByte(t *testing.T) {
+	err := ErrShortBytes
+	cerr := WrapError(err, "test")
+	if cerr != err {
+		t.Fatal()
+	}
+	if Cause(err) != err {
+		t.Fatal()
+	}
+}

--- a/msgp/errors_test.go
+++ b/msgp/errors_test.go
@@ -50,6 +50,15 @@ func TestWrapResumableError(t *testing.T) {
 	}
 }
 
+func TestWrapMultiple(t *testing.T) {
+	err := &TypeError{}
+	w := WrapError(WrapError(err, "b"), "a")
+	expected := `msgp: attempted to decode type "<invalid>" with method for "<invalid>" at a/b`
+	if expected != w.Error() {
+		t.Fatal()
+	}
+}
+
 func TestCause(t *testing.T) {
 	for idx, err := range []error{
 		errors.New("test"),

--- a/msgp/write.go
+++ b/msgp/write.go
@@ -685,7 +685,7 @@ func (mw *Writer) WriteIntf(v interface{}) error {
 	case reflect.Map:
 		return mw.writeMap(val)
 	}
-	return &ErrUnsupportedType{val.Type()}
+	return &ErrUnsupportedType{T: val.Type()}
 }
 
 func (mw *Writer) writeMap(v reflect.Value) (err error) {


### PR DESCRIPTION
We have a lot of trouble debugging our server when client applications fail to encode fields correctly. I have prepared a patch that adds information about the problematic field to the error output. Benchmarks don't seem to be adversely affected. It looks like a big patch but it's mostly tests and additions to the error types.

I think I have managed to do it without breaking backward compatibility with the error types. The only compromise I can see is that ErrShortBytes can not include context information without introducing such a break.

I haven't quite worked out how best to test writer failures yet during Marshal or Encode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/205)
<!-- Reviewable:end -->
