### PR TITLE
Manage non-[]byte types when type-conversion needed from generated code

### DIFF
--- a/gen/decode.go
+++ b/gen/decode.go
@@ -156,7 +156,8 @@ func (d *decodeGen) gBase(b *BaseElem) {
 	switch b.Value {
 	case Bytes:
 		if b.Convert {
-			d.p.printf("\n%s, err = dc.ReadBytes([]byte(%s))", tmp, vname)
+			lowered := b.ToBase() + "(" + vname + ")"
+			d.p.printf("\n%s, err = dc.ReadBytes(%s)", tmp, lowered)
 		} else {
 			d.p.printf("\n%s, err = dc.ReadBytes(%s)", vname, vname)
 		}


### PR DESCRIPTION
In case of the code below:
```go
package main

import uuid "github.com/gofrs/uuid"

//msgp:shim uuid.UUID as:[]byte using:uuidToBytes/bytesToUUID
type T struct {
	Id uuid.UUID `json:"id"`
}

func uuidToBytes(uid uuid.UUID) []byte {
	return uid[:]
}

func bytesToUUID(uid []byte) uuid.UUID {
	return uuid.FromBytesOrNil(uid)
}
```

While `go generate` the `tinylib/msgp` lib expected type as []byte and doesn't use the function proveded for conversion. See as example the expected generated code as a diff:
```
func (z *T) DecodeMsg(dc *msgp.Reader) (err error) {
	[...]
	case "Id":
	{
		var zb0002 []byte
-		zb0002, err = dc.ReadBytes([]byte(z.Id))
+		zb0002, err = dc.ReadBytes(uuidToBytes(z.Id))
```

The representation of the UUID behind `github.com/gofrs/uuid` is an [16]byte (an array and not a slice of byte). So the actual hardcoded []byte cast not working.

Btw, this bug is only related to the `DecodeMsg()` func and not to the `UnmarshalMsg()` func because it reuse well the conversion function provided by the go annotation. That's why the fix is inspired by this second function to correct the first.

This PR allow to fix this kind of issue without crashing existing tests.
