### PR TITLE
Support GopherJS and other pure Go environments

### DIFF
--- a/msgp/purego.go
+++ b/msgp/purego.go
@@ -1,4 +1,4 @@
-// +build appengine
+// +build purego appengine
 
 package msgp
 

--- a/msgp/unsafe.go
+++ b/msgp/unsafe.go
@@ -1,4 +1,4 @@
-// +build !appengine
+// +build !purego,!appengine
 
 package msgp
 


### PR DESCRIPTION
Unsafe pointer arithmetic is not supported under GopherJS, and currently fails silently.

Add the `purego` tag, standardized as part of golang/go#23172, in addition to the `appengine` tag kept for backwards compatibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/218)
<!-- Reviewable:end -->
