### PR TITLE
Add allownil tag

### DIFF
--- a/_generated/allownil.go
+++ b/_generated/allownil.go
@@ -1,0 +1,230 @@
+package _generated
+
+import "time"
+
+//go:generate msgp
+
+type AllowNil0 struct {
+	ABool       bool       `msg:"abool,allownil"`
+	AInt        int        `msg:"aint,allownil"`
+	AInt8       int8       `msg:"aint8,allownil"`
+	AInt16      int16      `msg:"aint16,allownil"`
+	AInt32      int32      `msg:"aint32,allownil"`
+	AInt64      int64      `msg:"aint64,allownil"`
+	AUint       uint       `msg:"auint,allownil"`
+	AUint8      uint8      `msg:"auint8,allownil"`
+	AUint16     uint16     `msg:"auint16,allownil"`
+	AUint32     uint32     `msg:"auint32,allownil"`
+	AUint64     uint64     `msg:"auint64,allownil"`
+	AFloat32    float32    `msg:"afloat32,allownil"`
+	AFloat64    float64    `msg:"afloat64,allownil"`
+	AComplex64  complex64  `msg:"acomplex64,allownil"`
+	AComplex128 complex128 `msg:"acomplex128,allownil"`
+
+	ANamedBool    bool    `msg:"anamedbool,allownil"`
+	ANamedInt     int     `msg:"anamedint,allownil"`
+	ANamedFloat64 float64 `msg:"anamedfloat64,allownil"`
+
+	AMapStrStr map[string]string `msg:"amapstrstr,allownil"`
+
+	APtrNamedStr *NamedString `msg:"aptrnamedstr,allownil"`
+
+	AString      string `msg:"astring,allownil"`
+	ANamedString string `msg:"anamedstring,allownil"`
+	AByteSlice   []byte `msg:"abyteslice,allownil"`
+
+	ASliceString      []string      `msg:"aslicestring,allownil"`
+	ASliceNamedString []NamedString `msg:"aslicenamedstring,allownil"`
+
+	ANamedStruct    NamedStructAN  `msg:"anamedstruct,allownil"`
+	APtrNamedStruct *NamedStructAN `msg:"aptrnamedstruct,allownil"`
+
+	AUnnamedStruct struct {
+		A string `msg:"a,allownil"`
+	} `msg:"aunnamedstruct,allownil"` // allownil not supported on unnamed struct
+
+	EmbeddableStructAN `msg:",flatten,allownil"` // embed flat
+
+	EmbeddableStruct2AN `msg:"embeddablestruct2,allownil"` // embed non-flat
+
+	AArrayInt [5]int `msg:"aarrayint,allownil"` // not supported
+
+	ATime time.Time `msg:"atime,allownil"`
+}
+
+type AllowNil1 struct {
+	ABool       []bool       `msg:"abool,allownil"`
+	AInt        []int        `msg:"aint,allownil"`
+	AInt8       []int8       `msg:"aint8,allownil"`
+	AInt16      []int16      `msg:"aint16,allownil"`
+	AInt32      []int32      `msg:"aint32,allownil"`
+	AInt64      []int64      `msg:"aint64,allownil"`
+	AUint       []uint       `msg:"auint,allownil"`
+	AUint8      []uint8      `msg:"auint8,allownil"`
+	AUint16     []uint16     `msg:"auint16,allownil"`
+	AUint32     []uint32     `msg:"auint32,allownil"`
+	AUint64     []uint64     `msg:"auint64,allownil"`
+	AFloat32    []float32    `msg:"afloat32,allownil"`
+	AFloat64    []float64    `msg:"afloat64,allownil"`
+	AComplex64  []complex64  `msg:"acomplex64,allownil"`
+	AComplex128 []complex128 `msg:"acomplex128,allownil"`
+
+	ANamedBool    []bool    `msg:"anamedbool,allownil"`
+	ANamedInt     []int     `msg:"anamedint,allownil"`
+	ANamedFloat64 []float64 `msg:"anamedfloat64,allownil"`
+
+	AMapStrStr map[string]string `msg:"amapstrstr,allownil"`
+
+	APtrNamedStr *NamedString `msg:"aptrnamedstr,allownil"`
+
+	AString      []string `msg:"astring,allownil"`
+	ANamedString []string `msg:"anamedstring,allownil"`
+	AByteSlice   []byte   `msg:"abyteslice,allownil"`
+
+	ASliceString      []string      `msg:"aslicestring,allownil"`
+	ASliceNamedString []NamedString `msg:"aslicenamedstring,allownil"`
+
+	ANamedStruct    NamedStructAN  `msg:"anamedstruct,allownil"`
+	APtrNamedStruct *NamedStructAN `msg:"aptrnamedstruct,allownil"`
+
+	AUnnamedStruct struct {
+		A []string `msg:"a,allownil"`
+	} `msg:"aunnamedstruct,allownil"`
+
+	*EmbeddableStructAN `msg:",flatten,allownil"` // embed flat
+
+	*EmbeddableStruct2AN `msg:"embeddablestruct2,allownil"` // embed non-flat
+
+	AArrayInt [5]int `msg:"aarrayint,allownil"` // not supported
+
+	ATime *time.Time `msg:"atime,allownil"`
+}
+
+type EmbeddableStructAN struct {
+	SomeEmbed []string `msg:"someembed,allownil"`
+}
+
+type EmbeddableStruct2AN struct {
+	SomeEmbed2 []string `msg:"someembed2,allownil"`
+}
+
+type NamedStructAN struct {
+	A []string `msg:"a,allownil"`
+	B []string `msg:"b,allownil"`
+}
+
+type AllowNilHalfFull struct {
+	Field00 []string `msg:"field00,allownil"`
+	Field01 []string `msg:"field01"`
+	Field02 []string `msg:"field02,allownil"`
+	Field03 []string `msg:"field03"`
+}
+
+type AllowNilLotsOFields struct {
+	Field00 []string `msg:"field00,allownil"`
+	Field01 []string `msg:"field01,allownil"`
+	Field02 []string `msg:"field02,allownil"`
+	Field03 []string `msg:"field03,allownil"`
+	Field04 []string `msg:"field04,allownil"`
+	Field05 []string `msg:"field05,allownil"`
+	Field06 []string `msg:"field06,allownil"`
+	Field07 []string `msg:"field07,allownil"`
+	Field08 []string `msg:"field08,allownil"`
+	Field09 []string `msg:"field09,allownil"`
+	Field10 []string `msg:"field10,allownil"`
+	Field11 []string `msg:"field11,allownil"`
+	Field12 []string `msg:"field12,allownil"`
+	Field13 []string `msg:"field13,allownil"`
+	Field14 []string `msg:"field14,allownil"`
+	Field15 []string `msg:"field15,allownil"`
+	Field16 []string `msg:"field16,allownil"`
+	Field17 []string `msg:"field17,allownil"`
+	Field18 []string `msg:"field18,allownil"`
+	Field19 []string `msg:"field19,allownil"`
+	Field20 []string `msg:"field20,allownil"`
+	Field21 []string `msg:"field21,allownil"`
+	Field22 []string `msg:"field22,allownil"`
+	Field23 []string `msg:"field23,allownil"`
+	Field24 []string `msg:"field24,allownil"`
+	Field25 []string `msg:"field25,allownil"`
+	Field26 []string `msg:"field26,allownil"`
+	Field27 []string `msg:"field27,allownil"`
+	Field28 []string `msg:"field28,allownil"`
+	Field29 []string `msg:"field29,allownil"`
+	Field30 []string `msg:"field30,allownil"`
+	Field31 []string `msg:"field31,allownil"`
+	Field32 []string `msg:"field32,allownil"`
+	Field33 []string `msg:"field33,allownil"`
+	Field34 []string `msg:"field34,allownil"`
+	Field35 []string `msg:"field35,allownil"`
+	Field36 []string `msg:"field36,allownil"`
+	Field37 []string `msg:"field37,allownil"`
+	Field38 []string `msg:"field38,allownil"`
+	Field39 []string `msg:"field39,allownil"`
+	Field40 []string `msg:"field40,allownil"`
+	Field41 []string `msg:"field41,allownil"`
+	Field42 []string `msg:"field42,allownil"`
+	Field43 []string `msg:"field43,allownil"`
+	Field44 []string `msg:"field44,allownil"`
+	Field45 []string `msg:"field45,allownil"`
+	Field46 []string `msg:"field46,allownil"`
+	Field47 []string `msg:"field47,allownil"`
+	Field48 []string `msg:"field48,allownil"`
+	Field49 []string `msg:"field49,allownil"`
+	Field50 []string `msg:"field50,allownil"`
+	Field51 []string `msg:"field51,allownil"`
+	Field52 []string `msg:"field52,allownil"`
+	Field53 []string `msg:"field53,allownil"`
+	Field54 []string `msg:"field54,allownil"`
+	Field55 []string `msg:"field55,allownil"`
+	Field56 []string `msg:"field56,allownil"`
+	Field57 []string `msg:"field57,allownil"`
+	Field58 []string `msg:"field58,allownil"`
+	Field59 []string `msg:"field59,allownil"`
+	Field60 []string `msg:"field60,allownil"`
+	Field61 []string `msg:"field61,allownil"`
+	Field62 []string `msg:"field62,allownil"`
+	Field63 []string `msg:"field63,allownil"`
+	Field64 []string `msg:"field64,allownil"`
+	Field65 []string `msg:"field65,allownil"`
+	Field66 []string `msg:"field66,allownil"`
+	Field67 []string `msg:"field67,allownil"`
+	Field68 []string `msg:"field68,allownil"`
+	Field69 []string `msg:"field69,allownil"`
+}
+
+type AllowNil10 struct {
+	Field00 []string `msg:"field00,allownil"`
+	Field01 []string `msg:"field01,allownil"`
+	Field02 []string `msg:"field02,allownil"`
+	Field03 []string `msg:"field03,allownil"`
+	Field04 []string `msg:"field04,allownil"`
+	Field05 []string `msg:"field05,allownil"`
+	Field06 []string `msg:"field06,allownil"`
+	Field07 []string `msg:"field07,allownil"`
+	Field08 []string `msg:"field08,allownil"`
+	Field09 []string `msg:"field09,allownil"`
+}
+
+type NotAllowNil10 struct {
+	Field00 []string `msg:"field00"`
+	Field01 []string `msg:"field01"`
+	Field02 []string `msg:"field02"`
+	Field03 []string `msg:"field03"`
+	Field04 []string `msg:"field04"`
+	Field05 []string `msg:"field05"`
+	Field06 []string `msg:"field06"`
+	Field07 []string `msg:"field07"`
+	Field08 []string `msg:"field08"`
+	Field09 []string `msg:"field09"`
+}
+
+type AllowNilOmitEmpty struct {
+	Field00 []string `msg:"field00,allownil,omitempty"`
+	Field01 []string `msg:"field01,allownil"`
+}
+
+type AllowNilOmitEmpty2 struct {
+	Field00 []string `msg:"field00,allownil,omitempty"`
+	Field01 []string `msg:"field01,allownil,omitempty"`
+}

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -137,6 +137,7 @@ func (c *common) SetVarname(s string) { c.vname = s }
 func (c *common) Varname() string     { return c.vname }
 func (c *common) Alias(typ string)    { c.alias = typ }
 func (c *common) hidden()             {}
