### PR TITLE
Added godoc badge to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MessagePack Code Generator [![Build Status](https://travis-ci.org/tinylib/msgp.svg?branch=master)](https://travis-ci.org/tinylib/msgp)
+MessagePack Code Generator [![Build Status](https://travis-ci.org/tinylib/msgp.svg?branch=master)](https://travis-ci.org/tinylib/msgp) [![GoDoc](https://godoc.org/github.com/tinylib/msgp/msgp?status.svg)](https://godoc.org/github.com/tinylib/msgp/msgp) 
 =======
 
 This is a code generation tool and serialization library for [MessagePack](http://msgpack.org). You can read more about MessagePack [in the wiki](http://github.com/tinylib/msgp/wiki), or at [msgpack.org](http://msgpack.org).


### PR DESCRIPTION
Reduces the number of clicks for a user to reach the godoc. Currently, a user has to goto the wiki page and click the godoc link for references. I think it would be a great addition.

Thanks for this amazing package :+1:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/234)
<!-- Reviewable:end -->
