### PR TITLE
msgp/unsafe: bring code in line with unsafe guidelines

### DIFF
--- a/msgp/unsafe.go
+++ b/msgp/unsafe.go
@@ -3,7 +3,6 @@
 package msgp
 
 import (
-	"reflect"
 	"unsafe"
 )
 
@@ -24,18 +23,14 @@ const (
 // THIS IS EVIL CODE.
 // YOU HAVE BEEN WARNED.
 func UnsafeString(b []byte) string {
-	sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	return *(*string)(unsafe.Pointer(&reflect.StringHeader{Data: sh.Data, Len: sh.Len}))
+	return *(*string)(unsafe.Pointer(&b))
 }
 
 // UnsafeBytes returns the string as a byte slice
-// THIS SHOULD ONLY BE USED BY THE CODE GENERATOR.
-// THIS IS EVIL CODE.
-// YOU HAVE BEEN WARNED.
+//
+// Deprecated:
+// Since this code is no longer used by the code generator,
+// UnsafeBytes(s) is precisely equivalent to []byte(s)
 func UnsafeBytes(s string) []byte {
-	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-		Len:  len(s),
-		Cap:  len(s),
-		Data: (*(*reflect.StringHeader)(unsafe.Pointer(&s))).Data,
-	}))
+	return []byte(s)
 }


### PR DESCRIPTION
At some point the guidelines for unsafe[1] were changed
such that allocating a variable of type 'reflect.StringHeader'
or 'reflect.SliceHeader' is no longer permitted, and 'go vet'
will soon reject code that does so[2].

Change the implementation of UnsafeString to avoid using
an intermediate StringHeader altogether, and deprecate UnsafeBytes,
as the new guidelines seem to indicate it cannot be implemented
safely (escape analysis may not handle it correctly).

[1] https://golang.org/pkg/unsafe/
[2] https://github.com/golang/go/issues/40701