### PR TITLE
WIP: Add omitempty annotation support

### DIFF
--- a/_generated/def.go
+++ b/_generated/def.go
@@ -61,6 +61,34 @@ type TestType struct {
 	SlicePtr   *[]string
 }
 
+type TestOmit struct {
+	F   *float64          `msg:"float,omitempty"`
+	Els map[string]string `msg:"elements,omitempty"`
+	Obj struct {          // test anonymous struct
+		ValueA string `msg:"value_a,omitempty"`
+		ValueB []byte `msg:"value_b,omitempty"`
+	} `msg:"object,omitempty"`
+	Child      *TestOmit   `msg:"child,omitempty"`
+	Time       time.Time   `msg:"time,omitempty"`
+	Any        interface{} `msg:"any,omitempty"`
+	Appended   msgp.Raw    `msg:"appended,omitempty"`
+	Num        msgp.Number `msg:"num,omitempty"`
+	Byte       byte        `msg:"byte,omitempty"`
+	Rune       rune        `msg:"rune,omitempty"`
+	RunePtr    *rune       `msg:"rune_ptr,omitempty"`
+	RunePtrPtr **rune      `msg:"rune_ptr_ptr,omitempty"`
+	RuneSlice  []rune      `msg:"rune_slece,omitempty"`
+	Slice1     []string    `msg:"slice1,omitempty"`
+	Slice2     []string    `msg:"slice2,omitempty"`
+	SlicePtr   *[]string   `msg:"slice_ptr,omitempty"`
+}
+
+type TestPart struct {
+	Time   time.Time `msg:"time"`
+	Byte   byte      `msg:"byte"`
+	Slice1 []string  `msg:"slice1"`
+}
+
 //msgp:tuple Object
 type Object struct {
 	ObjectNo string   `msg:"objno"`
@@ -120,6 +148,15 @@ type Things struct {
 	Arr2  [4]float64                        `msg:"arr2"`           // test basic lit array
 	Ext   *msgp.RawExtension                `msg:"ext,extension"`  // test extension
 	Oext  msgp.RawExtension                 `msg:"oext,extension"` // test extension reference
+}
+
+type ThingsOmit struct {
+	Cmplx complex64                         `msg:"complex,omitempty"` // test slices
+	Vals  []int32                           `msg:"values,omitempty"`
+	Arr   [msgp.ExtensionPrefixSize]float64 `msg:"arr,omitempty"`            // test const array and *ast.SelectorExpr as array size
+	Arr2  [4]float64                        `msg:"arr2,omitempty"`           // test basic lit array
+	Ext   *msgp.RawExtension                `msg:"ext,extension,omitempty"`  // test extension
+	Oext  msgp.RawExtension                 `msg:"oext,extension,omitempty"` // test extension reference
 }
 
 //msgp:shim SpecialID as:[]byte using:toBytes/fromBytes
@@ -195,6 +232,13 @@ type Custom struct {
 	Mp    map[string]*Embedded `msg:"mp"`
 	Enums []MyEnum             `msg:"enums"` // test explicit enum shim
 	Some  FileHandle           `msg:file_handle`
+}
+
+type CustomOmit struct {
+	Bts   CustomBytes          `msg:"bts,omitempty"`
+	Mp    map[string]*Embedded `msg:"mp,omitempty"`
+	Enums []MyEnum             `msg:"enums,omitempty"` // test explicit enum shim
+	Some  FileHandle           `msg:file_handle,omitempty`
 }
 
 type Files []*os.File

--- a/_generated/def_test.go
+++ b/_generated/def_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/tinylib/msgp/msgp"
+	"time"
 )
 
 func TestRuneEncodeDecode(t *testing.T) {
@@ -58,6 +59,173 @@ func TestRuneMarshalUnmarshal(t *testing.T) {
 	}
 
 	var out TestType
+	if _, err := (&out).UnmarshalMsg(bts); err != nil {
+		t.Errorf("%v", err)
+	}
+	if r != out.Rune {
+		t.Errorf("rune mismatch: expected %c found %c", r, out.Rune)
+	}
+	if r != *out.RunePtr {
+		t.Errorf("rune ptr mismatch: expected %c found %c", r, *out.RunePtr)
+	}
+	if r != **out.RunePtrPtr {
+		t.Errorf("rune ptr ptr mismatch: expected %c found %c", r, **out.RunePtrPtr)
+	}
+	if !reflect.DeepEqual(tt.RuneSlice, out.RuneSlice) {
+		t.Errorf("rune slice mismatch")
+	}
+}
+
+func TestOmitEncodeEmpty(t *testing.T) {
+	tt := &TestOmit{}
+
+	var buf bytes.Buffer
+	wrt := msgp.NewWriter(&buf)
+	if err := tt.EncodeMsg(wrt); err != nil {
+		t.Errorf("%v", err)
+	}
+	wrt.Flush()
+
+	bts := buf.Bytes()
+	// Expected empty map
+	if len(bts) != 1 || bts[0] != 0x80 {
+		t.Errorf("data mismatch: expected empty map object, found %v", bts)
+	}
+}
+
+func TestOmitEncodePart(t *testing.T) {
+	now := time.Now()
+	tt := &TestOmit{
+		Time: now,
+		Byte: 42,
+		Slice1: []string{
+			"foo", "bar",
+		},
+	}
+	tp := &TestPart{
+		Time: now,
+		Byte: 42,
+		Slice1: []string{
+			"foo", "bar",
+		},
+	}
+
+	var buf bytes.Buffer
+	wrt := msgp.NewWriter(&buf)
+	if err := tt.EncodeMsg(wrt); err != nil {
+		t.Errorf("%v", err)
+	}
+	wrt.Flush()
+
+	exp, err := tp.MarshalMsg(nil)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	bts := buf.Bytes()
+	// Expected same binary data
+	if !bytes.Equal(exp, bts) {
+		t.Errorf("data mismatch: expected %v, found %v", exp, bts)
+	}
+}
+
+func TestOmitEncodeDecode(t *testing.T) {
+	tt := &TestOmit{}
+	r := 'r'
+	rp := &r
+	tt.Rune = r
+	tt.RunePtr = &r
+	tt.RunePtrPtr = &rp
+	tt.RuneSlice = []rune{'a', 'b', '😳'}
+
+	var buf bytes.Buffer
+	wrt := msgp.NewWriter(&buf)
+	if err := tt.EncodeMsg(wrt); err != nil {
+		t.Errorf("%v", err)
+	}
+	wrt.Flush()
+
+	var out TestOmit
+	rdr := msgp.NewReader(&buf)
+	if err := (&out).DecodeMsg(rdr); err != nil {
+		t.Errorf("%v", err)
+	}
+	if r != out.Rune {
+		t.Errorf("rune mismatch: expected %c found %c", r, out.Rune)
+	}
+	if r != *out.RunePtr {
+		t.Errorf("rune ptr mismatch: expected %c found %c", r, *out.RunePtr)
+	}
+	if r != **out.RunePtrPtr {
+		t.Errorf("rune ptr ptr mismatch: expected %c found %c", r, **out.RunePtrPtr)
+	}
+	if !reflect.DeepEqual(tt.RuneSlice, out.RuneSlice) {
+		t.Errorf("rune slice mismatch")
+	}
+}
+
+func TestOmitMarshalEmpty(t *testing.T) {
+	tt := &TestOmit{}
+
+	bts, err := tt.MarshalMsg(nil)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	// Expected empty map
+	if len(bts) != 1 || bts[0] != 0x80 {
+		t.Errorf("data mismatch: expected empty map object, found %v", bts)
+	}
+}
+
+func TestOmitMarshalPart(t *testing.T) {
+	now := time.Now()
+	tt := &TestOmit{
+		Time: now,
+		Byte: 42,
+		Slice1: []string{
+			"foo", "bar",
+		},
+	}
+	tp := &TestPart{
+		Time: now,
+		Byte: 42,
+		Slice1: []string{
+			"foo", "bar",
+		},
+	}
+
+	bts, err := tt.MarshalMsg(nil)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	exp, err := tp.MarshalMsg(nil)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	// Expected same bi
+	if !bytes.Equal(exp, bts) {
+		t.Errorf("data mismatch: expected %v, found %v", exp, bts)
+	}
+}
+
+func TestOmitMarshalUnmarshal(t *testing.T) {
+	tt := &TestOmit{}
+	r := 'r'
+	rp := &r
+	tt.Rune = r
+	tt.RunePtr = &r
+	tt.RunePtrPtr = &rp
+	tt.RuneSlice = []rune{'a', 'b', '😳'}
+
+	bts, err := tt.MarshalMsg(nil)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	var out TestOmit
 	if _, err := (&out).UnmarshalMsg(bts); err != nil {
 		t.Errorf("%v", err)
 	}

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -133,7 +133,10 @@ var builtins = map[string]struct{}{
 }
 
 // common data/methods for every Elem
-type common struct{ vname, alias string }
+type common struct {
+	vname, alias string
+	omitEmpty    bool
+}
 
 func (c *common) SetVarname(s string) { c.vname = s }
 func (c *common) Varname() string     { return c.vname }
@@ -408,6 +411,7 @@ type StructField struct {
 	RawTag    string // the full struct tag
 	FieldName string // the name of the struct field
 	FieldElem Elem   // the field type
+	OmitEmpty bool   // don't serialize empty field
 }
 
 type ShimMode int

--- a/gen/omitempty.go
+++ b/gen/omitempty.go
@@ -1,0 +1,126 @@
+package gen
+
+import (
+	"fmt"
+	"io"
+)
+
+func omitempies(w io.Writer) *omitemptyGen {
+	return &omitemptyGen{
+		p: printer{w: w},
+	}
+}
+
+type omitemptyGen struct {
+	passes
+	p    printer
+	expr string
+}
+
+func (s *omitemptyGen) Method() Method { return Size }
+
+func (s *omitemptyGen) Apply(dirs []string) error {
+	return nil
+}
+
+func (s *omitemptyGen) Execute(p Elem) error {
+	if !s.p.ok() {
+		return s.p.err
+	}
+	p = s.applyall(p)
+	if p == nil {
+		return nil
+	}
+	if !IsPrintable(p) {
+		return nil
+	}
+
+	s.p.comment("ShouldOmitAsEmpty returns true if all struct fields have default value")
+
+	s.p.printf("\nfunc (%s %s) ShouldOmitAsEmpty() (bool) {", p.Varname(), imutMethodReceiver(p))
+	next(s, p)
+	if s.expr != "" {
+		s.p.printf("\nreturn %s", s.expr)
+	} else {
+		s.p.printf("\nreturn true")
+	}
+	s.p.closeblock()
+	return s.p.err
+}
+
+func (s *omitemptyGen) gStruct(st *Struct) {
+	// Always serialize if at least one fields always serialized.
+	empty := omitemptyGen{}
+	for i := range st.Fields {
+		empty.expr = ""
+		next(&empty, st.Fields[i].FieldElem)
+		if empty.expr == "" {
+			s.expr = ""
+			return
+		}
+	}
+
+	// Check it object empty code.
+	vname := ""
+	for i := range st.Fields {
+		s.expr = ""
+		next(s, st.Fields[i].FieldElem)
+		if s.expr != "true" {
+			if vname == "" {
+				vname = randIdent()
+				if s.p.w != nil {
+					s.p.printf("\n%s := %s", vname, s.expr)
+				}
+			} else if s.p.w != nil {
+				s.p.printf("\n%s = %s && %s", vname, vname, s.expr)
+			}
+		}
+	}
+	if vname == "" {
+		vname = "true"
+	}
+	s.expr = vname
+}
+
+func (s *omitemptyGen) gPtr(p *Ptr) {
+	s.expr = fmt.Sprintf("(%s == nil)", p.Varname())
+}
+
+func (s *omitemptyGen) gSlice(sl *Slice) {
+	s.expr = fmt.Sprintf("(len(%s) == 0)", sl.Varname())
+}
+
+func (s *omitemptyGen) gArray(a *Array) {
+	s.expr = ""
+}
+
+func (s *omitemptyGen) gMap(m *Map) {
+	s.expr = fmt.Sprintf("((%s == nil) || (len(%s) == 0))", m.Varname(), m.Varname())
+}
+
+func (s *omitemptyGen) gBase(b *BaseElem) {
+	vname := b.Varname()
+	var verr string
+	if b.Convert {
+		if b.ShimMode == Cast {
+			vname = tobaseConvert(b)
+		} else {
+			vname = randIdent()
+			verr = randIdent()
+			if s.p.w != nil {
+				s.p.printf("\nvar %s %s", vname, b.BaseType())
+				s.p.printf("\nvar %s error", verr)
+				s.p.printf("\n%s, %s = %s", vname, verr, tobaseConvert(b))
+			}
+		}
+	}
+
+	if b.Value == IDENT { // unknown identity
+		s.expr = fmt.Sprintf("%s.ShouldOmitAsEmpty()", vname)
+	} else { // typical case
+		s.expr = fmt.Sprintf("msgp.ShouldOmitAsEmpty%s(%s)", b.BaseName(), vname)
+	}
+	if verr != "" {
+		s.expr = fmt.Sprintf("((%s == nil) && %s)", verr, s.expr)
+	}
+}

--- a/gen/omitempty.go
+++ b/gen/omitempty.go
@@ -36,14 +36,8 @@ func (s *omitemptyGen) Execute(p Elem) error {
 	}
 
 	s.p.comment("ShouldOmitAsEmpty returns true if all struct fields have default value")
-
 	s.p.printf("\nfunc (%s %s) ShouldOmitAsEmpty() (bool) {", p.Varname(), imutMethodReceiver(p))
-	next(s, p)
-	if s.expr != "" {
-		s.p.printf("\nreturn %s", s.expr)
-	} else {
-		s.p.printf("\nreturn true")
-	}
+	s.p.printf("\nreturn false")
 	s.p.closeblock()
 	return s.p.err
 }

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -82,15 +82,16 @@ func strtoMeth(s string) Method {
 }
 
 const (
-	Decode      Method                       = 1 << iota // msgp.Decodable
-	Encode                                               // msgp.Encodable
-	Marshal                                              // msgp.Marshaler
-	Unmarshal                                            // msgp.Unmarshaler
-	Size                                                 // msgp.Sizer
-	Test                                                 // generate tests
-	invalidmeth                                          // this isn't a method
-	encodetest  = Encode | Decode | Test                 // tests for Encodable and Decodable
-	marshaltest = Marshal | Unmarshal | Test             // tests for Marshaler and Unmarshaler
+	Decode    Method = 1 << iota // msgp.Decodable
+	Encode                       // msgp.Encodable
+	Marshal                      // msgp.Marshaler
+	Unmarshal                    // msgp.Unmarshaler
+	Size                         // msgp.Sizer
+	OmitEmpty
+	Test                                     // generate tests
+	invalidmeth                              // this isn't a method
+	encodetest  = Encode | Decode | Test     // tests for Encodable and Decodable
+	marshaltest = Marshal | Unmarshal | Test // tests for Marshaler and Unmarshaler
 )
 
 type Printer struct {
@@ -116,6 +117,9 @@ func NewPrinter(m Method, out io.Writer, tests io.Writer) *Printer {
 	}
 	if m.isset(Size) {
 		gens = append(gens, sizes(out))
+	}
+	if m.isset(OmitEmpty) {
+		gens = append(gens, omitempies(out))
 	}
 	if m.isset(marshaltest) {
 		gens = append(gens, mtest(tests))

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -82,16 +82,16 @@ func strtoMeth(s string) Method {
 }
 
 const (
-	Decode    Method = 1 << iota // msgp.Decodable
-	Encode                       // msgp.Encodable
-	Marshal                      // msgp.Marshaler
-	Unmarshal                    // msgp.Unmarshaler
-	Size                         // msgp.Sizer
-	OmitEmpty
-	Test                                     // generate tests
-	invalidmeth                              // this isn't a method
-	encodetest  = Encode | Decode | Test     // tests for Encodable and Decodable
-	marshaltest = Marshal | Unmarshal | Test // tests for Marshaler and Unmarshaler
+	Decode      Method                       = 1 << iota // msgp.Decodable
+	Encode                                               // msgp.Encodable
+	Marshal                                              // msgp.Marshaler
+	Unmarshal                                            // msgp.Unmarshaler
+	Size                                                 // msgp.Sizer
+	OmitEmpty                                            // msgp.OmitEmptyAware
+	Test                                                 // generate tests
+	invalidmeth                                          // this isn't a method
+	encodetest  = Encode | Decode | Test                 // tests for Encodable and Decodable
+	marshaltest = Marshal | Unmarshal | Test             // tests for Marshaler and Unmarshaler
 )
 
 type Printer struct {

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ var (
 	file       = flag.String("file", "", "input file")
 	encode     = flag.Bool("io", true, "create Encode and Decode methods")
 	marshal    = flag.Bool("marshal", true, "create Marshal and Unmarshal methods")
+	omitempty  = flag.Bool("omitempty", true, "create ShouldOmitAsEmpty methods")
 	tests      = flag.Bool("tests", true, "create tests and benchmarks")
 	unexported = flag.Bool("unexported", false, "also process unexported types")
 )
@@ -62,6 +63,9 @@ func main() {
 	}
 	if *marshal {
 		mode |= (gen.Marshal | gen.Unmarshal | gen.Size)
+	}
+	if *omitempty {
+		mode |= (gen.OmitEmpty)
 	}
 	if *tests {
 		mode |= gen.Test

--- a/msgp/number.go
+++ b/msgp/number.go
@@ -27,6 +27,10 @@ type Number struct {
 	typ  Type
 }
 
+func (n *Number) ShouldOmitAsEmpty() bool {
+	return n.bits == 0
+}
+
 // AsInt sets the number to an int64.
 func (n *Number) AsInt(i int64) {
 

--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -55,6 +55,10 @@ func IsNil(b []byte) bool {
 // data without interpreting its contents.
 type Raw []byte
 
+func (r Raw) ShouldOmitAsEmpty() bool {
+	return len(r) == 0
+}
+
 // MarshalMsg implements msgp.Marshaler.
 // It appends the raw contents of 'raw'
 // to the provided byte slice. If 'raw'

--- a/msgp/shouldomit.go
+++ b/msgp/shouldomit.go
@@ -2,6 +2,12 @@ package msgp
 
 import "time"
 
+// Implement this interface to enable struct type to be omitted by `omitempty`.
+type OmitEmptyAware interface {
+	// This method should return true if the object should not be serialized with `omitempty` marker.
+	ShouldOmitAsEmpty() bool
+}
+
 func ShouldOmitAsEmptyBytes(v []byte) bool {
 	return len(v) == 0
 }

--- a/msgp/shouldomit.go
+++ b/msgp/shouldomit.go
@@ -1,0 +1,67 @@
+package msgp
+
+import "time"
+
+func ShouldOmitAsEmptyBytes(v []byte) bool {
+	return len(v) == 0
+}
+func ShouldOmitAsEmptyString(v string) bool {
+	return v == ""
+}
+func ShouldOmitAsEmptyFloat32(v float32) bool {
+	return v == 0
+}
+func ShouldOmitAsEmptyFloat64(v float64) bool {
+	return v == 0
+}
+func ShouldOmitAsEmptyComplex64(v complex64) bool {
+	return v == 0
+}
+func ShouldOmitAsEmptyComplex128(v complex128) bool {
+	return v == 0
+}
+func ShouldOmitAsEmptyIntf(v interface{}) bool {
+	return v == nil
+}
+func ShouldOmitAsEmptyUint(v uint) bool {
+	return v == 0
+}
+func ShouldOmitAsEmptyUint8(v uint8) bool {
+	return v == 0
+}
+func ShouldOmitAsEmptyUint16(v uint16) bool {
+	return v == 0
+}
+func ShouldOmitAsEmptyUint32(v uint32) bool {
+	return v == 0
+}
+func ShouldOmitAsEmptyUint64(v uint64) bool {
+	return v == 0
+}
+func ShouldOmitAsEmptyByte(v byte) bool {
+	return v == 0
+}
+func ShouldOmitAsEmptyInt(v int) bool {
+	return v == 0
+}
+func ShouldOmitAsEmptyInt8(v int8) bool {
+	return v == 0
+}
+func ShouldOmitAsEmptyInt16(v int16) bool {
+	return v == 0
+}
+func ShouldOmitAsEmptyInt32(v int32) bool {
+	return v == 0
+}
+func ShouldOmitAsEmptyInt64(v int64) bool {
+	return v == 0
+}
+func ShouldOmitAsEmptyBool(v bool) bool {
+	return v == false
+}
+func ShouldOmitAsEmptyTime(v time.Time) bool {
+	return v.IsZero()
+}
+func ShouldOmitAsEmptyExtension(v *RawExtension) bool {
+	return v == nil
+}


### PR DESCRIPTION
**This PR is incomplete becuase it don't contains new tests and most likely contains contentious issues. 
I will be glad to receive feedback to make this changes production-ready.**

Reason: add ability to skip empty fields on serialization (like default `json`/`xml` marshaling) for reduce serialized object size and deserialization time.

Changes summary:

 * add "omitempty" option specifies: the field should be omitted from the encoding if the field has an empty value;
 * add autogenerated method `ShouldOmitAsEmpty() bool` for structures;
 * add methods `msgp.ShouldOmitAsEmpty<base type>(v) bool` for primitive types;
 * add flag `-omitempty` for `msgp` generator (default: `true`).

Field omit rules (only for marked fields):

 * struct - if method `ShouldOmitAsEmpty()` returns `true` (generated method return `true` if all serializable fields can be ommited);
 * pointer - on `nil` value;
 * fixed size array - newer;
 * slice - on empty size;
 * map - on `nil` or empty.

Incompatible changes:

 * Generated `EncodeMsg`, `MarshalMsg` code try invoke `ShouldOmitAsEmpty` method for structures with custom marshaling. Can be disabled with `-omitempty=false` flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/206)
<!-- Reviewable:end -->
