### PR TITLE
Add Reader/Writer constructors with custom buffer

### DIFF
--- a/msgp/read.go
+++ b/msgp/read.go
@@ -126,6 +126,11 @@ func NewReaderSize(r io.Reader, sz int) *Reader {
 	return &Reader{R: fwd.NewReaderSize(r, sz)}
 }
 
+// NewReaderBuf returns a *Reader with a provided buffer.
+func NewReaderBuf(r io.Reader, buf []byte) *Reader {
+	return &Reader{R: fwd.NewReaderBuf(r, buf)}
+}
+
 // Reader wraps an io.Reader and provides
 // methods to read MessagePack-encoded values
 // from it. Readers are buffered.

--- a/msgp/write.go
+++ b/msgp/write.go
@@ -10,6 +10,11 @@ import (
 	"time"
 )
 
+const (
+	// min buffer size for the writer
+	minWriterSize = 18
+)
+
 // Sizer is an interface implemented
 // by types that can estimate their
 // size when MessagePack encoded.
@@ -120,16 +125,27 @@ func NewWriter(w io.Writer) *Writer {
 
 // NewWriterSize returns a writer with a custom buffer size.
 func NewWriterSize(w io.Writer, sz int) *Writer {
-	// we must be able to require() 18
+	// we must be able to require() 'minWriterSize'
 	// contiguous bytes, so that is the
 	// practical minimum buffer size
-	if sz < 18 {
-		sz = 18
+	if sz < minWriterSize {
+		sz = minWriterSize
 	}
+	buf := make([]byte, sz)
+	return NewWriterBuf(w, buf)
+}
 
+// NewWriterBuf returns a writer with a provided buffer.
+// 'buf' is not used when the capacity is smaller than 18,
+// custom buffer is allocated instead.
+func NewWriterBuf(w io.Writer, buf []byte) *Writer {
+	if cap(buf) < minWriterSize {
+		buf = make([]byte, minWriterSize)
+	}
+	buf = buf[:cap(buf)]
 	return &Writer{
 		w:   w,
-		buf: make([]byte, sz),
+		buf: buf,
 	}
 }
 


### PR DESCRIPTION
This patch adds simple new functions to create `Reader`/`Writer` with custom buffers. It is helpful in times when buffers are recycled with `sync.Pool` this way we can reuse buffer rather than having separate `sync.Pool` for `msgp.Reader`/`msgp.Writer`.

This change doesn't change any existing logic.

~~Requires https://github.com/philhofer/fwd/pull/19 to be merged.~~

Once this MR is accepted and merged I would really appreciate to bump the version (it would help to update the dependency in our project).