### PR TITLE
PR for omitempty support

### DIFF
--- a/_generated/omitempty.go
+++ b/_generated/omitempty.go
@@ -1,0 +1,177 @@
+package _generated
+
+import "time"
+
+//go:generate msgp
+
+type OmitEmpty0 struct {
+	ABool       bool       `msg:"abool,omitempty"`
+	AInt        int        `msg:"aint,omitempty"`
+	AInt8       int8       `msg:"aint8,omitempty"`
+	AInt16      int16      `msg:"aint16,omitempty"`
+	AInt32      int32      `msg:"aint32,omitempty"`
+	AInt64      int64      `msg:"aint64,omitempty"`
+	AUint       uint       `msg:"auint,omitempty"`
+	AUint8      uint8      `msg:"auint8,omitempty"`
+	AUint16     uint16     `msg:"auint16,omitempty"`
+	AUint32     uint32     `msg:"auint32,omitempty"`
+	AUint64     uint64     `msg:"auint64,omitempty"`
+	AFloat32    float32    `msg:"afloat32,omitempty"`
+	AFloat64    float64    `msg:"afloat64,omitempty"`
+	AComplex64  complex64  `msg:"acomplex64,omitempty"`
+	AComplex128 complex128 `msg:"acomplex128,omitempty"`
+
+	ANamedBool    bool    `msg:"anamedbool,omitempty"`
+	ANamedInt     int     `msg:"anamedint,omitempty"`
+	ANamedFloat64 float64 `msg:"anamedfloat64,omitempty"`
+
+	AMapStrStr map[string]string `msg:"amapstrstr,omitempty"`
+
+	APtrNamedStr *NamedString `msg:"aptrnamedstr,omitempty"`
+
+	AString      string `msg:"astring,omitempty"`
+	ANamedString string `msg:"anamedstring,omitempty"`
+	AByteSlice   []byte `msg:"abyteslice,omitempty"`
+
+	ASliceString      []string      `msg:"aslicestring,omitempty"`
+	ASliceNamedString []NamedString `msg:"aslicenamedstring,omitempty"`
+
+	ANamedStruct    NamedStruct  `msg:"anamedstruct,omitempty"`
+	APtrNamedStruct *NamedStruct `msg:"aptrnamedstruct,omitempty"`
+
+	AUnnamedStruct struct {
+		A string `msg:"a,omitempty"`
+	} `msg:"aunnamedstruct,omitempty"` // omitempty not supported on unnamed struct
+
+	EmbeddableStruct `msg:",flatten,omitempty"` // embed flat
+
+	EmbeddableStruct2 `msg:"embeddablestruct2,omitempty"` // embed non-flat
+
+	AArrayInt [5]int `msg:"aarrayint,omitempty"` // not supported
+
+	ATime time.Time `msg:"atime,omitempty"`
+}
+
+type NamedBool bool
+type NamedInt int
+type NamedFloat64 float64
+type NamedString string
+
+type EmbeddableStruct struct {
+	SomeEmbed string `msg:"someembed,omitempty"`
+}
+
+type EmbeddableStruct2 struct {
+	SomeEmbed2 string `msg:"someembed2,omitempty"`
+}
+
+type NamedStruct struct {
+	A string `msg:"a,omitempty"`
+	B string `msg:"b,omitempty"`
+}
+
+type OmitEmptyHalfFull struct {
+	Field00 string `msg:"field00,omitempty"`
+	Field01 string `msg:"field01"`
+	Field02 string `msg:"field02,omitempty"`
+	Field03 string `msg:"field03"`
+}
+
+type OmitEmptyLotsOFields struct {
+	Field00 string `msg:"field00,omitempty"`
+	Field01 string `msg:"field01,omitempty"`
+	Field02 string `msg:"field02,omitempty"`
+	Field03 string `msg:"field03,omitempty"`
+	Field04 string `msg:"field04,omitempty"`
+	Field05 string `msg:"field05,omitempty"`
+	Field06 string `msg:"field06,omitempty"`
+	Field07 string `msg:"field07,omitempty"`
+	Field08 string `msg:"field08,omitempty"`
+	Field09 string `msg:"field09,omitempty"`
+	Field10 string `msg:"field10,omitempty"`
+	Field11 string `msg:"field11,omitempty"`
+	Field12 string `msg:"field12,omitempty"`
+	Field13 string `msg:"field13,omitempty"`
+	Field14 string `msg:"field14,omitempty"`
+	Field15 string `msg:"field15,omitempty"`
+	Field16 string `msg:"field16,omitempty"`
+	Field17 string `msg:"field17,omitempty"`
+	Field18 string `msg:"field18,omitempty"`
+	Field19 string `msg:"field19,omitempty"`
+	Field20 string `msg:"field20,omitempty"`
+	Field21 string `msg:"field21,omitempty"`
+	Field22 string `msg:"field22,omitempty"`
+	Field23 string `msg:"field23,omitempty"`
+	Field24 string `msg:"field24,omitempty"`
+	Field25 string `msg:"field25,omitempty"`
+	Field26 string `msg:"field26,omitempty"`
+	Field27 string `msg:"field27,omitempty"`
+	Field28 string `msg:"field28,omitempty"`
+	Field29 string `msg:"field29,omitempty"`
+	Field30 string `msg:"field30,omitempty"`
+	Field31 string `msg:"field31,omitempty"`
+	Field32 string `msg:"field32,omitempty"`
+	Field33 string `msg:"field33,omitempty"`
+	Field34 string `msg:"field34,omitempty"`
+	Field35 string `msg:"field35,omitempty"`
+	Field36 string `msg:"field36,omitempty"`
+	Field37 string `msg:"field37,omitempty"`
+	Field38 string `msg:"field38,omitempty"`
+	Field39 string `msg:"field39,omitempty"`
+	Field40 string `msg:"field40,omitempty"`
+	Field41 string `msg:"field41,omitempty"`
+	Field42 string `msg:"field42,omitempty"`
+	Field43 string `msg:"field43,omitempty"`
+	Field44 string `msg:"field44,omitempty"`
+	Field45 string `msg:"field45,omitempty"`
+	Field46 string `msg:"field46,omitempty"`
+	Field47 string `msg:"field47,omitempty"`
+	Field48 string `msg:"field48,omitempty"`
+	Field49 string `msg:"field49,omitempty"`
+	Field50 string `msg:"field50,omitempty"`
+	Field51 string `msg:"field51,omitempty"`
+	Field52 string `msg:"field52,omitempty"`
+	Field53 string `msg:"field53,omitempty"`
+	Field54 string `msg:"field54,omitempty"`
+	Field55 string `msg:"field55,omitempty"`
+	Field56 string `msg:"field56,omitempty"`
+	Field57 string `msg:"field57,omitempty"`
+	Field58 string `msg:"field58,omitempty"`
+	Field59 string `msg:"field59,omitempty"`
+	Field60 string `msg:"field60,omitempty"`
+	Field61 string `msg:"field61,omitempty"`
+	Field62 string `msg:"field62,omitempty"`
+	Field63 string `msg:"field63,omitempty"`
+	Field64 string `msg:"field64,omitempty"`
+	Field65 string `msg:"field65,omitempty"`
+	Field66 string `msg:"field66,omitempty"`
+	Field67 string `msg:"field67,omitempty"`
+	Field68 string `msg:"field68,omitempty"`
+	Field69 string `msg:"field69,omitempty"`
+}
+
+type OmitEmpty10 struct {
+	Field00 string `msg:"field00,omitempty"`
+	Field01 string `msg:"field01,omitempty"`
+	Field02 string `msg:"field02,omitempty"`
+	Field03 string `msg:"field03,omitempty"`
+	Field04 string `msg:"field04,omitempty"`
+	Field05 string `msg:"field05,omitempty"`
+	Field06 string `msg:"field06,omitempty"`
+	Field07 string `msg:"field07,omitempty"`
+	Field08 string `msg:"field08,omitempty"`
+	Field09 string `msg:"field09,omitempty"`
+}
+
+type NotOmitEmpty10 struct {
+	Field00 string `msg:"field00"`
+	Field01 string `msg:"field01"`
+	Field02 string `msg:"field02"`
+	Field03 string `msg:"field03"`
+	Field04 string `msg:"field04"`
+	Field05 string `msg:"field05"`
+	Field06 string `msg:"field06"`
+	Field07 string `msg:"field07"`
+	Field08 string `msg:"field08"`
+	Field09 string `msg:"field09"`
+}

