### PR TITLE
gen: fix vet problem

### DIFF
--- a/gen/spec.go
+++ b/gen/spec.go
@@ -297,7 +297,7 @@ func (p *printer) declare(name string, typ string) {
 // if m != nil && size > 0 {
 //     m = make(type, size)
 // } else if len(m) > 0 {
-//     for key, _ := range m { delete(m, key) }
+//     for key := range m { delete(m, key) }
 // }
 //
 func (p *printer) resizeMap(size string, m *Map) {
@@ -322,7 +322,7 @@ func (p *printer) mapAssign(m *Map) {
 
 // clear map keys
 func (p *printer) clearMap(name string) {
-	p.printf("\nfor key, _ := range %[1]s { delete(%[1]s, key) }", name)
+	p.printf("\nfor key := range %[1]s { delete(%[1]s, key) }", name)
 }
 
 func (p *printer) resizeSlice(size string, s *Slice) {


### PR DESCRIPTION
Fixes a problem that `go vet` complains about:
```
should omit 2nd value from range; this loop is equivalent to `for key := range ...`
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/220)
<!-- Reviewable:end -->
