### PR TITLE
gen: prevent generated tests from calling t.Logf with struct as argument, fixing go vet copylocks error when struct has sync.Mutex field - #255

### DIFF
--- a/_generated/vet_copylocks.go
+++ b/_generated/vet_copylocks.go
@@ -1,0 +1,11 @@
+package _generated
+
+import "sync"
+
+//go:generate msgp
+//go:generate go vet
+
+type Foo struct {
+	I    struct{}
+	lock sync.Mutex
+}

--- a/gen/testgen.go
+++ b/gen/testgen.go
@@ -129,7 +129,7 @@ func BenchmarkUnmarshal{{.TypeName}}(b *testing.B) {
 
 	m := v.Msgsize()
 	if buf.Len() > m {
-		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+		t.Log("WARNING: TestEncodeDecode{{.TypeName}} Msgsize() is inaccurate")
 	}
 
 	vn := {{.TypeName}}{}


### PR DESCRIPTION
https://github.com/tinylib/msgp/issues/255