### PR TITLE
Fix empty map case

### DIFF
--- a/gen/spec.go
+++ b/gen/spec.go
@@ -294,7 +294,7 @@ func (p *printer) declare(name string, typ string) {
 
 // does:
 //
-// if m != nil && size > 0 {
+// if m == nil {
 //     m = make(type, size)
 // } else if len(m) > 0 {
 //     for key := range m { delete(m, key) }
@@ -305,7 +305,7 @@ func (p *printer) resizeMap(size string, m *Map) {
 	if !p.ok() {
 		return
 	}
-	p.printf("\nif %s == nil && %s > 0 {", vn, size)
+	p.printf("\nif %s == nil {", vn)
 	p.printf("\n%s = make(%s, %s)", vn, m.TypeName(), size)
 	p.printf("\n} else if len(%s) > 0 {", vn)
 	p.clearMap(vn)


### PR DESCRIPTION
An empty map in the data should result in an empty map in Go. It's a small performance loss in the rare cases where people have empty maps in their data and use structs with maps that haven't been initialized yet. But for correctness its better and it allows people to distinguish between no map in the data or an empty map.

See #219

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/233)
<!-- Reviewable:end -->
