### PR TITLE
Make array on decode if it's not supposed to be nil

### DIFF
--- a/gen/spec.go
+++ b/gen/spec.go
@@ -376,6 +376,7 @@ func (p *printer) wrapErrCheck(ctx string) {
 }
 
 func (p *printer) resizeSlice(size string, s *Slice) {
+	p.printf("\nif %[2]s==0 && %[1]s==nil { %[1]s = make(%[3]s, 0) }", s.Varname(), size, s.TypeName())
 	p.printf("\nif cap(%[1]s) >= int(%[2]s) { %[1]s = (%[1]s)[:%[2]s] } else { %[1]s = make(%[3]s, %[2]s) }", s.Varname(), size, s.TypeName())
 }
 


### PR DESCRIPTION
Addresses https://github.com/tinylib/msgp/pull/278. #302  fixed issue only partially. It serialized non-nil empty `slice` as it should, but on decode it deserialized as `nil` anyway. 

This PR addresses this "issue".

I'm open to any suggestions on code improvement for this one