### PR TITLE
Default timestamp timezone to UTC rather than Local

### DIFF
--- a/_generated/convert_test.go
+++ b/_generated/convert_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/tinylib/msgp/msgp"
+	"github.com/GannettDigital/msgp/msgp"
 )
 
 func TestConvertFromEncodeError(t *testing.T) {

--- a/_generated/def.go
+++ b/_generated/def.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/tinylib/msgp/msgp"
+	"github.com/GannettDigital/msgp/msgp"
 )
 
 //go:generate msgp -o generated.go

--- a/_generated/def_test.go
+++ b/_generated/def_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/tinylib/msgp/msgp"
+	"github.com/GannettDigital/msgp/msgp"
 )
 
 func TestRuneEncodeDecode(t *testing.T) {

--- a/_generated/gen_test.go
+++ b/_generated/gen_test.go
@@ -2,7 +2,7 @@ package _generated
 
 import (
 	"bytes"
-	"github.com/tinylib/msgp/msgp"
+	"github.com/GannettDigital/msgp/msgp"
 	"reflect"
 	"testing"
 	"time"

--- a/gen/encode.go
+++ b/gen/encode.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/tinylib/msgp/msgp"
+	"github.com/GannettDigital/msgp/msgp"
 )
 
 func encode(w io.Writer) *encodeGen {

--- a/gen/marshal.go
+++ b/gen/marshal.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/tinylib/msgp/msgp"
+	"github.com/GannettDigital/msgp/msgp"
 )
 
 func marshal(w io.Writer) *marshalGen {

--- a/gen/size.go
+++ b/gen/size.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"strconv"
 
-	"github.com/tinylib/msgp/msgp"
+	"github.com/GannettDigital/msgp/msgp"
 )
 
 type sizeState uint8

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -294,7 +294,7 @@ func (p *printer) declare(name string, typ string) {
 
 // does:
 //
-// if m != nil && size > 0 {
+// if m == nil {
 //     m = make(type, size)
 // } else if len(m) > 0 {
 //     for key := range m { delete(m, key) }
@@ -305,7 +305,7 @@ func (p *printer) resizeMap(size string, m *Map) {
 	if !p.ok() {
 		return
 	}
-	p.printf("\nif %s == nil && %s > 0 {", vn, size)
+	p.printf("\nif %s == nil {", vn)
 	p.printf("\n%s = make(%s, %s)", vn, m.TypeName(), size)
 	p.printf("\n} else if len(%s) > 0 {", vn)
 	p.clearMap(vn)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/GannettDigital/msgp
+
+go 1.12
+
+require (
+	github.com/philhofer/fwd v1.0.0
+	github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31
+	golang.org/x/tools v0.0.0-20190815212832-922a4ee32d1a
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/philhofer/fwd v1.0.0 h1:UbZqGr5Y38ApvM/V/jEljVxwocdweyH+vmYvRPBnbqQ=
+github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
+github.com/tinylib/msgp v1.1.0 h1:9fQd+ICuRIu/ue4vxJZu6/LzxN0HwMds2nq/0cFvxHU=
+github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
+github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31 h1:OXcKh35JaYsGMRzpvFkLv/MEyPuL49CThT1pZ8aSml4=
+github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190815212832-922a4ee32d1a h1:5qy6QUqKAbbhe26lVEbveBo0jK0xeNAAJ7gEi32NUkU=
+golang.org/x/tools v0.0.0-20190815212832-922a4ee32d1a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/issue185_test.go
+++ b/issue185_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/tinylib/msgp/gen"
+	"github.com/GannettDigital/msgp/gen"
 )
 
 // When stuff's going wrong, you'll be glad this is here!

--- a/main.go
+++ b/main.go
@@ -29,9 +29,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/tinylib/msgp/gen"
-	"github.com/tinylib/msgp/parse"
-	"github.com/tinylib/msgp/printer"
+	"github.com/GannettDigital/msgp/gen"
+	"github.com/GannettDigital/msgp/parse"
+	"github.com/GannettDigital/msgp/printer"
 	"github.com/ttacon/chalk"
 )
 
@@ -98,7 +98,14 @@ func Run(gofile string, mode gen.Method, unexported bool) error {
 		return nil
 	}
 
-	return printer.PrintFile(newFilename(gofile, fs.Package), fs, mode)
+	if err := printer.PrintFile(newFilename(gofile, fs.Package), fs, mode); err != nil {
+		return err
+	}
+
+	fmt.Printf(chalk.Magenta.Color(">>> Wrote and formatted \"%s\"\n"), gofile)
+	fmt.Printf(chalk.Magenta.Color(">>> Wrote and formatted \"%s\"\n"), strings.TrimSuffix(gofile, ".go")+"_test.go")
+
+	return nil
 }
 
 // picks a new file name based on input flags and input filename(s).

--- a/msgp/file_test.go
+++ b/msgp/file_test.go
@@ -5,7 +5,7 @@ package msgp_test
 import (
 	"bytes"
 	"crypto/rand"
-	"github.com/tinylib/msgp/msgp"
+	"github.com/GannettDigital/msgp/msgp"
 	prand "math/rand"
 	"os"
 	"testing"

--- a/msgp/read.go
+++ b/msgp/read.go
@@ -1233,7 +1233,7 @@ func (m *Reader) ReadMapStrIntf(mp map[string]interface{}) (err error) {
 }
 
 // ReadTime reads a time.Time object from the reader.
-// The returned time's location will be set to time.Local.
+// The returned time's location will be set to UTC.
 func (m *Reader) ReadTime() (t time.Time, err error) {
 	var p []byte
 	p, err = m.R.Peek(15)
@@ -1249,7 +1249,7 @@ func (m *Reader) ReadTime() (t time.Time, err error) {
 		return
 	}
 	sec, nsec := getUnix(p[3:])
-	t = time.Unix(sec, int64(nsec)).Local()
+	t = time.Unix(sec, int64(nsec)).UTC()
 	_, err = m.R.Skip(15)
 	return
 }

--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -982,7 +982,7 @@ func ReadTimeBytes(b []byte) (t time.Time, o []byte, err error) {
 		return
 	}
 	sec, nsec := getUnix(b[3:])
-	t = time.Unix(sec, int64(nsec)).Local()
+	t = time.Unix(sec, int64(nsec)).UTC()
 	o = b[15:]
 	return
 }

--- a/parse/directives.go
+++ b/parse/directives.go
@@ -5,7 +5,7 @@ import (
 	"go/ast"
 	"strings"
 
-	"github.com/tinylib/msgp/gen"
+	"github.com/GannettDigital/msgp/gen"
 )
 
 const linePrefix = "//msgp:"

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/tinylib/msgp/gen"
+	"github.com/GannettDigital/msgp/gen"
 	"github.com/ttacon/chalk"
 )
 

