### PR TITLE
 Adding Power on support to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: go
 
+arch:
+  - amd64
+  - ppc64le
 go:
   - 1.14.x
   - tip
@@ -7,5 +10,15 @@ go:
 env:
   - GIMME_ARCH=amd64
   - GIMME_ARCH=386
+  - GIMME_ARCH=ppc64le
+jobs: 
+  exclude:
+    - arch: ppc64le
+      env:  GIMME_ARCH=amd64
+    - arch: ppc64le
+      env:  GIMME_ARCH=386
+    - arch: amd64
+      env:  GIMME_ARCH=ppc64le
+
 
 script: "make travis"


### PR DESCRIPTION
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly, 
we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.
