### PR TITLE
added Unwrap method to errWrapped plus tests; switched travis to go 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.12.x
+  - 1.14.x
   - tip
 
 env:

--- a/msgp/errors.go
+++ b/msgp/errors.go
@@ -123,6 +123,9 @@ func (e errWrapped) Resumable() bool {
 	return resumableDefault
 }
 
+// Unwrap returns the cause.
+func (e errWrapped) Unwrap() error { return e.cause }
+
 type errShort struct{}
 
 func (e errShort) Error() string   { return "msgp: too few bytes left to read object" }


### PR DESCRIPTION
Here's the PR as mentioned in https://github.com/tinylib/msgp/issues/269

Since the new error handling requires at least Go 1.13, I went ahead and updated the travis config to the latest.