### PR TITLE
added blank identifier to mask to prevent edge case

### DIFF
--- a/gen/encode.go
+++ b/gen/encode.go
@@ -139,6 +139,7 @@ func (e *encodeGen) structmap(s *Struct) {
 		e.p.printf("\n// omitempty: check for empty values")
 		e.p.printf("\n%s := uint32(%d)", fieldNVar, nfields)
 		e.p.printf("\n%s", bm.typeDecl())
+		e.p.printf("\n_ = %s", bm.varname)
 		for i, sf := range s.Fields {
 			if !e.p.ok() {
 				return

--- a/gen/marshal.go
+++ b/gen/marshal.go
@@ -134,6 +134,7 @@ func (m *marshalGen) mapstruct(s *Struct) {
 		m.p.printf("\n// omitempty: check for empty values")
 		m.p.printf("\n%s := uint32(%d)", fieldNVar, nfields)
 		m.p.printf("\n%s", bm.typeDecl())
+		m.p.printf("\n_ = %s", bm.varname)
 		for i, sf := range s.Fields {
 			if !m.p.ok() {
 				return


### PR DESCRIPTION
There's an edge case where if all the fields within a struct provide their own marshal/encode methods the mask doesn't end up being used at all which then causes the compiler "unused variable" flags to prevent compilation. This doesn't change the base operation of the functionality, but avoids needing to go manually adjust the auto generated code when this edge case comes up.