--- a/parse/inline.go
+++ b/parse/inline.go
@@ -1,7 +1,7 @@
 package parse
 
 import (
-	"github.com/tinylib/msgp/gen"
+	"github.com/GannettDigital/msgp/gen"
 )
 
 // This file defines when and how we

--- a/printer/print.go
+++ b/printer/print.go
@@ -7,15 +7,10 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/tinylib/msgp/gen"
-	"github.com/tinylib/msgp/parse"
-	"github.com/ttacon/chalk"
+	"github.com/GannettDigital/msgp/gen"
+	"github.com/GannettDigital/msgp/parse"
 	"golang.org/x/tools/imports"
 )
-
-func infof(s string, v ...interface{}) {
-	fmt.Printf(chalk.Magenta.Color(s), v...)
-}
 
 // PrintFile prints the methods for the provided list
 // of elements to the given file name and canonical
@@ -39,7 +34,6 @@ func PrintFile(file string, f *parse.FileSet, mode gen.Method) error {
 		if err != nil {
 			return err
 		}
-		infof(">>> Wrote and formatted \"%s\"\n", testfile)
 	}
 	err = <-res
 	if err != nil {
@@ -60,7 +54,6 @@ func goformat(file string, data []byte) <-chan error {
 	out := make(chan error, 1)
 	go func(file string, data []byte, end chan error) {
 		end <- format(file, data)
-		infof(">>> Wrote and formatted \"%s\"\n", file)
 	}(file, data, out)
 	return out
 }
@@ -81,7 +74,7 @@ func generate(f *parse.FileSet, mode gen.Method) (*bytes.Buffer, *bytes.Buffer, 
 	outbuf := bytes.NewBuffer(make([]byte, 0, 4096))
 	writePkgHeader(outbuf, f.Package)
 
-	myImports := []string{"github.com/tinylib/msgp/msgp"}
+	myImports := []string{"github.com/GannettDigital/msgp/msgp"}
 	for _, imp := range f.Imports {
 		if imp.Name != nil {
 			// have an alias, include it.
@@ -99,9 +92,9 @@ func generate(f *parse.FileSet, mode gen.Method) (*bytes.Buffer, *bytes.Buffer, 
 		testbuf = bytes.NewBuffer(make([]byte, 0, 4096))
 		writePkgHeader(testbuf, f.Package)
 		if mode&(gen.Encode|gen.Decode) != 0 {
-			writeImportHeader(testbuf, "bytes", "github.com/tinylib/msgp/msgp", "testing")
+			writeImportHeader(testbuf, "bytes", "github.com/GannettDigital/msgp/msgp", "testing")
 		} else {
-			writeImportHeader(testbuf, "github.com/tinylib/msgp/msgp", "testing")
+			writeImportHeader(testbuf, "github.com/GannettDigital/msgp/msgp", "testing")
 		}
 		testwr = testbuf
 	}


### PR DESCRIPTION
I found it unintuitive that a timestamp is returned in my local timezone when the original timezone is not known (being lost in the serialization), rather returning in UTC seems better. This also makes the output consistent no matter where the machine happen to think it is located.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/236)
<!-- Reviewable:end -->
