### PR TITLE
msgp: fix dropped test errors

### DIFF
--- a/msgp/number_test.go
+++ b/msgp/number_test.go
@@ -80,6 +80,9 @@ func TestNumber(t *testing.T) {
 			t.Fatal("marshal error:", err)
 		}
 		err = dout[i].EncodeMsg(wr)
+		if err != nil {
+			t.Fatal("encode error", err)
+		}
 	}
 	wr.Flush()
 

--- a/msgp/read_test.go
+++ b/msgp/read_test.go
@@ -507,6 +507,9 @@ func TestReadUint64(t *testing.T) {
 			t.Fatal(err)
 		}
 		out, err := rd.ReadUint64()
+		if err != nil {
+			t.Fatal(err)
+		}
 		if out != num {
 			t.Errorf("Test case %d: put %d in and got %d out", i, num, out)
 		}


### PR DESCRIPTION
This fixes two dropped `err` variables in the `msgp` tests.