### PR TITLE
msgp/msgp: fix ReadMapKeyZC

### DIFF
--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -201,14 +201,14 @@ func ReadMapHeaderBytes(b []byte) (sz uint32, o []byte, err error) {
 // - ErrShortBytes (too few bytes)
 // - TypeError{} (not a str or bin)
 func ReadMapKeyZC(b []byte) ([]byte, []byte, error) {
-	o, b, err := ReadStringZC(b)
+	o, x, err := ReadStringZC(b)
 	if err != nil {
 		if tperr, ok := err.(TypeError); ok && tperr.Encoded == BinType {
 			return ReadBytesZC(b)
 		}
 		return nil, b, err
 	}
-	return o, b, nil
+	return o, x, nil
 }
 
 // ReadArrayHeaderBytes attempts to read

--- a/msgp/read_bytes_test.go
+++ b/msgp/read_bytes_test.go
@@ -552,6 +552,44 @@ func TestReadComplex128Bytes(t *testing.T) {
 	}
 }
 
+// both the 'str' and 'bin' types are acceptable map keys
+func TestReadMapKey(t *testing.T) {
+	args := []string{
+		"a",
+		"ab",
+		"qwertyuiop",
+	}
+	var buf bytes.Buffer
+	en := NewWriter(&buf)
+
+	for i := range args {
+		en.WriteString(args[i])
+		en.WriteBytes([]byte(args[i]))
+	}
+	en.Flush()
+	b := buf.Bytes()
+
+	for i := range args {
+		var s0, s1 []byte
+		var err error
+
+		s0, b, err = ReadMapKeyZC(b)
+		if err != nil {
+			t.Fatalf("couldn't read string as map key: %q", err)
+		}
+		s1, b, err = ReadMapKeyZC(b)
+		if err != nil {
+			t.Fatalf("couldn't read bytes as map key: %q", err)
+		}
+		if !bytes.Equal(s0, s1) {
+			t.Fatalf("%q != %q", s0, s1)
+		}
+		if string(s0) != args[i] {
+			t.Fatalf("%q != %q", s0, args[i])
+		}
+	}
+}
+
 func TestReadComplex64Bytes(t *testing.T) {
 	var buf bytes.Buffer
 	en := NewWriter(&buf)


### PR DESCRIPTION
Due to some unintentional variable shadowing, ReadMapKeyZC
never actually accepted 'bin'-typed map keys. Fix the shadowing
and add test coverage.

Fixes #243 

cc @erikdubbelboer @sudeep9