### PR TITLE
Support time duration

### DIFF
--- a/gen/elem.go
+++ b/gen/elem.go
@@ -88,9 +88,10 @@ const (
 	Int32
 	Int64
 	Bool
-	Intf // interface{}
-	Time // time.Time
-	Ext  // extension
+	Intf     // interface{}
+	Time     // time.Time
+	Duration // time.Duration
+	Ext      // extension
 
 	IDENT // IDENT means an unrecognized identifier
 )
@@ -119,6 +120,7 @@ var primitives = map[string]Primitive{
 	"bool":           Bool,
 	"interface{}":    Intf,
 	"time.Time":      Time,
+	"time.Duration":  Duration,
 	"msgp.Extension": Ext,
 }
 
@@ -573,10 +575,13 @@ func (s *BaseElem) FromBase() string {
 // BaseName returns the string form of the
 // base type (e.g. Float64, Ident, etc)
 func (s *BaseElem) BaseName() string {
-	// time is a special case;
+	// time.Time and time.Duration are special cases;
 	// we strip the package prefix
 	if s.Value == Time {
 		return "Time"
+	}
+	if s.Value == Duration {
+		return "Duration"
 	}
 	return s.Value.String()
 }
@@ -594,6 +599,8 @@ func (s *BaseElem) BaseType() string {
 		return "[]byte"
 	case Time:
 		return "time.Time"
+	case Duration:
+		return "time.Duration"
 	case Ext:
 		return "msgp.Extension"
 
@@ -657,7 +664,8 @@ func (s *BaseElem) ZeroExpr() string {
 		Int8,
 		Int16,
 		Int32,
-		Int64:
+		Int64,
+		Duration:
 		return "0"
 	case Bool:
 		return "false"
@@ -721,6 +729,8 @@ func (k Primitive) String() string {
 		return "Intf"
 	case Time:
 		return "time.Time"
+	case Duration:
+		return "time.Duration"
 	case Ext:
 		return "Extension"
 	case IDENT:

--- a/msgp/read.go
+++ b/msgp/read.go
@@ -36,6 +36,7 @@ const (
 	IntType
 	UintType
 	NilType
+	DurationType
 	ExtensionType
 
 	// pseudo-types provided
@@ -1306,6 +1307,10 @@ func (m *Reader) ReadIntf() (i interface{}, err error) {
 
 	case TimeType:
 		i, err = m.ReadTime()
+		return
+
+	case DurationType:
+		i, err = m.ReadDuration()
 		return
 
 	case ExtensionType:

--- a/msgp/read.go
+++ b/msgp/read.go
@@ -559,6 +559,12 @@ func (m *Reader) ReadBool() (b bool, err error) {
 	return
 }
 
+// ReadDuration reads a time.Duration from the reader
+func (m *Reader) ReadDuration() (d time.Duration, err error) {
+	i, err := m.ReadInt64()
+	return time.Duration(i), err
+}
+
 // ReadInt64 reads an int64 from the reader
 func (m *Reader) ReadInt64() (i int64, err error) {
 	var p []byte

--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -382,6 +382,16 @@ func ReadBoolBytes(b []byte) (bool, []byte, error) {
 	}
 }
 
+// ReadDurationBytes tries to read a time.Duration
+// from 'b' and return the value and the remaining bytes.
+// Possible errors:
+// - ErrShortBytes (too few bytes)
+// - TypeError (not a int)
+func ReadDurationBytes(b []byte) (d time.Duration, o []byte, err error) {
+	i, o, err := ReadInt64Bytes(b)
+	return time.Duration(i), o, err
+}
+
 // ReadInt64Bytes tries to read an int64
 // from 'b' and return the value and the remaining bytes.
 // Possible errors:

--- a/msgp/read_test.go
+++ b/msgp/read_test.go
@@ -30,6 +30,7 @@ func TestReadIntf(t *testing.T) {
 		int64(-40),
 		uint64(9082981),
 		time.Now(),
+		48*time.Hour + 3*time.Minute + 2*time.Second + 3*time.Nanosecond,
 		"hello!",
 		[]byte("hello!"),
 		map[string]interface{}{
@@ -65,6 +66,12 @@ func TestReadIntf(t *testing.T) {
 		if tm, ok := v.(time.Time); ok {
 			if !tm.Equal(v.(time.Time)) {
 				t.Errorf("%v != %v", ts, v)
+			}
+		} else if intd, ok := ts.(time.Duration); ok {
+			/* for time.Duration, cast before comparing */
+			outtd := time.Duration(v.(int64))
+			if intd != outtd {
+				t.Errorf("%v in; %v out", intd, outtd)
 			}
 		} else if !reflect.DeepEqual(v, ts) {
 			t.Errorf("%v in; %v out", ts, v)

--- a/msgp/size.go
+++ b/msgp/size.go
@@ -25,9 +25,10 @@ const (
 	Complex64Size  = 10
 	Complex128Size = 18
 
-	TimeSize = 15
-	BoolSize = 1
-	NilSize  = 1
+	DurationSize = Int64Size
+	TimeSize     = 15
+	BoolSize     = 1
+	NilSize      = 1
 
 	MapHeaderSize   = 5
 	ArrayHeaderSize = 5

--- a/msgp/write.go
+++ b/msgp/write.go
@@ -356,6 +356,11 @@ func (mw *Writer) WriteFloat32(f float32) error {
 	return mw.prefix32(mfloat32, math.Float32bits(f))
 }
 
+// WriteDuration writes a time.Duration to the writer
+func (mw *Writer) WriteDuration(d time.Duration) error {
+	return mw.WriteInt64(int64(d))
+}
+
 // WriteInt64 writes an int64 to the writer
 func (mw *Writer) WriteInt64(i int64) error {
 	if i >= 0 {

--- a/msgp/write.go
+++ b/msgp/write.go
@@ -687,6 +687,8 @@ func (mw *Writer) WriteIntf(v interface{}) error {
 		return mw.WriteMapStrIntf(v)
 	case time.Time:
 		return mw.WriteTime(v)
+	case time.Duration:
+		return mw.WriteDuration(v)
 	}
 
 	val := reflect.ValueOf(v)

--- a/msgp/write_bytes.go
+++ b/msgp/write_bytes.go
@@ -73,6 +73,11 @@ func AppendFloat32(b []byte, f float32) []byte {
 	return o
 }
 
+// AppendDuration appends a time.Duration to the slice
+func AppendDuration(b []byte, d time.Duration) []byte {
+	return AppendInt64(b, int64(d))
+}
+
 // AppendInt64 appends an int64 to the slice
 func AppendInt64(b []byte, i int64) []byte {
 	if i >= 0 {

--- a/msgp/write_test.go
+++ b/msgp/write_test.go
@@ -214,6 +214,39 @@ func TestWriteFloat64(t *testing.T) {
 	}
 }
 
+func TestReadWriterDuration(t *testing.T) {
+	var buf bytes.Buffer
+	wr := NewWriter(&buf)
+
+	for i := 0; i < 10000; i++ {
+		buf.Reset()
+		dur := time.Duration(rand.Int63())
+		err := wr.WriteDuration(dur)
+		if err != nil {
+			t.Errorf("Error with %v: %s", dur, err)
+		}
+		err = wr.Flush()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		bts := buf.Bytes()
+
+		if bts[0] != mint64 {
+			t.Errorf("Leading byte was %x and not %x", bts[0], mint64)
+		}
+
+		wr := NewReader(&buf)
+		d, err := wr.ReadDuration()
+		if err != nil {
+			t.Errorf("Error reading duration: %v", err)
+		}
+		if d != dur {
+			t.Errorf("Got duration %v, want %v", d, dur)
+		}
+	}
+}
+
 func BenchmarkWriteFloat64(b *testing.B) {
 	f := rand.Float64()
 	wr := NewWriter(Nowhere)


### PR DESCRIPTION
Hi, we've been needing to add msgpack to a large codebase using many POD structures, some of them had `time.Duration` fields.

We haven't found a way to directly use `time.Duration` and it seemed like a good addition.
We're just sending the int64 value and converting at the edge, we don't decode the string version (eg `3m30s`).

Is this something you'd be interested in being merged upstream? If so, let me know what/if should I add anything to the current pull-request.

By the way, thanks for a very well-thought, easy to use and performant library.