--- a/_generated/omitempty_test.go
+++ b/_generated/omitempty_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/bradleypeabody/msgp/msgp"
+	"github.com/tinylib/msgp/msgp"
 )
 
 func mustEncodeToJSON(o msgp.Encodable) string {

--- a/_generated/omitempty_test.go
+++ b/_generated/omitempty_test.go
@@ -1,0 +1,233 @@
+package _generated
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/bradleypeabody/msgp/msgp"
+)
+
+func mustEncodeToJSON(o msgp.Encodable) string {
+	var buf bytes.Buffer
+	var err error
+
+	en := msgp.NewWriter(&buf)
+	err = o.EncodeMsg(en)
+	if err != nil {
+		panic(err)
+	}
+	en.Flush()
+
+	var outbuf bytes.Buffer
+	_, err = msgp.CopyToJSON(&outbuf, &buf)
+	if err != nil {
+		panic(err)
+	}
+
+	return outbuf.String()
+}
+
+func TestOmitEmpty0(t *testing.T) {
+
+	var s string
+
+	var oe0a OmitEmpty0
+
+	s = mustEncodeToJSON(&oe0a)
+	if s != `{"aunnamedstruct":{},"aarrayint":[0,0,0,0,0]}` {
+		t.Errorf("wrong result: %s", s)
+	}
+
+	var oe0b OmitEmpty0
+	oe0b.AString = "teststr"
+	s = mustEncodeToJSON(&oe0b)
+	if s != `{"astring":"teststr","aunnamedstruct":{},"aarrayint":[0,0,0,0,0]}` {
+		t.Errorf("wrong result: %s", s)
+	}
+
+	// more than 15 fields filled in
+	var oe0c OmitEmpty0
+	oe0c.ABool = true
+	oe0c.AInt = 1
+	oe0c.AInt8 = 1
+	oe0c.AInt16 = 1
+	oe0c.AInt32 = 1
+	oe0c.AInt64 = 1
+	oe0c.AUint = 1
+	oe0c.AUint8 = 1
+	oe0c.AUint16 = 1
+	oe0c.AUint32 = 1
+	oe0c.AUint64 = 1
+	oe0c.AFloat32 = 1
+	oe0c.AFloat64 = 1
+	oe0c.AComplex64 = complex(1, 1)
+	oe0c.AComplex128 = complex(1, 1)
+	oe0c.AString = "test"
+	oe0c.ANamedBool = true
+	oe0c.ANamedInt = 1
+	oe0c.ANamedFloat64 = 1
+
+	var buf bytes.Buffer
+	en := msgp.NewWriter(&buf)
+	err := oe0c.EncodeMsg(en)
+	if err != nil {
+		t.Fatal(err)
+	}
+	en.Flush()
+	de := msgp.NewReader(&buf)
+	var oe0d OmitEmpty0
+	err = oe0d.DecodeMsg(de)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// spot check some fields
+	if oe0c.AFloat32 != oe0d.AFloat32 {
+		t.Fail()
+	}
+	if oe0c.ANamedBool != oe0d.ANamedBool {
+		t.Fail()
+	}
+	if oe0c.AInt64 != oe0d.AInt64 {
+		t.Fail()
+	}
+
+}
+
+// TestOmitEmptyHalfFull tests mixed omitempty and not
+func TestOmitEmptyHalfFull(t *testing.T) {
+
+	var s string
+
+	var oeA OmitEmptyHalfFull
+
+	s = mustEncodeToJSON(&oeA)
+	if s != `{"field01":"","field03":""}` {
+		t.Errorf("wrong result: %s", s)
+	}
+
+	var oeB OmitEmptyHalfFull
+	oeB.Field02 = "val2"
+	s = mustEncodeToJSON(&oeB)
+	if s != `{"field01":"","field02":"val2","field03":""}` {
+		t.Errorf("wrong result: %s", s)
+	}
+
+	var oeC OmitEmptyHalfFull
+	oeC.Field03 = "val3"
+	s = mustEncodeToJSON(&oeC)
+	if s != `{"field01":"","field03":"val3"}` {
+		t.Errorf("wrong result: %s", s)
+	}
+}
+
+// TestOmitEmptyLotsOFields tests the case of > 64 fields (triggers the bitmask needing to be an array instead of a single value)
+func TestOmitEmptyLotsOFields(t *testing.T) {
+
+	var s string
+
+	var oeLotsA OmitEmptyLotsOFields
+
+	s = mustEncodeToJSON(&oeLotsA)
+	if s != `{}` {
+		t.Errorf("wrong result: %s", s)
+	}
+
+	var oeLotsB OmitEmptyLotsOFields
+	oeLotsB.Field04 = "val4"
+	s = mustEncodeToJSON(&oeLotsB)
+	if s != `{"field04":"val4"}` {
+		t.Errorf("wrong result: %s", s)
+	}
+
+	var oeLotsC OmitEmptyLotsOFields
+	oeLotsC.Field64 = "val64"
+	s = mustEncodeToJSON(&oeLotsC)
+	if s != `{"field64":"val64"}` {
+		t.Errorf("wrong result: %s", s)
+	}
+
+}
+
+func BenchmarkOmitEmpty10AllEmpty(b *testing.B) {
+
+	en := msgp.NewWriter(ioutil.Discard)
+	var s OmitEmpty10
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		err := s.EncodeMsg(en)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+}
+
+func BenchmarkOmitEmpty10AllFull(b *testing.B) {
+
+	en := msgp.NewWriter(ioutil.Discard)
+	var s OmitEmpty10
+	s.Field00 = "this is the value of field00"
+	s.Field01 = "this is the value of field01"
+	s.Field02 = "this is the value of field02"
+	s.Field03 = "this is the value of field03"
+	s.Field04 = "this is the value of field04"
+	s.Field05 = "this is the value of field05"
+	s.Field06 = "this is the value of field06"
+	s.Field07 = "this is the value of field07"
+	s.Field08 = "this is the value of field08"
+	s.Field09 = "this is the value of field09"
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		err := s.EncodeMsg(en)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+}
+
+func BenchmarkNotOmitEmpty10AllEmpty(b *testing.B) {
+
+	en := msgp.NewWriter(ioutil.Discard)
+	var s NotOmitEmpty10
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		err := s.EncodeMsg(en)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkNotOmitEmpty10AllFull(b *testing.B) {
+
+	en := msgp.NewWriter(ioutil.Discard)
+	var s NotOmitEmpty10
+	s.Field00 = "this is the value of field00"
+	s.Field01 = "this is the value of field01"
+	s.Field02 = "this is the value of field02"
+	s.Field03 = "this is the value of field03"
+	s.Field04 = "this is the value of field04"
+	s.Field05 = "this is the value of field05"
+	s.Field06 = "this is the value of field06"
+	s.Field07 = "this is the value of field07"
+	s.Field08 = "this is the value of field08"
+	s.Field09 = "this is the value of field09"
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		err := s.EncodeMsg(en)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/gen/encode.go
+++ b/gen/encode.go
@@ -128,7 +128,7 @@ func (e *encodeGen) structmap(s *Struct) {
 		fieldNVar = oeIdentPrefix + "Len"
 
 		e.p.printf("\n// omitempty: check for empty values")
-		e.p.printf("\n%s := %d", fieldNVar, nfields)
+		e.p.printf("\n%s := uint32(%d)", fieldNVar, nfields)
 		e.p.printf("\n%s", bm.typeDecl())
 		for i, sf := range s.Fields {
 			if !e.p.ok() {
@@ -143,7 +143,7 @@ func (e *encodeGen) structmap(s *Struct) {
 		}
 
 		e.p.printf("\n// variable map header, size %s", fieldNVar)
-		e.p.varMapHeader("err = en.Append(", ")", fieldNVar, nfields)
+		e.p.varWriteMapHeader("en", fieldNVar, nfields)
 		e.p.print("\nif err != nil { return }")
 		if !e.p.ok() {
 			return

--- a/gen/encode.go
+++ b/gen/encode.go
@@ -3,6 +3,7 @@ package gen
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/tinylib/msgp/msgp"
 )
@@ -110,24 +111,85 @@ func (e *encodeGen) appendraw(bts []byte) {
 }
 
 func (e *encodeGen) structmap(s *Struct) {
+
+	oeIdentPrefix := randIdent()
+
+	var data []byte
 	nfields := len(s.Fields)
-	data := msgp.AppendMapHeader(nil, uint32(nfields))
-	e.p.printf("\n// map header, size %d", nfields)
-	e.Fuse(data)
-	if len(s.Fields) == 0 {
-		e.fuseHook()
+	bm := bmask{
+		bitlen:  nfields,
+		varname: oeIdentPrefix + "Mask",
 	}
+
+	omitempty := s.AnyHasTagPart("omitempty")
+	var fieldNVar string
+	if omitempty {
+
+		fieldNVar = oeIdentPrefix + "Len"
+
+		e.p.printf("\n// omitempty: check for empty values")
+		e.p.printf("\n%s := %d", fieldNVar, nfields)
+		e.p.printf("\n%s", bm.typeDecl())
+		for i, sf := range s.Fields {
+			if !e.p.ok() {
+				return
+			}
+			if ize := sf.FieldElem.IfZeroExpr(); ize != "" && sf.HasTagPart("omitempty") {
+				e.p.printf("\nif %s {", ize)
+				e.p.printf("\n%s--", fieldNVar)
+				e.p.printf("\n%s", bm.setStmt(i))
+				e.p.printf("\n}")
+			}
+		}
+
+		e.p.printf("\n// variable map header, size %s", fieldNVar)
+		e.p.varMapHeader("err = en.Append(", ")", fieldNVar, nfields)
+		e.p.print("\nif err != nil { return }")
+		if !e.p.ok() {
+			return
+		}
+
+		// quick return for the case where the entire thing is empty, but only at the top level
+		if !strings.Contains(s.Varname(), ".") {
+			e.p.printf("\nif %s == 0 { return }", fieldNVar)
+		}
+
+	} else {
+
+		// non-omitempty version
+		data = msgp.AppendMapHeader(nil, uint32(nfields))
+		e.p.printf("\n// map header, size %d", nfields)
+		e.Fuse(data)
+		if len(s.Fields) == 0 {
+			e.fuseHook()
+		}
+
+	}
+
 	for i := range s.Fields {
 		if !e.p.ok() {
 			return
 		}
+
+		// if field is omitempty, wrap with if statement based on the emptymask
+		oeField := s.Fields[i].HasTagPart("omitempty") && s.Fields[i].FieldElem.IfZeroExpr() != ""
+		if oeField {
+			e.p.printf("\nif %s == 0 { // if not empty", bm.readExpr(i))
+		}
+
 		data = msgp.AppendString(nil, s.Fields[i].FieldTag)
 		e.p.printf("\n// write %q", s.Fields[i].FieldTag)
 		e.Fuse(data)
+		e.fuseHook()
 
 		e.ctx.PushString(s.Fields[i].FieldName)
 		next(e, s.Fields[i].FieldElem)
 		e.ctx.Pop()
+
+		if oeField {
+			e.p.print("\n}") // close if statement
+		}
+
 	}
 }
 

--- a/gen/marshal.go
+++ b/gen/marshal.go
@@ -123,7 +123,7 @@ func (m *marshalGen) mapstruct(s *Struct) {
 		fieldNVar = oeIdentPrefix + "Len"
 
 		m.p.printf("\n// omitempty: check for empty values")
-		m.p.printf("\n%s := %d", fieldNVar, nfields)
+		m.p.printf("\n%s := uint32(%d)", fieldNVar, nfields)
 		m.p.printf("\n%s", bm.typeDecl())
 		for i, sf := range s.Fields {
 			if !m.p.ok() {
@@ -138,7 +138,7 @@ func (m *marshalGen) mapstruct(s *Struct) {
 		}
 
 		m.p.printf("\n// variable map header, size %s", fieldNVar)
-		m.p.varMapHeader("o = append(o,", ")", fieldNVar, nfields)
+		m.p.varAppendMapHeader("o", fieldNVar, nfields)
 		if !m.p.ok() {
 			return
 		}

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -355,6 +355,7 @@ func (fs *FileSet) getField(f *ast.Field) []gen.StructField {
 			return nil
 		}
 		sf[0].FieldTag = tags[0]
+		sf[0].FieldTagParts = tags
 		sf[0].RawTag = f.Tag.Value
 	}
 
@@ -389,6 +390,7 @@ func (fs *FileSet) getField(f *ast.Field) []gen.StructField {
 	sf[0].FieldElem = ex
 	if sf[0].FieldTag == "" {
 		sf[0].FieldTag = sf[0].FieldName
+		sf[0].FieldTagParts = []string{sf[0].FieldName}
 	}
 
 	// validate extension


### PR DESCRIPTION
As discussed in #263, here is a PR for omitempty support.

Highlights:

- types moved to more appropriate places - bmask added a type in spec.go, the struct tag checking was added directly to Struct and StructField types, ZeroExpr and IfZeroExpr added to Elem
- as before, no change if not using "omitempty"
- no change to decoding behavior
- implementation and test stuff added for various cases like embedded structs

Let me know if anything else is needed on this, but I believe this hits all of the important points.