+func (c *common) AllowNil() bool      { return false }
 
 func IsPrintable(e Elem) bool {
 	if be, ok := e.(*BaseElem); ok && !be.Printable() {
@@ -182,6 +183,10 @@ type Elem interface {
 	// value.  Can be used for assignment.
 	// Returns "" if zero/empty not supported for this Elem.
 	ZeroExpr() string
+
+	// AllowNil will return true for types that can be nil but doesn't automatically check.
+	// This is true for slices and maps.
+	AllowNil() bool
 
 	// IfZeroExpr returns the expression to compare to zero/empty
 	// for this type.  It is meant to be used in an if statement
@@ -292,6 +297,9 @@ func (m *Map) ZeroExpr() string { return "nil" }
 // IfZeroExpr returns the expression to compare to zero/empty.
 func (m *Map) IfZeroExpr() string { return m.Varname() + " == nil" }
 
+// AllowNil is true for maps.
+func (m *Map) AllowNil() bool { return true }
+
 type Slice struct {
 	common
 	Index string
@@ -332,6 +340,9 @@ func (s *Slice) ZeroExpr() string { return "nil" }
 
 // IfZeroExpr returns the expression to compare to zero/empty.
 func (s *Slice) IfZeroExpr() string { return s.Varname() + " == nil" }
+
+// AllowNil is true for slices.
+func (s *Slice) AllowNil() bool { return true }
 
 type Ptr struct {
 	common

--- a/gen/encode.go
+++ b/gen/encode.go
@@ -93,9 +93,18 @@ func (e *encodeGen) tuple(s *Struct) {
 		if !e.p.ok() {
 			return
 		}
+		anField := s.Fields[i].HasTagPart("allownil") && s.Fields[i].FieldElem.AllowNil()
+		if anField {
+			e.p.printf("\nif %s { // allownil: if nil", s.Fields[i].FieldElem.IfZeroExpr())
+			e.p.printf("\nerr = en.WriteNil(); if err != nil { return; }")
+			e.p.printf("\n} else {")
+		}
 		e.ctx.PushString(s.Fields[i].FieldName)
 		next(e, s.Fields[i].FieldElem)
 		e.ctx.Pop()
+		if anField {
+			e.p.print("\n}") // close if statement
+		}
 	}
 }
 
@@ -172,7 +181,7 @@ func (e *encodeGen) structmap(s *Struct) {
 		}
 
 		// if field is omitempty, wrap with if statement based on the emptymask
-		oeField := s.Fields[i].HasTagPart("omitempty") && s.Fields[i].FieldElem.IfZeroExpr() != ""
+		oeField := omitempty && s.Fields[i].HasTagPart("omitempty") && s.Fields[i].FieldElem.IfZeroExpr() != ""
 		if oeField {
 			e.p.printf("\nif %s == 0 { // if not empty", bm.readExpr(i))
 		}
@@ -182,11 +191,18 @@ func (e *encodeGen) structmap(s *Struct) {
 		e.Fuse(data)
 		e.fuseHook()
 
+		anField := !oeField && s.Fields[i].HasTagPart("allownil") && s.Fields[i].FieldElem.AllowNil()
+		if anField {
+			e.p.printf("\nif %s { // allownil: if nil", s.Fields[i].FieldElem.IfZeroExpr())
+			e.p.printf("\nerr = en.WriteNil(); if err != nil { return; }")
+			e.p.printf("\n} else {")
+		}
+
 		e.ctx.PushString(s.Fields[i].FieldName)
 		next(e, s.Fields[i].FieldElem)
 		e.ctx.Pop()
 
-		if oeField {
+		if oeField || anField {
 			e.p.print("\n}") // close if statement
 		}
 

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -86,8 +86,15 @@ func (u *unmarshalGen) tuple(s *Struct) {
 			return
 		}
 		u.ctx.PushString(s.Fields[i].FieldName)
+		anField := s.Fields[i].HasTagPart("allownil") && s.Fields[i].FieldElem.AllowNil()
+		if anField {
+			u.p.printf("\nif msgp.IsNil(bts) {\nbts = bts[1:]\n%s = nil\n} else {", s.Fields[i].FieldElem.Varname())
+		}
 		next(u, s.Fields[i].FieldElem)
 		u.ctx.Pop()
+		if anField {
+			u.p.printf("\n}")
+		}
 	}
 }
 
@@ -107,8 +114,16 @@ func (u *unmarshalGen) mapstruct(s *Struct) {
 		}
 		u.p.printf("\ncase \"%s\":", s.Fields[i].FieldTag)
 		u.ctx.PushString(s.Fields[i].FieldName)
+
+		anField := s.Fields[i].HasTagPart("allownil") && s.Fields[i].FieldElem.AllowNil()
+		if anField {
+			u.p.printf("\nif msgp.IsNil(bts) {\nbts = bts[1:]\n%s = nil\n} else {", s.Fields[i].FieldElem.Varname())
+		}
 		next(u, s.Fields[i].FieldElem)
 		u.ctx.Pop()
+		if anField {
+			u.p.printf("\n}")
+		}
 	}
 	u.p.print("\ndefault:\nbts, err = msgp.Skip(bts)")
 	u.p.wrapErrCheck(u.ctx.ArgsStr())


### PR DESCRIPTION
Allows to specify `msgp:"name,allownil"` which will add nil entries for slices and maps. This also makes behavior more close to `encoding/json`.

This will allow symmetric roundtrips with tuples and regular objects without `omitempty` which will completely omit the key.

When specified alongside `omitempty` the struct will be omitted, so that takes precedence. To unmarshal maps and slices that can be nil, the `allownil` must be specified.

Unless specified no generated code changes.

Related #278