### PR TITLE
Various cleanups to generator for consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ msgp/defgen_test.go
 msgp/cover.out
 *~
 *.coverprofile
+.idea
+.DS_Store

--- a/gen/decode.go
+++ b/gen/decode.go
@@ -29,7 +29,7 @@ func (d *decodeGen) needsField() {
 }
 
 func (d *decodeGen) Execute(p Elem) error {
-	p = d.applyall(p)
+	p = d.applyAll(p)
 	if p == nil {
 		return nil
 	}

--- a/gen/encode.go
+++ b/gen/encode.go
@@ -49,7 +49,7 @@ func (e *encodeGen) Execute(p Elem) error {
 	if !e.p.ok() {
 		return e.p.err
 	}
-	p = e.applyall(p)
+	p = e.applyAll(p)
 	if p == nil {
 		return nil
 	}

--- a/gen/marshal.go
+++ b/gen/marshal.go
@@ -29,7 +29,7 @@ func (m *marshalGen) Execute(p Elem) error {
 	if !m.p.ok() {
 		return m.p.err
 	}
-	p = m.applyall(p)
+	p = m.applyAll(p)
 	if p == nil {
 		return nil
 	}

--- a/gen/size.go
+++ b/gen/size.go
@@ -72,7 +72,7 @@ func (s *sizeGen) Execute(p Elem) error {
 	if !s.p.ok() {
 		return s.p.err
 	}
-	p = s.applyall(p)
+	p = s.applyAll(p)
 	if p == nil {
 		return nil
 	}

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -297,7 +297,7 @@ func (p *printer) declare(name string, typ string) {
 // if m != nil && size > 0 {
 //     m = make(type, size)
 // } else if len(m) > 0 {
-//     for key, _ := range m { delete(m, key) }
+//     for key := range m { delete(m, key) }
 // }
 //
 func (p *printer) resizeMap(size string, m *Map) {

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -322,7 +322,7 @@ func (p *printer) mapAssign(m *Map) {
 
 // clear map keys
 func (p *printer) clearMap(name string) {
-	p.printf("\nfor key, _ := range %[1]s { delete(%[1]s, key) }", name)
+	p.printf("\nfor key := range %[1]s { delete(%[1]s, key) }", name)
 }
 
 func (p *printer) resizeSlice(size string, s *Slice) {

--- a/gen/testgen.go
+++ b/gen/testgen.go
@@ -27,7 +27,7 @@ type mtestGen struct {
 }
 
 func (m *mtestGen) Execute(p Elem) error {
-	p = m.applyall(p)
+	p = m.applyAll(p)
 	if p != nil && IsPrintable(p) {
 		switch p.(type) {
 		case *Struct, *Array, *Slice, *Map:
@@ -49,7 +49,7 @@ func etest(w io.Writer) *etestGen {
 }
 
 func (e *etestGen) Execute(p Elem) error {
-	p = e.applyall(p)
+	p = e.applyAll(p)
 	if p != nil && IsPrintable(p) {
 		switch p.(type) {
 		case *Struct, *Array, *Slice, *Map:

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -32,7 +32,7 @@ func (u *unmarshalGen) Execute(p Elem) error {
 	if !u.p.ok() {
 		return u.p.err
 	}
-	p = u.applyall(p)
+	p = u.applyAll(p)
 	if p == nil {
 		return nil
 	}

--- a/parse/directives.go
+++ b/parse/directives.go
@@ -14,7 +14,7 @@ const linePrefix = "//msgp:"
 type directive func([]string, *FileSet) error
 
 // func(passName, args, printer)
-type passDirective func(gen.Method, []string, *gen.Printer) error
+type passDirective func(gen.Method, []string, *gen.GeneratorSet) error
 
 // map of all recognized directives
 //
@@ -30,7 +30,7 @@ var passDirectives = map[string]passDirective{
 	"ignore": passignore,
 }
 
-func passignore(m gen.Method, text []string, p *gen.Printer) error {
+func passignore(m gen.Method, text []string, p *gen.GeneratorSet) error {
 	pushstate(m.String())
 	for _, a := range text {
 		p.ApplyDirective(m, gen.IgnoreTypename(a))


### PR DESCRIPTION
It is more idiomatic in Go and cleaner code to simply have one variable set (without the blank identifier) when ranging over a map if only the key of each element is desired.

According to the language specification (here: https://golang.org/ref/spec#RangeClause):

> As with an assignment, if present the operands on the left must be addressable or map index expressions; they denote the iteration variables. If the range expression is a channel, at most one iteration variable is permitted, otherwise there may be up to two. If the last iteration variable is the blank identifier, the range clause is equivalent to the same clause without that identifier.

(Also here I'm adding two items to .gitignore—I would like to contribute further to this project.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/210)
<!-- Reviewable:end -->
