### PR TITLE
Added type name regexp matching

### DIFF
--- a/parse/getast.go
+++ b/parse/getast.go
@@ -20,7 +20,7 @@ type FileSet struct {
 	Package    string              // package name
 	Specs      map[string]ast.Expr // type specs in file
 	Identities map[string]gen.Elem // processed from specs
-	Directives []string            // raw preprocessor directives
+	Directives []string            // raw preprocessor directives (lines of comments)
 	Imports    []*ast.ImportSpec   // imports
 }
 
@@ -223,9 +223,11 @@ loop:
 		chunks := strings.Split(d, " ")
 		if len(chunks) > 1 {
 			for i := range chunks {
+				// Remove spacing around each word (type name) in
+				// case there is any spacing.
 				chunks[i] = strings.TrimSpace(chunks[i])
 			}
-			m := strToMethod(chunks[0])
+			m := strToMethod(chunks[0]) // m is the directive's gen.Method
 			if m == 0 {
 				warnf("unknown pass name: %q\n", chunks[0])
 				continue loop


### PR DESCRIPTION
You can now use regular expressions for type names in directives. Instead of the concrete type name, you can prefix "reg=" before the regular expression to match, or prefix "reg!=" before the regular expression that the type names should NOT match.

This comes in extremely useful when you want to ignore a set of types that begin a particular way.

For example, this set of directives:
```
//go:generate msgp
//msgp:encode ignore reg=Req
//msgp:unmarshal ignore reg!=^Contents
```
indicate that types that include "Req" in the name will not get an `EncodeMsg` method, and only types that begin with "Contents" will get an `UnmarshalMsg` method.

You can use plain concrete type names as before, even along with regexp:
`//msgp:encode ignore reg=Req AnotherType`

Using a flag like `-io` or `-marshal` may not be enough for you if, for example, in general you don't want methods of a particular kind but do want it for only certain types. I'm finding regexp extremely useful for my work.

The regular expression syntax is described here: https://godoc.org/regexp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/212)
<!-- Reviewable:end -->
