### PR TITLE
TinyGo support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: bionic
+
 language: go
 
 arch:
@@ -5,8 +7,8 @@ arch:
   - ppc64le
   - arm64
 go:
-  - 1.14.x
   - 1.15.x
+  - 1.16.x
   - tip
 
 jobs:
@@ -17,3 +19,4 @@ jobs:
       env: GIMME_ARCH=386
 
 script: "make travis"
+

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ all: install $(GGEN) $(MGEN)
 
 # travis CI enters here
 travis:
+	arch
+	if [ `arch` == 'x86_64' ]; then sudo apt update; sudo apt install build-essential; wget https://github.com/tinygo-org/tinygo/releases/download/v0.18.0/tinygo_0.18.0_amd64.deb; sudo dpkg -i tinygo_0.18.0_amd64.deb; export PATH=$PATH:/usr/local/tinygo/bin; fi
 	go get -d -t ./...
 	go build -o "$${GOPATH%%:*}/bin/msgp" .
 	go generate ./msgp

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/tinylib/msgp
 go 1.14
 
 require (
-	github.com/philhofer/fwd v1.1.1
+	github.com/philhofer/fwd v1.1.2-0.20210722190033-5c56ac6d0bb9
 	golang.org/x/tools v0.0.0-20201022035929-9cf592e881e9
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/philhofer/fwd v1.1.1 h1:GdGcTjf5RNAxwS4QLsiMzJYj5KEvPJD3Abr261yRQXQ=
-github.com/philhofer/fwd v1.1.1/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
+github.com/philhofer/fwd v1.1.2-0.20210722190033-5c56ac6d0bb9 h1:6ob53CVz+ja2i7easAStApZJlh7sxyq3Cm7g1Di6iqA=
+github.com/philhofer/fwd v1.1.2-0.20210722190033-5c56ac6d0bb9/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/msgp/advise_linux.go
+++ b/msgp/advise_linux.go
@@ -1,4 +1,4 @@
-// +build linux,!appengine
+// +build linux,!appengine,!tinygo
 
 package msgp
 

--- a/msgp/advise_other.go
+++ b/msgp/advise_other.go
@@ -1,4 +1,4 @@
-// +build !linux appengine
+// +build !linux,!tinygo appengine
 
 package msgp
 

--- a/msgp/elsize.go
+++ b/msgp/elsize.go
@@ -1,72 +1,107 @@
 package msgp
 
-// size of every object on the wire,
-// plus type information. gives us
-// constant-time type information
-// for traversing composite objects.
-//
-var sizes = [256]bytespec{
-	mnil:      {size: 1, extra: constsize, typ: NilType},
-	mfalse:    {size: 1, extra: constsize, typ: BoolType},
-	mtrue:     {size: 1, extra: constsize, typ: BoolType},
-	mbin8:     {size: 2, extra: extra8, typ: BinType},
-	mbin16:    {size: 3, extra: extra16, typ: BinType},
-	mbin32:    {size: 5, extra: extra32, typ: BinType},
-	mext8:     {size: 3, extra: extra8, typ: ExtensionType},
-	mext16:    {size: 4, extra: extra16, typ: ExtensionType},
-	mext32:    {size: 6, extra: extra32, typ: ExtensionType},
-	mfloat32:  {size: 5, extra: constsize, typ: Float32Type},
-	mfloat64:  {size: 9, extra: constsize, typ: Float64Type},
-	muint8:    {size: 2, extra: constsize, typ: UintType},
-	muint16:   {size: 3, extra: constsize, typ: UintType},
-	muint32:   {size: 5, extra: constsize, typ: UintType},
-	muint64:   {size: 9, extra: constsize, typ: UintType},
-	mint8:     {size: 2, extra: constsize, typ: IntType},
-	mint16:    {size: 3, extra: constsize, typ: IntType},
-	mint32:    {size: 5, extra: constsize, typ: IntType},
-	mint64:    {size: 9, extra: constsize, typ: IntType},
-	mfixext1:  {size: 3, extra: constsize, typ: ExtensionType},
-	mfixext2:  {size: 4, extra: constsize, typ: ExtensionType},
-	mfixext4:  {size: 6, extra: constsize, typ: ExtensionType},
-	mfixext8:  {size: 10, extra: constsize, typ: ExtensionType},
-	mfixext16: {size: 18, extra: constsize, typ: ExtensionType},
-	mstr8:     {size: 2, extra: extra8, typ: StrType},
-	mstr16:    {size: 3, extra: extra16, typ: StrType},
-	mstr32:    {size: 5, extra: extra32, typ: StrType},
-	marray16:  {size: 3, extra: array16v, typ: ArrayType},
-	marray32:  {size: 5, extra: array32v, typ: ArrayType},
-	mmap16:    {size: 3, extra: map16v, typ: MapType},
-	mmap32:    {size: 5, extra: map32v, typ: MapType},
-}
+func calcBytespec(v byte) bytespec {
 
-func init() {
-	// set up fixed fields
+	// single byte values
+	switch v {
+
+	case mnil:
+		return bytespec{size: 1, extra: constsize, typ: NilType}
+	case mfalse:
+		return bytespec{size: 1, extra: constsize, typ: BoolType}
+	case mtrue:
+		return bytespec{size: 1, extra: constsize, typ: BoolType}
+	case mbin8:
+		return bytespec{size: 2, extra: extra8, typ: BinType}
+	case mbin16:
+		return bytespec{size: 3, extra: extra16, typ: BinType}
+	case mbin32:
+		return bytespec{size: 5, extra: extra32, typ: BinType}
+	case mext8:
+		return bytespec{size: 3, extra: extra8, typ: ExtensionType}
+	case mext16:
+		return bytespec{size: 4, extra: extra16, typ: ExtensionType}
+	case mext32:
+		return bytespec{size: 6, extra: extra32, typ: ExtensionType}
+	case mfloat32:
+		return bytespec{size: 5, extra: constsize, typ: Float32Type}
+	case mfloat64:
+		return bytespec{size: 9, extra: constsize, typ: Float64Type}
+	case muint8:
+		return bytespec{size: 2, extra: constsize, typ: UintType}
+	case muint16:
+		return bytespec{size: 3, extra: constsize, typ: UintType}
+	case muint32:
+		return bytespec{size: 5, extra: constsize, typ: UintType}
+	case muint64:
+		return bytespec{size: 9, extra: constsize, typ: UintType}
+	case mint8:
+		return bytespec{size: 2, extra: constsize, typ: IntType}
+	case mint16:
+		return bytespec{size: 3, extra: constsize, typ: IntType}
+	case mint32:
+		return bytespec{size: 5, extra: constsize, typ: IntType}
+	case mint64:
+		return bytespec{size: 9, extra: constsize, typ: IntType}
+	case mfixext1:
+		return bytespec{size: 3, extra: constsize, typ: ExtensionType}
+	case mfixext2:
+		return bytespec{size: 4, extra: constsize, typ: ExtensionType}
+	case mfixext4:
+		return bytespec{size: 6, extra: constsize, typ: ExtensionType}
+	case mfixext8:
+		return bytespec{size: 10, extra: constsize, typ: ExtensionType}
+	case mfixext16:
+		return bytespec{size: 18, extra: constsize, typ: ExtensionType}
+	case mstr8:
+		return bytespec{size: 2, extra: extra8, typ: StrType}
+	case mstr16:
+		return bytespec{size: 3, extra: extra16, typ: StrType}
+	case mstr32:
+		return bytespec{size: 5, extra: extra32, typ: StrType}
+	case marray16:
+		return bytespec{size: 3, extra: array16v, typ: ArrayType}
+	case marray32:
+		return bytespec{size: 5, extra: array32v, typ: ArrayType}
+	case mmap16:
+		return bytespec{size: 3, extra: map16v, typ: MapType}
+	case mmap32:
+		return bytespec{size: 5, extra: map32v, typ: MapType}
+	}
+
+	switch {
 
 	// fixint
-	for i := mfixint; i < 0x80; i++ {
-		sizes[i] = bytespec{size: 1, extra: constsize, typ: IntType}
-	}
+	case v >= mfixint && v < 0x80:
+		return bytespec{size: 1, extra: constsize, typ: IntType}
 
-	// nfixint
-	for i := uint16(mnfixint); i < 0x100; i++ {
-		sizes[uint8(i)] = bytespec{size: 1, extra: constsize, typ: IntType}
-	}
-
-	// fixstr gets constsize,
-	// since the prefix yields the size
-	for i := mfixstr; i < 0xc0; i++ {
-		sizes[i] = bytespec{size: 1 + rfixstr(i), extra: constsize, typ: StrType}
-	}
+	// fixstr gets constsize, since the prefix yields the size
+	case v >= mfixstr && v < 0xc0:
+		return bytespec{size: 1 + rfixstr(v), extra: constsize, typ: StrType}
 
 	// fixmap
-	for i := mfixmap; i < 0x90; i++ {
-		sizes[i] = bytespec{size: 1, extra: varmode(2 * rfixmap(i)), typ: MapType}
-	}
+	case v >= mfixmap && v < 0x90:
+		return bytespec{size: 1, extra: varmode(2 * rfixmap(v)), typ: MapType}
 
 	// fixarray
-	for i := mfixarray; i < 0xa0; i++ {
-		sizes[i] = bytespec{size: 1, extra: varmode(rfixarray(i)), typ: ArrayType}
+	case v >= mfixarray && v < 0xa0:
+		return bytespec{size: 1, extra: varmode(rfixarray(v)), typ: ArrayType}
+
+	// nfixint
+	case v >= mnfixint && uint16(v) < 0x100:
+		return bytespec{size: 1, extra: constsize, typ: IntType}
+
 	}
+
+	// 0xC1 is unused per the spec and falls through to here,
+	// everything else is covered above
+
+	return bytespec{}
+
+}
+
+func getType(v byte) Type {
+	return getBytespec(v).typ
 }
 
 // a valid bytespsec has
@@ -93,7 +128,3 @@ const (
 	array16v          = -6 // use array16
 	array32v          = -7 // use array32
 )
-
-func getType(v byte) Type {
-	return sizes[v].typ
-}

--- a/msgp/elsize_default.go
+++ b/msgp/elsize_default.go
@@ -1,0 +1,21 @@
+// +build !tinygo
+
+package msgp
+
+// size of every object on the wire,
+// plus type information. gives us
+// constant-time type information
+// for traversing composite objects.
+//
+var sizes [256]bytespec
+
+func init() {
+	for i := 0; i < 256; i++ {
+		sizes[i] = calcBytespec(byte(i))
+	}
+}
+
+// getBytespec gets inlined to a simple array index
+func getBytespec(v byte) bytespec {
+	return sizes[v]
+}

--- a/msgp/elsize_test.go
+++ b/msgp/elsize_test.go
@@ -1,0 +1,96 @@
+package msgp
+
+import "testing"
+
+func TestBytespec(t *testing.T) {
+
+	// verify that bytespec refactor for TinyGo behaves the same as the old code
+
+	// previous sizes array setup verbatim:
+
+	// size of every object on the wire,
+	// plus type information. gives us
+	// constant-time type information
+	// for traversing composite objects.
+	//
+	var sizes = [256]bytespec{
+		mnil:      {size: 1, extra: constsize, typ: NilType},
+		mfalse:    {size: 1, extra: constsize, typ: BoolType},
+		mtrue:     {size: 1, extra: constsize, typ: BoolType},
+		mbin8:     {size: 2, extra: extra8, typ: BinType},
+		mbin16:    {size: 3, extra: extra16, typ: BinType},
+		mbin32:    {size: 5, extra: extra32, typ: BinType},
+		mext8:     {size: 3, extra: extra8, typ: ExtensionType},
+		mext16:    {size: 4, extra: extra16, typ: ExtensionType},
+		mext32:    {size: 6, extra: extra32, typ: ExtensionType},
+		mfloat32:  {size: 5, extra: constsize, typ: Float32Type},
+		mfloat64:  {size: 9, extra: constsize, typ: Float64Type},
+		muint8:    {size: 2, extra: constsize, typ: UintType},
+		muint16:   {size: 3, extra: constsize, typ: UintType},
+		muint32:   {size: 5, extra: constsize, typ: UintType},
+		muint64:   {size: 9, extra: constsize, typ: UintType},
+		mint8:     {size: 2, extra: constsize, typ: IntType},
+		mint16:    {size: 3, extra: constsize, typ: IntType},
+		mint32:    {size: 5, extra: constsize, typ: IntType},
+		mint64:    {size: 9, extra: constsize, typ: IntType},
+		mfixext1:  {size: 3, extra: constsize, typ: ExtensionType},
+		mfixext2:  {size: 4, extra: constsize, typ: ExtensionType},
+		mfixext4:  {size: 6, extra: constsize, typ: ExtensionType},
+		mfixext8:  {size: 10, extra: constsize, typ: ExtensionType},
+		mfixext16: {size: 18, extra: constsize, typ: ExtensionType},
+		mstr8:     {size: 2, extra: extra8, typ: StrType},
+		mstr16:    {size: 3, extra: extra16, typ: StrType},
+		mstr32:    {size: 5, extra: extra32, typ: StrType},
+		marray16:  {size: 3, extra: array16v, typ: ArrayType},
+		marray32:  {size: 5, extra: array32v, typ: ArrayType},
+		mmap16:    {size: 3, extra: map16v, typ: MapType},
+		mmap32:    {size: 5, extra: map32v, typ: MapType},
+	}
+
+	//func init() {
+	// set up fixed fields
+
+	// fixint
+	for i := mfixint; i < 0x80; i++ {
+		sizes[i] = bytespec{size: 1, extra: constsize, typ: IntType}
+	}
+
+	// nfixint
+	for i := uint16(mnfixint); i < 0x100; i++ {
+		sizes[uint8(i)] = bytespec{size: 1, extra: constsize, typ: IntType}
+	}
+
+	// fixstr gets constsize,
+	// since the prefix yields the size
+	for i := mfixstr; i < 0xc0; i++ {
+		sizes[i] = bytespec{size: 1 + rfixstr(i), extra: constsize, typ: StrType}
+	}
+
+	// fixmap
+	for i := mfixmap; i < 0x90; i++ {
+		sizes[i] = bytespec{size: 1, extra: varmode(2 * rfixmap(i)), typ: MapType}
+	}
+
+	// fixarray
+	for i := mfixarray; i < 0xa0; i++ {
+		sizes[i] = bytespec{size: 1, extra: varmode(rfixarray(i)), typ: ArrayType}
+	}
+	//}
+
+	// compare all values to calcBytespec
+	for i := 0; i < 256; i++ {
+
+		sizeb := sizes[byte(i)]
+		cb := calcBytespec(byte(i))
+		if sizeb != cb {
+			t.Errorf("at index 0x%x calculated sizes array %#v does not match calcBytespec %#v", i, sizeb, cb)
+		}
+
+		// all except the unused byte C1 should have non-zero size
+		if i != 0xC1 && sizeb.size == 0 {
+			t.Errorf("unexpected zero size for index 0x%x", i)
+		}
+
+	}
+
+}

--- a/msgp/elsize_tinygo.go
+++ b/msgp/elsize_tinygo.go
@@ -1,0 +1,12 @@
+// +build tinygo
+
+package msgp
+
+// for tinygo, getBytespec just calls calcBytespec
+// a simple/slow function with a switch statement -
+// doesn't require any heap alloc, moves the space
+// requirements into code instad of ram
+
+func getBytespec(v byte) bytespec {
+	return calcBytespec(v)
+}

--- a/msgp/errors.go
+++ b/msgp/errors.go
@@ -1,8 +1,8 @@
 package msgp
 
 import (
-	"fmt"
 	"reflect"
+	"strconv"
 )
 
 const resumableDefault = false
@@ -81,18 +81,6 @@ func WrapError(err error, ctx ...interface{}) error {
 	}
 }
 
-// ctxString converts the incoming interface{} slice into a single string.
-func ctxString(ctx []interface{}) string {
-	out := ""
-	for idx, cv := range ctx {
-		if idx > 0 {
-			out += "/"
-		}
-		out += fmt.Sprintf("%v", cv)
-	}
-	return out
-}
-
 func addCtx(ctx, add string) string {
 	if ctx != "" {
 		return add + "/" + ctx
@@ -110,7 +98,7 @@ type errWrapped struct {
 
 func (e errWrapped) Error() string {
 	if e.ctx != "" {
-		return fmt.Sprintf("%s at %s", e.cause, e.ctx)
+		return e.cause.Error() + " at " + e.ctx
 	} else {
 		return e.cause.Error()
 	}
@@ -158,7 +146,7 @@ type ArrayError struct {
 
 // Error implements the error interface
 func (a ArrayError) Error() string {
-	out := fmt.Sprintf("msgp: wanted array of size %d; got %d", a.Wanted, a.Got)
+	out := "msgp: wanted array of size " + strconv.Itoa(int(a.Wanted)) + "; got " + strconv.Itoa(int(a.Got))
 	if a.ctx != "" {
 		out += " at " + a.ctx
 	}
@@ -181,7 +169,7 @@ type IntOverflow struct {
 
 // Error implements the error interface
 func (i IntOverflow) Error() string {
-	str := fmt.Sprintf("msgp: %d overflows int%d", i.Value, i.FailedBitsize)
+	str := "msgp: " + strconv.FormatInt(i.Value, 10) + " overflows int" + strconv.Itoa(i.FailedBitsize)
 	if i.ctx != "" {
 		str += " at " + i.ctx
 	}
@@ -204,7 +192,7 @@ type UintOverflow struct {
 
 // Error implements the error interface
 func (u UintOverflow) Error() string {
-	str := fmt.Sprintf("msgp: %d overflows uint%d", u.Value, u.FailedBitsize)
+	str := "msgp: " + strconv.FormatUint(u.Value, 10) + " overflows uint" + strconv.Itoa(u.FailedBitsize)
 	if u.ctx != "" {
 		str += " at " + u.ctx
 	}
@@ -226,7 +214,7 @@ type UintBelowZero struct {
 
 // Error implements the error interface
 func (u UintBelowZero) Error() string {
-	str := fmt.Sprintf("msgp: attempted to cast int %d to unsigned", u.Value)
+	str := "msgp: attempted to cast int " + strconv.FormatInt(u.Value, 10) + " to unsigned"
 	if u.ctx != "" {
 		str += " at " + u.ctx
 	}
@@ -253,7 +241,7 @@ type TypeError struct {
 
 // Error implements the error interface
 func (t TypeError) Error() string {
-	out := fmt.Sprintf("msgp: attempted to decode type %q with method for %q", t.Encoded, t.Method)
+	out := "msgp: attempted to decode type " + quoteStr(t.Encoded.String()) + " with method for " + quoteStr(t.Method.String())
 	if t.ctx != "" {
 		out += " at " + t.ctx
 	}
@@ -269,7 +257,7 @@ func (t TypeError) withContext(ctx string) error { t.ctx = addCtx(t.ctx, ctx); r
 // TypeError depending on whether or not
 // the prefix is recognized
 func badPrefix(want Type, lead byte) error {
-	t := sizes[lead].typ
+	t := getType(lead)
 	if t == InvalidType {
 		return InvalidPrefixError(lead)
 	}
@@ -283,7 +271,7 @@ type InvalidPrefixError byte
 
 // Error implements the error interface
 func (i InvalidPrefixError) Error() string {
-	return fmt.Sprintf("msgp: unrecognized type prefix 0x%x", byte(i))
+	return "msgp: unrecognized type prefix 0x" + strconv.FormatInt(int64(i), 16)
 }
 
 // Resumable returns 'false' for InvalidPrefixErrors
@@ -300,7 +288,7 @@ type ErrUnsupportedType struct {
 
 // Error implements error
 func (e *ErrUnsupportedType) Error() string {
-	out := fmt.Sprintf("msgp: type %q not supported", e.T)
+	out := "msgp: type " + quoteStr(e.T.String()) + " not supported"
 	if e.ctx != "" {
 		out += " at " + e.ctx
 	}
@@ -314,4 +302,60 @@ func (e *ErrUnsupportedType) withContext(ctx string) error {
 	o := *e
 	o.ctx = addCtx(o.ctx, ctx)
 	return &o
+}
+
+// simpleQuoteStr is a simplified version of strconv.Quote for TinyGo,
+// which takes up a lot less code space by escaping all non-ASCII
+// (UTF-8) bytes with \x.  Saves about 4k of code size
+// (unicode tables, needed for IsPrint(), are big).
+// It lives in errors.go just so we can test it in errors_test.go
+func simpleQuoteStr(s string) string {
+
+	const (
+		lowerhex = "0123456789abcdef"
+	)
+
+	sb := make([]byte, 0, len(s)+2)
+
+	sb = append(sb, `"`...)
+
+l: // loop through string bytes (not UTF-8 characters)
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		// specific escape chars
+		switch b {
+		case '\\':
+			sb = append(sb, `\\`...)
+		case '"':
+			sb = append(sb, `\"`...)
+		case '\a':
+			sb = append(sb, `\a`...)
+		case '\b':
+			sb = append(sb, `\b`...)
+		case '\f':
+			sb = append(sb, `\f`...)
+		case '\n':
+			sb = append(sb, `\n`...)
+		case '\r':
+			sb = append(sb, `\r`...)
+		case '\t':
+			sb = append(sb, `\t`...)
+		case '\v':
+			sb = append(sb, `\v`...)
+		default:
+			// no escaping needed (printable ASCII)
+			if b >= 0x20 && b <= 0x7E {
+				sb = append(sb, b)
+				continue l
+			}
+			// anything else is \x
+			sb = append(sb, `\x`...)
+			sb = append(sb, lowerhex[byte(b)>>4])
+			sb = append(sb, lowerhex[byte(b)&0xF])
+			continue l
+		}
+	}
+
+	sb = append(sb, `"`...)
+	return string(sb)
 }

--- a/msgp/errors_default.go
+++ b/msgp/errors_default.go
@@ -1,0 +1,24 @@
+// +build !tinygo
+
+package msgp
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// ctxString converts the incoming interface{} slice into a single string.
+func ctxString(ctx []interface{}) string {
+	out := ""
+	for idx, cv := range ctx {
+		if idx > 0 {
+			out += "/"
+		}
+		out += fmt.Sprintf("%v", cv)
+	}
+	return out
+}
+
+func quoteStr(s string) string {
+	return strconv.Quote(s)
+}

--- a/msgp/errors_test.go
+++ b/msgp/errors_test.go
@@ -129,3 +129,57 @@ func TestUnwrap(t *testing.T) {
 	}
 
 }
+
+func TestSimpleQuoteStr(t *testing.T) {
+
+	// check some cases for simpleQuoteStr
+	type tcase struct {
+		in  string
+		out string
+	}
+	tcaseList := []tcase{
+		{
+			in:  ``,
+			out: `""`,
+		},
+		{
+			in:  `abc`,
+			out: `"abc"`,
+		},
+		{
+			in:  `"`,
+			out: `"\""`,
+		},
+		{
+			in:  `'`,
+			out: `"'"`,
+		},
+		{
+			in:  `on🔥!`,
+			out: `"on\xf0\x9f\x94\xa5!"`,
+		},
+		{
+			in:  "line\r\nbr",
+			out: `"line\r\nbr"`,
+		},
+		{
+			in:  "\x00",
+			out: `"\x00"`,
+		},
+		{ // invalid UTF-8 should make no difference but check it regardless
+			in:  "not\x80valid",
+			out: `"not\x80valid"`,
+		},
+	}
+
+	for i, tc := range tcaseList {
+		tc := tc
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			out := simpleQuoteStr(tc.in)
+			if out != tc.out {
+				t.Errorf("input %q; expected: %s; but got: %s", tc.in, tc.out, out)
+			}
+		})
+	}
+
+}

--- a/msgp/errors_tinygo.go
+++ b/msgp/errors_tinygo.go
@@ -1,0 +1,43 @@
+// +build tinygo
+
+package msgp
+
+import (
+	"reflect"
+)
+
+// ctxString converts the incoming interface{} slice into a single string,
+// without using fmt under tinygo
+func ctxString(ctx []interface{}) string {
+	out := ""
+	for idx, cv := range ctx {
+		if idx > 0 {
+			out += "/"
+		}
+		out += ifToStr(cv)
+	}
+	return out
+}
+
+type stringer interface {
+	String() string
+}
+
+func ifToStr(i interface{}) string {
+
+	switch v := i.(type) {
+	case stringer:
+		return v.String()
+	case error:
+		return v.Error()
+	case string:
+		return v
+	default:
+		return reflect.ValueOf(i).String()
+	}
+
+}
+
+func quoteStr(s string) string {
+	return simpleQuoteStr(s)
+}

--- a/msgp/extension.go
+++ b/msgp/extension.go
@@ -1,8 +1,9 @@
 package msgp
 
 import (
-	"fmt"
+	"errors"
 	"math"
+	"strconv"
 )
 
 const (
@@ -38,10 +39,10 @@ var extensionReg = make(map[int8]func() Extension)
 func RegisterExtension(typ int8, f func() Extension) {
 	switch typ {
 	case Complex64Extension, Complex128Extension, TimeExtension:
-		panic(fmt.Sprint("msgp: forbidden extension type:", typ))
+		panic(errors.New("msgp: forbidden extension type: " + strconv.Itoa(int(typ))))
 	}
 	if _, ok := extensionReg[typ]; ok {
-		panic(fmt.Sprint("msgp: RegisterExtension() called with typ", typ, "more than once"))
+		panic(errors.New("msgp: RegisterExtension() called with typ " + strconv.Itoa(int(typ)) + " more than once"))
 	}
 	extensionReg[typ] = f
 }
@@ -56,7 +57,7 @@ type ExtensionTypeError struct {
 
 // Error implements the error interface
 func (e ExtensionTypeError) Error() string {
-	return fmt.Sprintf("msgp: error decoding extension: wanted type %d; got type %d", e.Want, e.Got)
+	return "msgp: error decoding extension: wanted type " + strconv.Itoa(int(e.Want)) + "; got type " + strconv.Itoa(int(e.Got))
 }
 
 // Resumable returns 'true' for ExtensionTypeErrors
@@ -230,7 +231,7 @@ func (m *Reader) peekExtensionType() (int8, error) {
 	if err != nil {
 		return 0, err
 	}
-	spec := sizes[p[0]]
+	spec := getBytespec(p[0])
 	if spec.typ != ExtensionType {
 		return 0, badPrefix(ExtensionType, p[0])
 	}
@@ -248,7 +249,7 @@ func (m *Reader) peekExtensionType() (int8, error) {
 // peekExtension peeks at the extension encoding type
 // (must guarantee at least 1 byte in 'b')
 func peekExtension(b []byte) (int8, error) {
-	spec := sizes[b[0]]
+	spec := getBytespec(b[0])
 	size := spec.size
 	if spec.typ != ExtensionType {
 		return 0, badPrefix(ExtensionType, b[0])

--- a/msgp/file.go
+++ b/msgp/file.go
@@ -1,5 +1,5 @@
 // +build linux darwin dragonfly freebsd netbsd openbsd
-// +build !appengine
+// +build !appengine,!tinygo
 
 package msgp
 

--- a/msgp/file_port.go
+++ b/msgp/file_port.go
@@ -1,4 +1,4 @@
-// +build windows appengine
+// +build windows appengine tinygo
 
 package msgp
 

--- a/msgp/read.go
+++ b/msgp/read.go
@@ -262,7 +262,7 @@ func getNextSize(r *fwd.Reader) (uintptr, uintptr, error) {
 		return 0, 0, err
 	}
 	lead := b[0]
-	spec := &sizes[lead]
+	spec := getBytespec(lead)
 	size, mode := spec.size, spec.extra
 	if size == 0 {
 		return 0, 0, InvalidPrefixError(lead)

--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -17,7 +17,7 @@ func NextType(b []byte) Type {
 	if len(b) == 0 {
 		return InvalidType
 	}
-	spec := sizes[b[0]]
+	spec := getBytespec(b[0])
 	t := spec.typ
 	if t == ExtensionType && len(b) > int(spec.size) {
 		var tp int8
@@ -1205,7 +1205,7 @@ func getSize(b []byte) (uintptr, uintptr, error) {
 		return 0, 0, ErrShortBytes
 	}
 	lead := b[0]
-	spec := &sizes[lead] // get type information
+	spec := getBytespec(lead) // get type information
 	size, mode := spec.size, spec.extra
 	if size == 0 {
 		return 0, 0, InvalidPrefixError(lead)

--- a/msgp/write.go
+++ b/msgp/write.go
@@ -2,7 +2,6 @@ package msgp
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"math"
 	"reflect"
@@ -687,7 +686,7 @@ func (mw *Writer) WriteIntf(v interface{}) error {
 
 	val := reflect.ValueOf(v)
 	if !isSupported(val.Kind()) || !val.IsValid() {
-		return fmt.Errorf("msgp: type %s not supported", val)
+		return errors.New("msgp: type " + val.String() + " not supported")
 	}
 
 	switch val.Kind() {
@@ -751,12 +750,12 @@ func (mw *Writer) writeStruct(v reflect.Value) error {
 	if enc, ok := v.Interface().(Encodable); ok {
 		return enc.EncodeMsg(mw)
 	}
-	return fmt.Errorf("msgp: unsupported type: %s", v.Type())
+	return errors.New("msgp: unsupported type: " + v.Type().String())
 }
 
 func (mw *Writer) writeVal(v reflect.Value) error {
 	if !isSupported(v.Kind()) {
-		return fmt.Errorf("msgp: msgp/enc: type %q not supported", v.Type())
+		return errors.New("msgp: msgp/enc: type not supported: " + v.Type().String())
 	}
 
 	// shortcut for nil values
@@ -798,7 +797,7 @@ func (mw *Writer) writeVal(v reflect.Value) error {
 		return mw.writeStruct(v)
 
 	}
-	return fmt.Errorf("msgp: msgp/enc: type %q not supported", v.Type())
+	return errors.New("msgp: msgp/enc: type not supported: " + v.Type().String())
 }
 
 // is the reflect.Kind encodable?

--- a/tinygotest/.gitignore
+++ b/tinygotest/.gitignore
@@ -1,0 +1,10 @@
+*_gen.go
+*_gen_test.go
+*.out
+*.bin
+*.hex
+*.wasm
+*.wasi
+nativebin
+tmp*
+

--- a/tinygotest/testdata/empty/main.go
+++ b/tinygotest/testdata/empty/main.go
@@ -1,0 +1,7 @@
+package main
+
+// baseline file just so we can compare the size
+
+func main() {
+	println("successfully did nothing")
+}

--- a/tinygotest/testdata/roundtrip/main.go
+++ b/tinygotest/testdata/roundtrip/main.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"bytes"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+//go:generate msgp
+
+type SomeStruct struct {
+	A string `msg:"a"`
+}
+
+type EmbeddedStruct struct {
+	A string `msg:"a"`
+}
+
+// Example provides a decent variety of types and features and
+// lets us test for basic functionality in TinyGo.
+type Example struct {
+	Int64       int64      `msg:"int64"`
+	Uint64      uint64     `msg:"uint64"`
+	Int32       int32      `msg:"int32"`
+	Uint32      uint32     `msg:"uint32"`
+	Int16       int32      `msg:"int16"`
+	Uint16      uint32     `msg:"uint16"`
+	Int8        int32      `msg:"int8"`
+	Byte        byte       `msg:"byte"`
+	Float64     float64    `msg:"float64"`
+	Float32     float32    `msg:"float32"`
+	String      string     `msg:"string"`
+	ByteSlice   []byte     `msg:"byte_slice"`
+	StringSlice []string   `msg:"string_slice"`
+	IntArray    [2]int     `msg:"int_array"`
+	SomeStruct  SomeStruct `msg:"some_struct"`
+
+	EmbeddedStruct
+
+	Omitted string `msg:"-"`
+
+	OmitEmptyString string `msg:"omit_empty_string,omitempty"`
+}
+
+// Setup populuates the struct with test data
+func (e *Example) Setup() {
+	e.Int64 = 10
+	e.Uint64 = 11
+	e.Int32 = 12
+	e.Uint32 = 13
+	e.Int16 = 14
+	e.Uint16 = 15
+	e.Int8 = 16
+	e.Byte = 17
+	e.Float64 = 18.1
+	e.Float32 = 19.2
+	e.String = "astr"
+	e.ByteSlice = []byte("bstr")
+	e.StringSlice = []string{"a", "b"}
+	e.IntArray = [...]int{20, 21}
+	e.SomeStruct = SomeStruct{A: "x"}
+
+	e.EmbeddedStruct = EmbeddedStruct{A: "y"}
+
+	e.Omitted = "nope"
+
+	e.OmitEmptyString = "here"
+
+}
+
+func (e *Example) Eq(e2 *Example) bool {
+	if e.Int64 != e2.Int64 {
+		return false
+	}
+	if e.Uint64 != e2.Uint64 {
+		return false
+	}
+	if e.Int32 != e2.Int32 {
+		return false
+	}
+	if e.Uint32 != e2.Uint32 {
+		return false
+	}
+	if e.Int16 != e2.Int16 {
+		return false
+	}
+	if e.Uint16 != e2.Uint16 {
+		return false
+	}
+	if e.Int8 != e2.Int8 {
+		return false
+	}
+	if e.Byte != e2.Byte {
+		return false
+	}
+	if e.Float64 != e2.Float64 {
+		return false
+	}
+	if e.Float32 != e2.Float32 {
+		return false
+	}
+	if e.String != e2.String {
+		return false
+	}
+	if bytes.Compare(e.ByteSlice, e2.ByteSlice) != 0 {
+		return false
+	}
+	if len(e.StringSlice) != len(e2.StringSlice) {
+		return false
+	}
+	for i := 0; i < len(e.StringSlice); i++ {
+		if e.StringSlice[i] != e2.StringSlice[i] {
+			return false
+		}
+	}
+	if len(e.IntArray) != len(e2.IntArray) {
+		return false
+	}
+	for i := 0; i < len(e.IntArray); i++ {
+		if e.IntArray[i] != e2.IntArray[i] {
+			return false
+		}
+	}
+	if e.SomeStruct.A != e2.SomeStruct.A {
+		return false
+	}
+
+	if e.EmbeddedStruct.A != e2.EmbeddedStruct.A {
+		return false
+	}
+
+	if e.Omitted != e2.Omitted {
+		return false
+	}
+
+	if e.OmitEmptyString != e2.OmitEmptyString {
+		return false
+	}
+
+	return true
+}
+
+var buf [256]byte
+
+func main() {
+
+	var e Example
+	e.Setup()
+
+	b, err := e.MarshalMsg(buf[:0])
+	if err != nil {
+		panic(err)
+	}
+	b1 := b
+
+	var e2 Example
+	_, err = e2.UnmarshalMsg(b)
+	if err != nil {
+		panic(err)
+	}
+
+	println("marshal/unmarshal done: ", &e2)
+
+	e.Omitted = ""
+	if !e.Eq(&e2) {
+		panic("comparison after marshal/unmarhsal failed")
+	}
+
+	var wbuf bytes.Buffer
+	mw := msgp.NewWriterSize(&wbuf, 64)
+
+	e.Omitted = "other"
+	err = e.EncodeMsg(mw)
+	if err != nil {
+		panic(err)
+	}
+	mw.Flush()
+
+	e2 = Example{}
+	mr := msgp.NewReaderSize(bytes.NewReader(wbuf.Bytes()), 64)
+	err = e2.DecodeMsg(mr)
+	if err != nil {
+		panic(err)
+	}
+
+	println("writer/reader done: ", &e2)
+	e.Omitted = ""
+	if !e.Eq(&e2) {
+		panic("comparison after writer/reader failed")
+	}
+
+	if bytes.Compare(wbuf.Bytes(), b1) != 0 {
+		panic("writer and marshal produced different results")
+	}
+
+}

--- a/tinygotest/testdata/simple_bytes_append/main.go
+++ b/tinygotest/testdata/simple_bytes_append/main.go
@@ -1,0 +1,32 @@
+package main
+
+import "github.com/tinylib/msgp/msgp"
+
+type Example struct {
+	I int
+	S string
+}
+
+var buf [64]byte
+
+func main() {
+
+	e := Example{
+		I: 1,
+		S: "2",
+	}
+
+	b := buf[:0]
+	b = msgp.AppendMapHeader(b, 2)
+	b = msgp.AppendString(b, "i")
+	b = msgp.AppendInt(b, e.I)
+	b = msgp.AppendString(b, "s")
+	b = msgp.AppendString(b, e.S)
+
+	println("done, len(b):", len(b))
+	for i := 0; i < len(b); i++ {
+		print(b[i], " ")
+	}
+	println()
+
+}

--- a/tinygotest/testdata/simple_bytes_read/main.go
+++ b/tinygotest/testdata/simple_bytes_read/main.go
@@ -1,0 +1,57 @@
+package main
+
+import "github.com/tinylib/msgp/msgp"
+
+type Example struct {
+	I int
+	S string
+}
+
+func main() {
+
+	b := []byte{130, 161, 105, 1, 161, 115, 161, 50}
+
+	e := Example{}
+
+	sz, b, err := msgp.ReadMapHeaderBytes(b)
+	if err != nil {
+		panic(err)
+	}
+	if sz != 2 {
+		panic("bad sz")
+	}
+
+	for i := 0; i < int(sz); i++ {
+		var sb []byte
+		var i32 int32
+		var err error
+		sb, b, err = msgp.ReadStringZC(b)
+		switch string(sb) {
+		case "i":
+			i32, b, err = msgp.ReadInt32Bytes(b)
+			if err != nil {
+				panic(err)
+			}
+			e.I = int(i32)
+		case "s":
+			sb, b, err = msgp.ReadStringZC(b)
+			if err != nil {
+				panic(err)
+			}
+			e.S = string(sb)
+		default:
+			panic("unexpected field:" + string(sb))
+		}
+	}
+
+	if len(b) != 0 {
+		panic("unexpected extra")
+	}
+
+	if e.I != 1 || e.S != "2" {
+		panic("not equal")
+	}
+
+	println("done")
+
+}

--- a/tinygotest/testdata/simple_marshal/main.go
+++ b/tinygotest/testdata/simple_marshal/main.go
@@ -1,0 +1,27 @@
+package main
+
+//go:generate msgp
+
+type Example struct {
+	I int    `msg:"i"`
+	S string `msg:"s"`
+}
+
+func main() {
+
+	e := Example{
+		I: 1,
+		S: "2",
+	}
+	b, err := e.MarshalMsg(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	println("done, len(b):", len(b))
+	for i := 0; i < len(b); i++ {
+		print(b[i], " ")
+	}
+	println()
+
+}

--- a/tinygotest/testdata/simple_roundtrip/main.go
+++ b/tinygotest/testdata/simple_roundtrip/main.go
@@ -1,0 +1,39 @@
+package main
+
+//go:generate msgp
+
+type Example struct {
+	I int    `msg:"i"`
+	S string `msg:"s"`
+	// NOTE: floats omitted intentionally, many MCUs don't have
+	// native support for it so the binary size bloats just due to
+	// the software float implementation
+}
+
+func main() {
+
+	e := Example{
+		I: 1,
+		S: "2",
+	}
+	b, err := e.MarshalMsg(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	var e2 Example
+	extra, err := e2.UnmarshalMsg(b)
+	if err != nil {
+		panic(err)
+	}
+	if len(extra) != 0 {
+		panic("unexpected extra")
+	}
+
+	if e.I != e2.I || e.S != e2.S {
+		panic("not equal")
+	}
+
+	println("done, len(b):", len(b))
+
+}

--- a/tinygotest/testdata/simple_unmarshal/main.go
+++ b/tinygotest/testdata/simple_unmarshal/main.go
@@ -1,0 +1,29 @@
+package main
+
+//go:generate msgp
+
+type Example struct {
+	I int    `msg:"i"`
+	S string `msg:"s"`
+}
+
+func main() {
+
+	b := []byte{130, 161, 105, 1, 161, 115, 161, 50}
+
+	var e2 Example
+	extra, err := e2.UnmarshalMsg(b)
+	if err != nil {
+		panic(err)
+	}
+	if len(extra) != 0 {
+		panic("unexpected extra")
+	}
+
+	if e2.I != 1 || e2.S != "2" {
+		panic("not equal")
+	}
+
+	println("done, len(b):", len(b))
+
+}

--- a/tinygotest/tinygo_test.go
+++ b/tinygotest/tinygo_test.go
@@ -1,0 +1,250 @@
+// +build amd64 darwin
+
+package tinygotest
+
+// NOTE: this is intended to be run with `go test` not `tinygo test`,
+// as it then in turn performs various `tinygo build` commands and
+// verifies the output.
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// empty gives us a baseline to compare sizes (and to prove that tinygo itself isn't broken)
+
+func TestEmptyRun(t *testing.T) {
+	// build and run native executable
+	tinygoBuild(t, "empty")
+	run(t, "empty", "nativebin")
+}
+
+func TestEmptyBuild(t *testing.T) {
+	// build for various environments
+	tinygoBuild(t, "empty", buildOnlyTargets...)
+	reportSizes(t, "empty")
+}
+
+// roundtrip provides reasonable coverage for various cases, but is
+// fairly bloated in terms of size compared to simpler examples
+
+func TestRoundtripRun(t *testing.T) {
+	// build and run native executable
+	goGenerate(t, "roundtrip")
+	tinygoBuild(t, "roundtrip")
+	run(t, "roundtrip", "nativebin")
+}
+
+func TestRoundtripBuild(t *testing.T) {
+	// build for various environments
+	goGenerate(t, "roundtrip")
+	tinygoBuild(t, "roundtrip", buildOnlyTargets...)
+	reportSizes(t, "roundtrip")
+}
+
+// simple_roundtrip is a minimal marshal+unmarshal example and should show
+// the baseline size when only using minimal functionality and marshal+unmarshal
+
+func TestSimpleRoundtripRun(t *testing.T) {
+	// build and run native executable
+	goGenerate(t, "simple_roundtrip")
+	tinygoBuild(t, "simple_roundtrip")
+	run(t, "simple_roundtrip", "nativebin")
+}
+
+func TestSimpleRoundtripBuild(t *testing.T) {
+	// build for various environments
+	goGenerate(t, "simple_roundtrip")
+	tinygoBuild(t, "simple_roundtrip", buildOnlyTargets...)
+	sizes := reportSizes(t, "simple_roundtrip")
+	// this was ~13k at the time this test was written,
+	// if it bloats up to over 20k, we assume something is wrong
+	// (e.g. "fmt" or other large package being using)
+	sz := sizes["arduino-nano33.bin"]
+	if sz > 20000 {
+		t.Errorf("arduino-nano33.bin is larger than expected: %d", sz)
+	}
+
+}
+
+// simple_marshal is just the MarshalMsg part
+
+func TestSimpleMarshalRun(t *testing.T) {
+	// build and run native executable
+	goGenerate(t, "simple_marshal")
+	tinygoBuild(t, "simple_marshal")
+	run(t, "simple_marshal", "nativebin")
+}
+
+func TestSimpleMarshalBuild(t *testing.T) {
+	// build for various environments
+	goGenerate(t, "simple_marshal")
+	tinygoBuild(t, "simple_marshal", buildOnlyTargets...)
+	reportSizes(t, "simple_marshal")
+}
+
+// simple_unmarshal is just the UnmarshalMsg part
+
+func TestSimpleUnmarshalRun(t *testing.T) {
+	// build and run native executable
+	goGenerate(t, "simple_unmarshal")
+	tinygoBuild(t, "simple_unmarshal")
+	run(t, "simple_unmarshal", "nativebin")
+}
+
+func TestSimpleUnmarshalBuild(t *testing.T) {
+	// build for various environments
+	goGenerate(t, "simple_unmarshal")
+	tinygoBuild(t, "simple_unmarshal", buildOnlyTargets...)
+	reportSizes(t, "simple_unmarshal")
+}
+
+// simple_bytes_append is AppendX() methods without code generation
+
+func TestSimpleBytesAppendRun(t *testing.T) {
+	// build and run native executable
+	goGenerate(t, "simple_bytes_append")
+	tinygoBuild(t, "simple_bytes_append")
+	run(t, "simple_bytes_append", "nativebin")
+}
+
+func TestSimpleBytesAppendBuild(t *testing.T) {
+	// build for various environments
+	goGenerate(t, "simple_bytes_append")
+	tinygoBuild(t, "simple_bytes_append", buildOnlyTargets...)
+	reportSizes(t, "simple_bytes_append")
+}
+
+// simple_bytes_append is ReadX() methods without code generation
+
+func TestSimpleBytesReadRun(t *testing.T) {
+	// build and run native executable
+	goGenerate(t, "simple_bytes_read")
+	tinygoBuild(t, "simple_bytes_read")
+	run(t, "simple_bytes_read", "nativebin")
+}
+
+func TestSimpleBytesReadBuild(t *testing.T) {
+	// build for various environments
+	goGenerate(t, "simple_bytes_read")
+	tinygoBuild(t, "simple_bytes_read", buildOnlyTargets...)
+	reportSizes(t, "simple_bytes_read")
+}
+
+// do builds for these tinygo boards/environments to make sure
+// it at least compiles
+var buildOnlyTargets = []string{
+	"arduino-nano33", // ARM Cortex-M0, SAMD21
+	"feather-m4",     // ARM Cortex-M4, SAMD51
+	"wasm",           // WebAssembly
+
+	// "arduino-nano",       // AVR - roundtrip build currently fails with: could not store type code number inside interface type code
+	// "esp32-coreboard-v2", // ESP - xtensa seems to require additional setup, currently errors with: No available targets are compatible with triple "xtensa"
+}
+
+func run(t *testing.T, dir, exe string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("./" + exe)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd.Dir = filepath.Join(wd, "testdata", dir)
+	cmd.Args = args
+	b, err := cmd.CombinedOutput()
+	if len(bytes.TrimSpace(b)) > 0 {
+		t.Logf("%s: %s %v; output: %s", dir, exe, args, b)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func goGenerate(t *testing.T, dir string) {
+	t.Helper()
+	t.Logf("%s: go generate", dir)
+	cmd := exec.Command("go", "generate")
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd.Dir = filepath.Join(wd, "testdata", dir)
+	b, err := cmd.CombinedOutput()
+	if len(bytes.TrimSpace(b)) > 0 {
+		t.Logf("%s: go generate output: %s", dir, b)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func tinygoBuild(t *testing.T, dir string, targets ...string) {
+
+	t.Helper()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dirabs := filepath.Join(wd, "testdata", dir)
+
+	// no targets specified implies just build the native executable
+	if len(targets) == 0 {
+		targets = []string{""}
+	}
+
+	for _, tgt := range targets {
+
+		ext := ".bin"
+		if tgt == "wasm" {
+			ext = ".wasm"
+		}
+
+		var args []string
+		if tgt == "" { // empty target means the native platform
+			args = []string{"build", "-o=nativebin", "."}
+		} else {
+			args = []string{"build", "-target=" + tgt, "-o=" + tgt + ext, "."}
+		}
+
+		t.Logf("%s: tinygo %v", dir, args)
+		cmd := exec.Command("tinygo", args...)
+		cmd.Dir = dirabs
+		b, err := cmd.CombinedOutput()
+		if len(bytes.TrimSpace(b)) > 0 {
+			t.Logf("%s: tinygo build %v; output: %s", dir, args, b)
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+}
+
+var spacePad = strings.Repeat(" ", 64)
+
+func reportSizes(t *testing.T, dir string) (ret map[string]int64) {
+	ret = make(map[string]int64)
+	var fnl []string
+	for _, gl := range []string{"*.bin", "*.wasm"} {
+		fnl2, err := filepath.Glob(filepath.Join("testdata", dir, gl))
+		if err != nil {
+			t.Fatal(err)
+		}
+		fnl = append(fnl, fnl2...)
+	}
+	for _, fn := range fnl {
+		st, err := os.Stat(fn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, jfn := filepath.Split(fn)
+		t.Logf("size report - %s %6d bytes", (jfn + spacePad)[:24], st.Size())
+		ret[jfn] = st.Size()
+	}
+	return ret
+}


### PR DESCRIPTION
So this (https://github.com/tinylib/msgp/issues/294) turned out to be more involved than I originally thought, but the changes are actually fairly simple:

* **go.mod updated** to use latest `fwd`
* `file*` and `advise*` were **just build tag changes**
* **elsize.go needed an alternate implementation** for TinyGo - the `sizes` lookup table makes sense on regular machines but on a microcontroller it is better to move that into code in the form of a switch statement and save the 1k of RAM.  References in other files to `sizes[x]` were converted to `getBytespec(x)`, which I verified with `go test -gcflags="-m=2"` are inlined by the regular Go compiler, e.g. `./read_bytes.go:1208:21: inlining call to getBytespec func(byte) bytespec { return sizes[v] }`
* **References to `fmt` package removed for TinyGo** compilation path.  In some cases I replaced with a call to `strconv` that does the same thing, and a couple others (see `ctxString`) I kept the original implementation and made a non-fmt version for TinyGo.  The `fmt` package adds about 30k to the output code size - in one example that's 70% of the overall program size.
* I checked a few other things like the `init()` methods in `json*.go` and the various dynamic stuff in the`WrapError` method to see if there were any size optimization opportunities there and everything turned out to be either already optimized away by the compiler or only have a negligible size difference, so I didn't take it any further.  Also, the buffers I was concerned about in `fwd` I don't think are relevant anyway - if someone is writing code where an extra couple of kb of memory matters, they should almost certainly not be using a Reader/Writer abstraction, but instead stick with Append..., MarshalMsg, UnmarshalMsg, etc.  I think this can just be mentioned in the wiki somewhere.

And the rest is the test suite (`tinygotest` dir).  Each subdir is a program and there are regular Go tests that drive building via `tinygo` for various target outputs and also build and run the executable on the local platform (tested on Mac, should work on Linux, won't work on Windows) and verify it exits cleanly.  This run step turned out to be needed as there was a subtle panic in the beginning that this helped catch and fix.   There is also some logging that shows the output file sizes so one can get a feel for how big the resulting binaries are on MCUs.   ARM and WASM outputs work without issue, but I ran into some problems with other architectures like AVR and ESP32/xtensa.  If I find the time I'll see if I can fiddle with it more but for now I think what's here is still very useful for a lot of environments (including very popular ones like ARM-based Arduinos).

I also updated `.travis.yml` to [install TinyGo](https://tinygo.org/getting-started/install/linux/), we'll see if it works.  And I added Go 1.16.x while I was in there.
