### PR TITLE
Fix MarshalMsg to output fixed size extension types.

### DIFF
--- a/msgp/extension.go
+++ b/msgp/extension.go
@@ -445,26 +445,27 @@ func AppendExtension(b []byte, e Extension) ([]byte, error) {
 		o[n] = mfixext16
 		o[n+1] = byte(e.ExtensionType())
 		n += 2
-	}
-	switch {
-	case l < math.MaxUint8:
-		o, n = ensure(b, l+3)
-		o[n] = mext8
-		o[n+1] = byte(uint8(l))
-		o[n+2] = byte(e.ExtensionType())
-		n += 3
-	case l < math.MaxUint16:
-		o, n = ensure(b, l+4)
-		o[n] = mext16
-		big.PutUint16(o[n+1:], uint16(l))
-		o[n+3] = byte(e.ExtensionType())
-		n += 4
 	default:
-		o, n = ensure(b, l+6)
-		o[n] = mext32
-		big.PutUint32(o[n+1:], uint32(l))
-		o[n+5] = byte(e.ExtensionType())
-		n += 6
+		switch {
+		case l < math.MaxUint8:
+			o, n = ensure(b, l+3)
+			o[n] = mext8
+			o[n+1] = byte(uint8(l))
+			o[n+2] = byte(e.ExtensionType())
+			n += 3
+		case l < math.MaxUint16:
+			o, n = ensure(b, l+4)
+			o[n] = mext16
+			big.PutUint16(o[n+1:], uint16(l))
+			o[n+3] = byte(e.ExtensionType())
+			n += 4
+		default:
+			o, n = ensure(b, l+6)
+			o[n] = mext32
+			big.PutUint32(o[n+1:], uint32(l))
+			o[n+5] = byte(e.ExtensionType())
+			n += 6
+		}
 	}
 	return o, e.MarshalBinaryTo(o[n:])
 }

--- a/msgp/extension_test.go
+++ b/msgp/extension_test.go
@@ -47,3 +47,28 @@ func TestReadWriteExtensionBytes(t *testing.T) {
 		}
 	}
 }
+
+func TestAppendAndWriteCompatibility(t *testing.T) {
+	rand.Seed(time.Now().Unix())
+
+	var bts []byte
+	var buf bytes.Buffer
+	en := NewWriter(&buf)
+
+	for i := 0; i < 24; i++ {
+		buf.Reset()
+		e := randomExt()
+		bts, _ = AppendExtension(bts[0:0], &e)
+		en.WriteExtension(&e)
+		en.Flush()
+
+		if !bytes.Equal(buf.Bytes(), bts) {
+			t.Errorf("the outputs are different:\n\t%x\n\t%x", buf.Bytes(), bts)
+		}
+
+		_, err := ReadExtensionBytes(bts, &e)
+		if err != nil {
+			t.Errorf("error with extension (length %d): %s", len(bts), err)
+		}
+	}
+}


### PR DESCRIPTION
`MarshalMsg` can not output fixed size format but `EncodeMsg` can it.
This is due to different implementations of `msgp.WriteExtension` and `msgp.AppendExtension`.

I wrote a test code:

```extension_compatibility_test.go
package msgp

func TestAppendAndWriteCompatibility(t *testing.T) {
	rand.Seed(time.Now().Unix())

	var bts []byte
	var buf bytes.Buffer
	en := NewWriter(&buf)

	for i := 0; i < 24; i++ {
		buf.Reset()
		e := randomExt()
		bts, _ = AppendExtension(bts[0:0], &e)
		en.WriteExtension(&e)
		en.Flush()

		if !bytes.Equal(buf.Bytes(), bts) {
			t.Errorf("the outputs are different:\n\t%x\n\t%x", buf.Bytes(), bts)
		}

		_, err := ReadExtensionBytes(bts, &e)
		if err != nil {
			t.Errorf("error with extension (length %d): %s", len(bts), err)
		}
	}
}
```

and result for [current master](https://github.com/tinylib/msgp/tree/5bb5e1aed7ba5bcc93307153b020e7ffe79b0509):

```go
=== RUN   TestAppendAndWriteCompatibility
--- FAIL: TestAppendAndWriteCompatibility (0.01s)
	extension_test.go:66: the outputs are different:
			WriteExtension: d8fe12c8e367f87516de1787d58a7ed085b1
			AppendExtension: c710fe12c8e367f87516de1787d58a7ed085b1
	extension_test.go:66: the outputs are different:
			WriteExtension: d59dbb0a
			AppendExtension: c7029dbb0a
	extension_test.go:66: the outputs are different:
			WriteExtension: d8faf6915a9e8b797673e95a9302a60b5d88
			AppendExtension: c710faf6915a9e8b797673e95a9302a60b5d88
	extension_test.go:66: the outputs are different:
			WriteExtension: d42272
			AppendExtension: c7012272
	extension_test.go:66: the outputs are different:
			WriteExtension: d70acd0c5863fefef70a
			AppendExtension: c7080acd0c5863fefef70a
	extension_test.go:66: the outputs are different:
			WriteExtension: d7f3b6bac6e1437ef194
			AppendExtension: c708f3b6bac6e1437ef194
	extension_test.go:66: the outputs are different:
			WriteExtension: d83aa23667032c2ad90b1eac4cf6d6c9f720
			AppendExtension: c7103aa23667032c2ad90b1eac4cf6d6c9f720
	extension_test.go:66: the outputs are different:
			WriteExtension: d52592fe
			AppendExtension: c7022592fe
	extension_test.go:66: the outputs are different:
			WriteExtension: d7adbc83acef960f3975
			AppendExtension: c708adbc83acef960f3975
	extension_test.go:66: the outputs are different:
			WriteExtension: d634dee871ab
			AppendExtension: c70434dee871ab
	extension_test.go:66: the outputs are different:
			WriteExtension: d4fa2b
			AppendExtension: c701fa2b
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/213)
<!-- Reviewable:end -->
