### PR TITLE
Feature: New msgp option to recursively compile all Go files in a directory

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,20 +117,20 @@ func compileDir(dir string, mode gen.Method) {
 	}
 	defer d.Close()
 
-	fid, err := d.ReadDir(-1)
+	fis, err := d.Readdir(-1)
 	if err != nil {
 		exitln("Cannot read files in " + dir + ": " + err.Error())
 	}
 
 	var names []string
-	for _, entry := range fid {
-		name := entry.Name()
-		skip := !entry.IsDir() &&
+	for _, fi = range fis {
+		name := fi.Name()
+		skip := !fi.IsDir() &&
 			(name == "." || name == ".." || filepath.Ext(name) != ".go" || strings.HasSuffix(name, "_gen.go"))
 		if skip {
 			continue
 		}
-		if !entry.IsDir() {
+		if !fi.IsDir() {
 			names = append(names, filepath.Join(dir, name))
 		} else {
 			subPath := filepath.Join(dir, name)


### PR DESCRIPTION
Allow providing a directory to recursively compile all Go files. When the new `dir` argument is provided the arguments `file` nd `out` will be ignored.

This is useful to have only one `go generate` for all your project in the main file. For example:

```go
package main

//go:generate go get -u github.com/tinylib/msgp
//go:generate msgp -io=false -tests=false -dir=../../internal/entities

func main() {
  // ...
}
```