### PR TITLE
Fix bin encoded map keys

### DIFF
--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -314,8 +314,7 @@ func ReadFloat32Bytes(b []byte) (f float32, o []byte, err error) {
 	}
 
 	if b[0] != mfloat32 {
-		err = TypeError{Method: Float32Type, Encoded: getType(b[0])}
-		return
+		return 0, b, TypeError{Method: Float32Type, Encoded: getType(b[0])}
 	}
 
 	f = math.Float32frombits(getMuint32(b))
@@ -865,8 +864,7 @@ func ReadStringZC(b []byte) (v []byte, o []byte, err error) {
 			b = b[5:]
 
 		default:
-			err = TypeError{Method: StrType, Encoded: getType(lead)}
-			return
+			return nil, b, TypeError{Method: StrType, Encoded: getType(lead)}
 		}
 	}
 

--- a/msgp/read_bytes_test.go
+++ b/msgp/read_bytes_test.go
@@ -677,3 +677,14 @@ func BenchmarkSkipBytes(b *testing.B) {
 		}
 	}
 }
+
+func TestReadMapKeyZC(t *testing.T) {
+	b := []byte{196, 1, 97}
+	if a, r, err := ReadMapKeyZC(b); err != nil {
+		t.Fatal(err)
+	} else if bytes.Compare(a, []byte("a")) != 0 {
+		t.Fatalf(`expected "a" got %q`, a)
+	} else if len(r) != 0 {
+		t.Fatalf("expected 0 got %d", len(r))
+	}
+}


### PR DESCRIPTION
When returning a TypeError the caller may try to continue reading a different type from the returned buffer. So make sure we actually return the buffer and not nil.

Fixes #243

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tinylib/msgp/244)
<!-- Reviewable:end -->
