### PR TITLE
Always create slices, even 0 length

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # normal `go install`.
 
 # generated integration test files
-GGEN = ./_generated/generated.go ./_generated/generated_test.go
+GGEN = ./_generated/generated.go ./_generated/generated_test.go ./_generated/*_gen.go ./_generated/*_gen_test.go
 # generated unit test files
 MGEN = ./msgp/defgen_test.go
 

--- a/_generated/gen_test.go
+++ b/_generated/gen_test.go
@@ -97,9 +97,12 @@ func Test1EncodeDecode(t *testing.T) {
 			ValueA: "here's the first inner value",
 			ValueB: []byte("here's the second inner value"),
 		},
-		Child:    nil,
-		Time:     time.Now(),
-		Appended: msgp.Raw([]byte{}), // 'nil'
+		Child:     nil,
+		Time:      time.Now(),
+		Appended:  msgp.Raw([]byte{}), // 'nil'
+		RuneSlice: []rune{},
+		Slice1:    []string{},
+		Slice2:    []string{},
 	}
 
 	var buf bytes.Buffer
@@ -117,8 +120,8 @@ func Test1EncodeDecode(t *testing.T) {
 	}
 
 	if !tt.Equal(tnew) {
-		t.Logf("in: %v", tt)
-		t.Logf("out: %v", tnew)
+		t.Logf("in: %#v", tt)
+		t.Logf("out: %#v", tnew)
 		t.Fatal("objects not equal")
 	}
 

--- a/_generated/issue247.go
+++ b/_generated/issue247.go
@@ -1,0 +1,7 @@
+package _generated
+
+//go:generate msgp
+
+type T247 struct {
+	S []string
+}

--- a/_generated/issue247_test.go
+++ b/_generated/issue247_test.go
@@ -1,0 +1,19 @@
+package _generated
+
+import (
+	"bytes"
+	"github.com/tinylib/msgp/msgp"
+	"testing"
+)
+
+func TestIssue247(t *testing.T) {
+	buf := bytes.Buffer{}
+	test := T247{}
+
+	msgp.Encode(&buf, &T247{S: []string{}})
+	msgp.Decode(&buf, &test)
+
+	if test.S == nil {
+		t.Errorf("expected slice to not be nil")
+	}
+}

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -376,7 +376,7 @@ func (p *printer) wrapErrCheck(ctx string) {
 }
 
 func (p *printer) resizeSlice(size string, s *Slice) {
-	p.printf("\nif cap(%[1]s) >= int(%[2]s) { %[1]s = (%[1]s)[:%[2]s] } else { %[1]s = make(%[3]s, %[2]s) }", s.Varname(), size, s.TypeName())
+	p.printf("\nif cap(%[1]s) >= int(%[2]s) { if (%[1]s == nil) { %[1]s = make(%[3]s, 0) } else { %[1]s = (%[1]s)[:%[2]s] } } else { %[1]s = make(%[3]s, %[2]s) }", s.Varname(), size, s.TypeName())
 }
 
 func (p *printer) arrayCheck(want string, got string) {


### PR DESCRIPTION
This change makes it so that when a 0 length slice is present in the
msgp data a 0 length slice will be allocated in Go, instead of nil.

This means msgp data generated using this library will always result in
a slice being allocated as this library doesn't contain any conditional
code to not emit the slice header if a slice is nil. Other libraries
that do omit the slice header will still result in a nil slice if the
slice is completely missing from the msgp data.

Fixes #247

@philhofer you might also want to think about changing the marshal code to not at all emit the slice/map headers if the slice/map is `nil`. This will result in less data and would allow users to differentiate between `nil` and empty.
Both this change and that suggested change are backwards incompatible if users depend on a certain `nil`/empty behavior.