### PR TITLE
add missing magic number when map is sized from mm16 -> mm32

### DIFF
--- a/msgp/edit.go
+++ b/msgp/edit.go
@@ -198,6 +198,7 @@ func resizeMap(raw []byte, delta int64) []byte {
 		if cap(raw)-len(raw) >= 2 {
 			raw = raw[0 : len(raw)+2]
 			copy(raw[5:], raw[3:])
+			raw[0] = mmap32
 			big.PutUint32(raw[1:], uint32(sz+delta))
 			return raw
 		}


### PR DESCRIPTION
Found this while using resizeMap for my own purposes; it doesn't fix a bug in msgp as `delta` is only set to -1 in the code I see. However since `resizeMap` plainly tries to do the right thing when sizing upwards it seems worth supplying a fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/216)
<!-- Reviewable:end -->
