### PR TITLE
gofmt code for current go versions, and some minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 MessagePack Code Generator
 =======
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/tinylib/msgp.svg)](https://pkg.go.dev/github.com/tinylib/msgp)
 [![test](https://github.com/tinylib/msgp/actions/workflows/test.yml/badge.svg)](https://github.com/tinylib/msgp/actions/workflows/test.yml)
 [![validate](https://github.com/tinylib/msgp/actions/workflows/validate.yml/badge.svg)](https://github.com/tinylib/msgp/actions/workflows/validate.yml)
 
@@ -10,7 +11,7 @@ This is a code generation tool and serialization library for [MessagePack](http:
 
 - Use Go as your schema language
 - Performance
-- [JSON interop](http://godoc.org/github.com/tinylib/msgp/msgp#CopyToJSON)
+- [JSON interop](https://pkg.go.dev/github.com/tinylib/msgp/msgp#CopyToJSON)
 - [User-defined extensions](http://github.com/tinylib/msgp/wiki/Using-Extensions)
 - Type safety
 - Encoding flexibility

--- a/_generated/def.go
+++ b/_generated/def.go
@@ -243,7 +243,7 @@ type ArrayConstants struct {
 	ConstantUint32 [ConstantUint32]string
 	ConstantUint64 [ConstantUint64]string
 	ConstantHex    [0x16]string
-	ConstantOctal  [07]string
+	ConstantOctal  [0o7]string
 }
 
 // Ensure non-msg struct tags work:

--- a/_generated/def.go
+++ b/_generated/def.go
@@ -88,15 +88,19 @@ type TestFast struct {
 }
 
 // Test nested aliases
-type FastAlias TestFast
-type AliasContainer struct {
-	Fast FastAlias
-}
+type (
+	FastAlias      TestFast
+	AliasContainer struct {
+		Fast FastAlias
+	}
+)
 
 // Test dependency resolution
-type IntA int
-type IntB IntA
-type IntC IntB
+type (
+	IntA int
+	IntB IntA
+	IntC IntB
+)
 
 type TestHidden struct {
 	A   string
@@ -124,8 +128,10 @@ type Things struct {
 
 //msgp:shim SpecialID as:[]byte using:toBytes/fromBytes
 
-type SpecialID string
-type TestObj struct{ ID1, ID2 SpecialID }
+type (
+	SpecialID string
+	TestObj   struct{ ID1, ID2 SpecialID }
+)
 
 func toBytes(id SpecialID) []byte   { return []byte(string(id)) }
 func fromBytes(id []byte) SpecialID { return SpecialID(string(id)) }
@@ -204,8 +210,10 @@ type FileHandle struct {
 	Name     string `msg:"name"`
 }
 
-type CustomInt int
-type CustomBytes []byte
+type (
+	CustomInt   int
+	CustomBytes []byte
+)
 
 type Wrapper struct {
 	Tree *Tree

--- a/_generated/gen_test.go
+++ b/_generated/gen_test.go
@@ -2,10 +2,11 @@ package _generated
 
 import (
 	"bytes"
-	"github.com/tinylib/msgp/msgp"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/tinylib/msgp/msgp"
 )
 
 // benchmark encoding a small, "fast" type.
@@ -76,12 +77,11 @@ func (a *TestType) Equal(b *TestType) bool {
 }
 
 // This covers the following cases:
-//  - Recursive types
-//  - Non-builtin identifiers (and recursive types)
-//  - time.Time
-//  - map[string]string
-//  - anonymous structs
-//
+//   - Recursive types
+//   - Non-builtin identifiers (and recursive types)
+//   - time.Time
+//   - map[string]string
+//   - anonymous structs
 func Test1EncodeDecode(t *testing.T) {
 	f := 32.00
 	tt := &TestType{

--- a/_generated/omitempty.go
+++ b/_generated/omitempty.go
@@ -52,10 +52,12 @@ type OmitEmpty0 struct {
 	ATime time.Time `msg:"atime,omitempty"`
 }
 
-type NamedBool bool
-type NamedInt int
-type NamedFloat64 float64
-type NamedString string
+type (
+	NamedBool    bool
+	NamedInt     int
+	NamedFloat64 float64
+	NamedString  string
+)
 
 type EmbeddableStruct struct {
 	SomeEmbed string `msg:"someembed,omitempty"`

--- a/_generated/omitempty_test.go
+++ b/_generated/omitempty_test.go
@@ -29,7 +29,6 @@ func mustEncodeToJSON(o msgp.Encodable) string {
 }
 
 func TestOmitEmpty0(t *testing.T) {
-
 	var s string
 
 	var oe0a OmitEmpty0
@@ -92,12 +91,10 @@ func TestOmitEmpty0(t *testing.T) {
 	if oe0c.AInt64 != oe0d.AInt64 {
 		t.Fail()
 	}
-
 }
 
 // TestOmitEmptyHalfFull tests mixed omitempty and not
 func TestOmitEmptyHalfFull(t *testing.T) {
-
 	var s string
 
 	var oeA OmitEmptyHalfFull
@@ -124,7 +121,6 @@ func TestOmitEmptyHalfFull(t *testing.T) {
 
 // TestOmitEmptyLotsOFields tests the case of > 64 fields (triggers the bitmask needing to be an array instead of a single value)
 func TestOmitEmptyLotsOFields(t *testing.T) {
-
 	var s string
 
 	var oeLotsA OmitEmptyLotsOFields
@@ -147,11 +143,9 @@ func TestOmitEmptyLotsOFields(t *testing.T) {
 	if s != `{"field64":"val64"}` {
 		t.Errorf("wrong result: %s", s)
 	}
-
 }
 
 func BenchmarkOmitEmpty10AllEmpty(b *testing.B) {
-
 	en := msgp.NewWriter(ioutil.Discard)
 	var s OmitEmpty10
 
@@ -163,11 +157,9 @@ func BenchmarkOmitEmpty10AllEmpty(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
-
 }
 
 func BenchmarkOmitEmpty10AllFull(b *testing.B) {
-
 	en := msgp.NewWriter(ioutil.Discard)
 	var s OmitEmpty10
 	s.Field00 = "this is the value of field00"
@@ -189,11 +181,9 @@ func BenchmarkOmitEmpty10AllFull(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
-
 }
 
 func BenchmarkNotOmitEmpty10AllEmpty(b *testing.B) {
-
 	en := msgp.NewWriter(ioutil.Discard)
 	var s NotOmitEmpty10
 
@@ -208,7 +198,6 @@ func BenchmarkNotOmitEmpty10AllEmpty(b *testing.B) {
 }
 
 func BenchmarkNotOmitEmpty10AllFull(b *testing.B) {
-
 	en := msgp.NewWriter(ioutil.Discard)
 	var s NotOmitEmpty10
 	s.Field00 = "this is the value of field00"

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -128,8 +128,8 @@ var primitives = map[string]Primitive{
 // that satisfy all of the
 // interfaces.
 var builtins = map[string]struct{}{
-	"msgp.Raw":    struct{}{},
-	"msgp.Number": struct{}{},
+	"msgp.Raw":    {},
+	"msgp.Number": {},
 }
 
 // common data/methods for every Elem
@@ -644,7 +644,6 @@ func (s *BaseElem) Resolved() bool {
 
 // ZeroExpr returns the zero/empty expression or empty string if not supported.
 func (s *BaseElem) ZeroExpr() string {
-
 	switch s.Value {
 	case Bytes:
 		return "nil"
@@ -754,7 +753,6 @@ func writeStructFields(s []StructField, name string) {
 // ArrayHeader implementation in this library using uint32. On the Go side, we
 // can declare array lengths as any constant integer width, which breaks when
 // attempting a direct comparison to an array header's uint32.
-//
 func coerceArraySize(asz string) string {
 	return fmt.Sprintf("uint32(%s)", asz)
 }

--- a/gen/encode.go
+++ b/gen/encode.go
@@ -119,7 +119,6 @@ func (e *encodeGen) appendraw(bts []byte) {
 }
 
 func (e *encodeGen) structmap(s *Struct) {
-
 	oeIdentPrefix := randIdent()
 
 	var data []byte

--- a/gen/marshal.go
+++ b/gen/marshal.go
@@ -114,7 +114,6 @@ func (m *marshalGen) tuple(s *Struct) {
 }
 
 func (m *marshalGen) mapstruct(s *Struct) {
-
 	oeIdentPrefix := randIdent()
 
 	var data []byte

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -318,12 +318,12 @@ func (p *printer) declare(name string, typ string) {
 
 // does:
 //
-// if m == nil {
-//     m = make(type, size)
-// } else if len(m) > 0 {
-//     for key := range m { delete(m, key) }
-// }
+//	if m == nil {
+//	    m = make(type, size)
+//	} else if len(m) > 0 {
 //
+//	    for key := range m { delete(m, key) }
+//	}
 func (p *printer) resizeMap(size string, m *Map) {
 	vn := m.Varname()
 	if !p.ok() {
@@ -368,10 +368,9 @@ func (p *printer) closeblock() { p.print("\n}") }
 
 // does:
 //
-// for idx := range iter {
-//     {{generate inner}}
-// }
-//
+//	for idx := range iter {
+//	    {{generate inner}}
+//	}
 func (p *printer) rangeBlock(ctx *Context, idx string, iter string, t traversal, inner Elem) {
 	ctx.PushVar(idx)
 	p.printf("\n for %s := range %s {", idx, iter)
@@ -444,7 +443,6 @@ func (b *bmask) typeDecl() string {
 
 // typeName returns the type, e.g. "uint8" or "[2]uint64"
 func (b *bmask) typeName() string {
-
 	if b.bitlen <= 8 {
 		return "uint8"
 	}
@@ -464,7 +462,6 @@ func (b *bmask) typeName() string {
 // readExpr returns the expression to read from a position in the bitmask.
 // Compare ==0 for false or !=0 for true.
 func (b *bmask) readExpr(bitoffset int) string {
-
 	if bitoffset < 0 || bitoffset >= b.bitlen {
 		panic(fmt.Errorf("bitoffset %d out of range for bitlen %d", bitoffset, b.bitlen))
 	}
@@ -481,12 +478,10 @@ func (b *bmask) readExpr(bitoffset int) string {
 	buf.WriteByte(')')
 
 	return buf.String()
-
 }
 
 // setStmt returns the statement to set the specified bit in the bitmask.
 func (b *bmask) setStmt(bitoffset int) string {
-
 	var buf bytes.Buffer
 	buf.Grow(len(b.varname) + 16)
 	buf.WriteString(b.varname)
@@ -496,5 +491,4 @@ func (b *bmask) setStmt(bitoffset int) string {
 	fmt.Fprintf(&buf, " |= 0x%X", (uint64(1) << (uint64(bitoffset) % 64)))
 
 	return buf.String()
-
 }

--- a/gen/testgen.go
+++ b/gen/testgen.go
@@ -178,5 +178,4 @@ func BenchmarkDecode{{.TypeName}}(b *testing.B) {
 }
 
 `))
-
 }

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -74,7 +74,6 @@ func (u *unmarshalGen) gStruct(s *Struct) {
 }
 
 func (u *unmarshalGen) tuple(s *Struct) {
-
 	// open block
 	sz := randIdent()
 	u.p.declare(sz, u32)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tinylib/msgp
 
-go 1.14
+go 1.15
 
 require (
 	github.com/philhofer/fwd v1.1.2-0.20210722190033-5c56ac6d0bb9

--- a/issue185_test.go
+++ b/issue185_test.go
@@ -26,7 +26,7 @@ const debugTemp = false
 // structs are currently processed alphabetically by msgp. this test relies on
 // that property.
 func TestIssue185Idents(t *testing.T) {
-	var identCases = []struct {
+	identCases := []struct {
 		tpl             *template.Template
 		expectedChanged []string
 	}{
@@ -89,7 +89,7 @@ type issue185TplData struct {
 }
 
 func TestIssue185Overlap(t *testing.T) {
-	var overlapCases = []struct {
+	overlapCases := []struct {
 		tpl  *template.Template
 		data issue185TplData
 	}{

--- a/issue185_test.go
+++ b/issue185_test.go
@@ -25,7 +25,6 @@ const debugTemp = false
 //
 // structs are currently processed alphabetically by msgp. this test relies on
 // that property.
-//
 func TestIssue185Idents(t *testing.T) {
 	var identCases = []struct {
 		tpl             *template.Template
@@ -225,7 +224,7 @@ func extractVars(file string) (extractedVars, error) {
 }
 
 func goGenerateTpl(cwd, tfile string, tpl *template.Template, tplData interface{}) error {
-	outf, err := os.OpenFile(tfile, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0600)
+	outf, err := os.OpenFile(tfile, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -6,20 +6,19 @@
 // To use it, include the following directive in a
 // go source file with types requiring source generation:
 //
-//     //go:generate msgp
+//	//go:generate msgp
 //
 // The go generate tool should set the proper environment variables for
 // the generator to execute without any command-line flags. However, the
 // following options are supported, if you need them:
 //
-//  -o = output file name (default is {input}_gen.go)
-//  -file = input file name (or directory; default is $GOFILE, which is set by the `go generate` command)
-//  -io = satisfy the `msgp.Decodable` and `msgp.Encodable` interfaces (default is true)
-//  -marshal = satisfy the `msgp.Marshaler` and `msgp.Unmarshaler` interfaces (default is true)
-//  -tests = generate tests and benchmarks (default is true)
+//	-o = output file name (default is {input}_gen.go)
+//	-file = input file name (or directory; default is $GOFILE, which is set by the `go generate` command)
+//	-io = satisfy the `msgp.Decodable` and `msgp.Encodable` interfaces (default is true)
+//	-marshal = satisfy the `msgp.Marshaler` and `msgp.Unmarshaler` interfaces (default is true)
+//	-tests = generate tests and benchmarks (default is true)
 //
 // For more information, please read README.md, and the wiki at github.com/tinylib/msgp
-//
 package main
 
 import (
@@ -98,7 +97,6 @@ func main() {
 // Run writes all methods using the associated file or path, e.g.
 //
 //	err := msgp.Run("path/to/myfile.go", gen.Size|gen.Marshal|gen.Unmarshal|gen.Test, false)
-//
 func Run(gofile string, mode gen.Method, unexported bool) error {
 	if mode&^gen.Test == 0 {
 		return nil

--- a/msgp/advise_linux.go
+++ b/msgp/advise_linux.go
@@ -1,3 +1,4 @@
+//go:build linux && !appengine && !tinygo
 // +build linux,!appengine,!tinygo
 
 package msgp

--- a/msgp/advise_other.go
+++ b/msgp/advise_other.go
@@ -1,3 +1,4 @@
+//go:build (!linux && !tinygo) || appengine
 // +build !linux,!tinygo appengine
 
 package msgp

--- a/msgp/defs.go
+++ b/msgp/defs.go
@@ -5,16 +5,19 @@
 // generator implement the Marshaler/Unmarshaler and Encodable/Decodable interfaces.
 //
 // This package defines four "families" of functions:
-// 	- AppendXxxx() appends an object to a []byte in MessagePack encoding.
-// 	- ReadXxxxBytes() reads an object from a []byte and returns the remaining bytes.
-// 	- (*Writer).WriteXxxx() writes an object to the buffered *Writer type.
-// 	- (*Reader).ReadXxxx() reads an object from a buffered *Reader type.
+//   - AppendXxxx() appends an object to a []byte in MessagePack encoding.
+//   - ReadXxxxBytes() reads an object from a []byte and returns the remaining bytes.
+//   - (*Writer).WriteXxxx() writes an object to the buffered *Writer type.
+//   - (*Reader).ReadXxxx() reads an object from a buffered *Reader type.
 //
 // Once a type has satisfied the `Encodable` and `Decodable` interfaces,
 // it can be written and read from arbitrary `io.Writer`s and `io.Reader`s using
-// 		msgp.Encode(io.Writer, msgp.Encodable)
+//
+//	msgp.Encode(io.Writer, msgp.Encodable)
+//
 // and
-//		msgp.Decode(io.Reader, msgp.Decodable)
+//
+//	msgp.Decode(io.Reader, msgp.Decodable)
 //
 // There are also methods for converting MessagePack to JSON without
 // an explicit de-serialization step.

--- a/msgp/defs.go
+++ b/msgp/defs.go
@@ -26,11 +26,13 @@
 // the wiki at http://github.com/tinylib/msgp
 package msgp
 
-const last4 = 0x0f
-const first4 = 0xf0
-const last5 = 0x1f
-const first3 = 0xe0
-const last7 = 0x7f
+const (
+	last4  = 0x0f
+	first4 = 0xf0
+	last5  = 0x1f
+	first3 = 0xe0
+	last7  = 0x7f
+)
 
 func isfixint(b byte) bool {
 	return b>>7 == 0

--- a/msgp/edit_test.go
+++ b/msgp/edit_test.go
@@ -81,7 +81,6 @@ func TestLocate(t *testing.T) {
 	if len(field) != 0 {
 		t.Fatalf("wanted a zero-length returned slice")
 	}
-
 }
 
 func TestReplace(t *testing.T) {

--- a/msgp/elsize.go
+++ b/msgp/elsize.go
@@ -1,7 +1,6 @@
 package msgp
 
 func calcBytespec(v byte) bytespec {
-
 	// single byte values
 	switch v {
 
@@ -97,7 +96,6 @@ func calcBytespec(v byte) bytespec {
 	// everything else is covered above
 
 	return bytespec{}
-
 }
 
 func getType(v byte) Type {

--- a/msgp/elsize_default.go
+++ b/msgp/elsize_default.go
@@ -1,3 +1,4 @@
+//go:build !tinygo
 // +build !tinygo
 
 package msgp
@@ -6,7 +7,6 @@ package msgp
 // plus type information. gives us
 // constant-time type information
 // for traversing composite objects.
-//
 var sizes [256]bytespec
 
 func init() {

--- a/msgp/elsize_test.go
+++ b/msgp/elsize_test.go
@@ -3,7 +3,6 @@ package msgp
 import "testing"
 
 func TestBytespec(t *testing.T) {
-
 	// verify that bytespec refactor for TinyGo behaves the same as the old code
 
 	// previous sizes array setup verbatim:
@@ -47,7 +46,6 @@ func TestBytespec(t *testing.T) {
 		mmap32:    {size: 5, extra: map32v, typ: MapType},
 	}
 
-	//func init() {
 	// set up fixed fields
 
 	// fixint
@@ -75,11 +73,9 @@ func TestBytespec(t *testing.T) {
 	for i := mfixarray; i < 0xa0; i++ {
 		sizes[i] = bytespec{size: 1, extra: varmode(rfixarray(i)), typ: ArrayType}
 	}
-	//}
 
 	// compare all values to calcBytespec
 	for i := 0; i < 256; i++ {
-
 		sizeb := sizes[byte(i)]
 		cb := calcBytespec(byte(i))
 		if sizeb != cb {
@@ -90,7 +86,5 @@ func TestBytespec(t *testing.T) {
 		if i != 0xC1 && sizeb.size == 0 {
 			t.Errorf("unexpected zero size for index 0x%x", i)
 		}
-
 	}
-
 }

--- a/msgp/elsize_test.go
+++ b/msgp/elsize_test.go
@@ -12,7 +12,7 @@ func TestBytespec(t *testing.T) {
 	// constant-time type information
 	// for traversing composite objects.
 	//
-	var sizes = [256]bytespec{
+	sizes := [256]bytespec{
 		mnil:      {size: 1, extra: constsize, typ: NilType},
 		mfalse:    {size: 1, extra: constsize, typ: BoolType},
 		mtrue:     {size: 1, extra: constsize, typ: BoolType},

--- a/msgp/elsize_tinygo.go
+++ b/msgp/elsize_tinygo.go
@@ -1,3 +1,4 @@
+//go:build tinygo
 // +build tinygo
 
 package msgp

--- a/msgp/errors.go
+++ b/msgp/errors.go
@@ -69,7 +69,6 @@ func Resumable(e error) bool {
 //
 // ErrShortBytes is not wrapped with any context due to backward compatibility
 // issues with the public API.
-//
 func WrapError(err error, ctx ...interface{}) error {
 	switch e := err.(type) {
 	case errShort:
@@ -310,7 +309,6 @@ func (e *ErrUnsupportedType) withContext(ctx string) error {
 // (unicode tables, needed for IsPrint(), are big).
 // It lives in errors.go just so we can test it in errors_test.go
 func simpleQuoteStr(s string) string {
-
 	const (
 		lowerhex = "0123456789abcdef"
 	)

--- a/msgp/errors_default.go
+++ b/msgp/errors_default.go
@@ -1,3 +1,4 @@
+//go:build !tinygo
 // +build !tinygo
 
 package msgp

--- a/msgp/errors_test.go
+++ b/msgp/errors_test.go
@@ -90,7 +90,6 @@ func TestCauseShortByte(t *testing.T) {
 }
 
 func TestUnwrap(t *testing.T) {
-
 	// check errors that get wrapped
 	for idx, err := range []error{
 		errors.New("test"),
@@ -124,14 +123,11 @@ func TestUnwrap(t *testing.T) {
 			if errors.Unwrap(cerr) != nil {
 				t.Fatal()
 			}
-
 		})
 	}
-
 }
 
 func TestSimpleQuoteStr(t *testing.T) {
-
 	// check some cases for simpleQuoteStr
 	type tcase struct {
 		in  string
@@ -181,5 +177,4 @@ func TestSimpleQuoteStr(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/msgp/errors_tinygo.go
+++ b/msgp/errors_tinygo.go
@@ -1,3 +1,4 @@
+//go:build tinygo
 // +build tinygo
 
 package msgp
@@ -24,7 +25,6 @@ type stringer interface {
 }
 
 func ifToStr(i interface{}) string {
-
 	switch v := i.(type) {
 	case stringer:
 		return v.String()
@@ -35,7 +35,6 @@ func ifToStr(i interface{}) string {
 	default:
 		return reflect.ValueOf(i).String()
 	}
-
 }
 
 func quoteStr(s string) string {

--- a/msgp/extension.go
+++ b/msgp/extension.go
@@ -31,7 +31,7 @@ var extensionReg = make(map[int8]func() Extension)
 //
 // For example, if you wanted to register a user-defined struct:
 //
-//  msgp.RegisterExtension(10, func() msgp.Extension { &MyExtension{} })
+//	msgp.RegisterExtension(10, func() msgp.Extension { &MyExtension{} })
 //
 // RegisterExtension will panic if you call it multiple times
 // with the same 'typ' argument, or if you use a reserved

--- a/msgp/file.go
+++ b/msgp/file.go
@@ -1,5 +1,7 @@
+//go:build (linux || darwin || dragonfly || freebsd || netbsd || openbsd) && !appengine && !tinygo
 // +build linux darwin dragonfly freebsd netbsd openbsd
-// +build !appengine,!tinygo
+// +build !appengine
+// +build !tinygo
 
 package msgp
 
@@ -20,7 +22,6 @@ import (
 // is only efficient for large files; small
 // files are best read and written using
 // the ordinary streaming interfaces.
-//
 func ReadFile(dst Unmarshaler, file *os.File) error {
 	stat, err := file.Stat()
 	if err != nil {

--- a/msgp/file_port.go
+++ b/msgp/file_port.go
@@ -1,3 +1,4 @@
+//go:build windows || appengine || tinygo
 // +build windows appengine tinygo
 
 package msgp

--- a/msgp/file_test.go
+++ b/msgp/file_test.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin || dragonfly || freebsd || netbsd || openbsd
 // +build linux darwin dragonfly freebsd netbsd openbsd
 
 package msgp_test
@@ -64,10 +65,9 @@ func TestReadWriteFile(t *testing.T) {
 var blobstrings = []string{"", "a string", "a longer string here!"}
 var blobfloats = []float64{0.0, -1.0, 1.0, 3.1415926535}
 var blobints = []int64{0, 1, -1, 80000, 1 << 30}
-var blobbytes = [][]byte{[]byte{}, []byte("hello"), []byte("{\"is_json\":true,\"is_compact\":\"unable to determine\"}")}
+var blobbytes = [][]byte{{}, []byte("hello"), []byte("{\"is_json\":true,\"is_compact\":\"unable to determine\"}")}
 
 func BenchmarkWriteReadFile(b *testing.B) {
-
 	// let's not run out of disk space...
 	if b.N > 10000000 {
 		b.N = 10000000 //nolint:staticcheck // ignoring "SA3001: should not assign to b.N (staticcheck)" as this should not usually happen.

--- a/msgp/file_test.go
+++ b/msgp/file_test.go
@@ -62,10 +62,12 @@ func TestReadWriteFile(t *testing.T) {
 	}
 }
 
-var blobstrings = []string{"", "a string", "a longer string here!"}
-var blobfloats = []float64{0.0, -1.0, 1.0, 3.1415926535}
-var blobints = []int64{0, 1, -1, 80000, 1 << 30}
-var blobbytes = [][]byte{{}, []byte("hello"), []byte("{\"is_json\":true,\"is_compact\":\"unable to determine\"}")}
+var (
+	blobstrings = []string{"", "a string", "a longer string here!"}
+	blobfloats  = []float64{0.0, -1.0, 1.0, 3.1415926535}
+	blobints    = []int64{0, 1, -1, 80000, 1 << 30}
+	blobbytes   = [][]byte{{}, []byte("hello"), []byte(`{"is_json":true,"is_compact":"unable to determine"}`)}
+)
 
 func BenchmarkWriteReadFile(b *testing.B) {
 	// let's not run out of disk space...

--- a/msgp/json_bytes.go
+++ b/msgp/json_bytes.go
@@ -12,7 +12,6 @@ import (
 var unfuns [_maxtype]func(jsWriter, []byte, []byte) ([]byte, []byte, error)
 
 func init() {
-
 	// NOTE(pmh): this is best expressed as a jump table,
 	// but gc doesn't do that yet. revisit post-go1.5.
 	unfuns = [_maxtype]func(jsWriter, []byte, []byte) ([]byte, []byte, error){

--- a/msgp/json_bytes_test.go
+++ b/msgp/json_bytes_test.go
@@ -72,7 +72,6 @@ func TestUnmarshalJSON(t *testing.T) {
 		} else {
 			t.Error(`can't type-assert "c" to map[string]interface{}`)
 		}
-
 	}
 
 	t.Logf("JSON: %s", js.Bytes())

--- a/msgp/number.go
+++ b/msgp/number.go
@@ -29,7 +29,6 @@ type Number struct {
 
 // AsInt sets the number to an int64.
 func (n *Number) AsInt(i int64) {
-
 	// we always store int(0)
 	// as {0, InvalidType} in
 	// order to preserve

--- a/msgp/number_test.go
+++ b/msgp/number_test.go
@@ -6,7 +6,6 @@ import (
 )
 
 func TestNumber(t *testing.T) {
-
 	n := Number{}
 
 	if n.Type() != IntType {
@@ -93,5 +92,4 @@ func TestNumber(t *testing.T) {
 	if !bytes.Equal(dat, buf.Bytes()) {
 		t.Errorf("encode: expected output %#v; got %#v", dat, buf.Bytes())
 	}
-
 }

--- a/msgp/purego.go
+++ b/msgp/purego.go
@@ -1,3 +1,4 @@
+//go:build purego || appengine
 // +build purego appengine
 
 package msgp

--- a/msgp/read.go
+++ b/msgp/read.go
@@ -395,7 +395,7 @@ func (m *Reader) ReadMapKey(scratch []byte) ([]byte, error) {
 	return out, nil
 }
 
-// MapKeyPtr returns a []byte pointing to the contents
+// ReadMapKeyPtr returns a []byte pointing to the contents
 // of a valid map key. The key cannot be empty, and it
 // must be shorter than the total buffer size of the
 // *Reader. Additionally, the returned slice is only

--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -153,9 +153,11 @@ func (r *Raw) MarshalJSON() ([]byte, error) {
 
 // ReadMapHeaderBytes reads a map header size
 // from 'b' and returns the remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (too few bytes)
-// - TypeError{} (not a map)
+//
+//   - ErrShortBytes (too few bytes)
+//   - TypeError{} (not a map)
 func ReadMapHeaderBytes(b []byte) (sz uint32, o []byte, err error) {
 	l := len(b)
 	if l < 1 {
@@ -197,9 +199,11 @@ func ReadMapHeaderBytes(b []byte) (sz uint32, o []byte, err error) {
 
 // ReadMapKeyZC attempts to read a map key
 // from 'b' and returns the key bytes and the remaining bytes
+//
 // Possible errors:
-// - ErrShortBytes (too few bytes)
-// - TypeError{} (not a str or bin)
+//
+//   - ErrShortBytes (too few bytes)
+//   - TypeError{} (not a str or bin)
 func ReadMapKeyZC(b []byte) ([]byte, []byte, error) {
 	o, x, err := ReadStringZC(b)
 	if err != nil {
@@ -214,9 +218,11 @@ func ReadMapKeyZC(b []byte) ([]byte, []byte, error) {
 // ReadArrayHeaderBytes attempts to read
 // the array header size off of 'b' and return
 // the size and remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (too few bytes)
-// - TypeError{} (not an array)
+//
+//   - ErrShortBytes (too few bytes)
+//   - TypeError{} (not an array)
 func ReadArrayHeaderBytes(b []byte) (sz uint32, o []byte, err error) {
 	if len(b) < 1 {
 		return 0, nil, ErrShortBytes
@@ -255,9 +261,11 @@ func ReadArrayHeaderBytes(b []byte) (sz uint32, o []byte, err error) {
 
 // ReadBytesHeader reads the 'bin' header size
 // off of 'b' and returns the size and remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (too few bytes)
-// - TypeError{} (not a bin object)
+//
+//   - ErrShortBytes (too few bytes)
+//   - TypeError{} (not a bin object)
 func ReadBytesHeader(b []byte) (sz uint32, o []byte, err error) {
 	if len(b) < 1 {
 		return 0, nil, ErrShortBytes
@@ -295,10 +303,12 @@ func ReadBytesHeader(b []byte) (sz uint32, o []byte, err error) {
 
 // ReadNilBytes tries to read a "nil" byte
 // off of 'b' and return the remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (too few bytes)
-// - TypeError{} (not a 'nil')
-// - InvalidPrefixError
+//
+//   - ErrShortBytes (too few bytes)
+//   - TypeError{} (not a 'nil')
+//   - InvalidPrefixError
 func ReadNilBytes(b []byte) ([]byte, error) {
 	if len(b) < 1 {
 		return nil, ErrShortBytes
@@ -311,9 +321,11 @@ func ReadNilBytes(b []byte) ([]byte, error) {
 
 // ReadFloat64Bytes tries to read a float64
 // from 'b' and return the value and the remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (too few bytes)
-// - TypeError{} (not a float64)
+//
+//   - ErrShortBytes (too few bytes)
+//   - TypeError{} (not a float64)
 func ReadFloat64Bytes(b []byte) (f float64, o []byte, err error) {
 	if len(b) < 9 {
 		if len(b) >= 5 && b[0] == mfloat32 {
@@ -344,9 +356,11 @@ func ReadFloat64Bytes(b []byte) (f float64, o []byte, err error) {
 
 // ReadFloat32Bytes tries to read a float64
 // from 'b' and return the value and the remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (too few bytes)
-// - TypeError{} (not a float32)
+//
+//   - ErrShortBytes (too few bytes)
+//   - TypeError{} (not a float32)
 func ReadFloat32Bytes(b []byte) (f float32, o []byte, err error) {
 	if len(b) < 5 {
 		err = ErrShortBytes
@@ -365,9 +379,11 @@ func ReadFloat32Bytes(b []byte) (f float32, o []byte, err error) {
 
 // ReadBoolBytes tries to read a float64
 // from 'b' and return the value and the remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (too few bytes)
-// - TypeError{} (not a bool)
+//
+//   - ErrShortBytes (too few bytes)
+//   - TypeError{} (not a bool)
 func ReadBoolBytes(b []byte) (bool, []byte, error) {
 	if len(b) < 1 {
 		return false, b, ErrShortBytes
@@ -384,9 +400,11 @@ func ReadBoolBytes(b []byte) (bool, []byte, error) {
 
 // ReadDurationBytes tries to read a time.Duration
 // from 'b' and return the value and the remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (too few bytes)
-// - TypeError (not a int)
+//
+//   - ErrShortBytes (too few bytes)
+//   - TypeError (not a int)
 func ReadDurationBytes(b []byte) (d time.Duration, o []byte, err error) {
 	i, o, err := ReadInt64Bytes(b)
 	return time.Duration(i), o, err
@@ -394,9 +412,11 @@ func ReadDurationBytes(b []byte) (d time.Duration, o []byte, err error) {
 
 // ReadInt64Bytes tries to read an int64
 // from 'b' and return the value and the remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (too few bytes)
-// - TypeError (not a int)
+//
+//   - ErrShortBytes (too few bytes)
+//   - TypeError (not a int)
 func ReadInt64Bytes(b []byte) (i int64, o []byte, err error) {
 	l := len(b)
 	if l < 1 {
@@ -501,10 +521,12 @@ func ReadInt64Bytes(b []byte) (i int64, o []byte, err error) {
 
 // ReadInt32Bytes tries to read an int32
 // from 'b' and return the value and the remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (too few bytes)
-// - TypeError{} (not a int)
-// - IntOverflow{} (value doesn't fit in int32)
+//
+//   - ErrShortBytes (too few bytes)
+//   - TypeError{} (not a int)
+//   - IntOverflow{} (value doesn't fit in int32)
 func ReadInt32Bytes(b []byte) (int32, []byte, error) {
 	i, o, err := ReadInt64Bytes(b)
 	if i > math.MaxInt32 || i < math.MinInt32 {
@@ -515,10 +537,12 @@ func ReadInt32Bytes(b []byte) (int32, []byte, error) {
 
 // ReadInt16Bytes tries to read an int16
 // from 'b' and return the value and the remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (too few bytes)
-// - TypeError{} (not a int)
-// - IntOverflow{} (value doesn't fit in int16)
+//
+//   - ErrShortBytes (too few bytes)
+//   - TypeError{} (not a int)
+//   - IntOverflow{} (value doesn't fit in int16)
 func ReadInt16Bytes(b []byte) (int16, []byte, error) {
 	i, o, err := ReadInt64Bytes(b)
 	if i > math.MaxInt16 || i < math.MinInt16 {
@@ -529,10 +553,12 @@ func ReadInt16Bytes(b []byte) (int16, []byte, error) {
 
 // ReadInt8Bytes tries to read an int16
 // from 'b' and return the value and the remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (too few bytes)
-// - TypeError{} (not a int)
-// - IntOverflow{} (value doesn't fit in int8)
+//
+//   - ErrShortBytes (too few bytes)
+//   - TypeError{} (not a int)
+//   - IntOverflow{} (value doesn't fit in int8)
 func ReadInt8Bytes(b []byte) (int8, []byte, error) {
 	i, o, err := ReadInt64Bytes(b)
 	if i > math.MaxInt8 || i < math.MinInt8 {
@@ -543,10 +569,12 @@ func ReadInt8Bytes(b []byte) (int8, []byte, error) {
 
 // ReadIntBytes tries to read an int
 // from 'b' and return the value and the remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (too few bytes)
-// - TypeError{} (not a int)
-// - IntOverflow{} (value doesn't fit in int; 32-bit platforms only)
+//
+//   - ErrShortBytes (too few bytes)
+//   - TypeError{} (not a int)
+//   - IntOverflow{} (value doesn't fit in int; 32-bit platforms only)
 func ReadIntBytes(b []byte) (int, []byte, error) {
 	if smallint {
 		i, b, err := ReadInt32Bytes(b)
@@ -558,9 +586,11 @@ func ReadIntBytes(b []byte) (int, []byte, error) {
 
 // ReadUint64Bytes tries to read a uint64
 // from 'b' and return the value and the remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (too few bytes)
-// - TypeError{} (not a uint)
+//
+//   - ErrShortBytes (too few bytes)
+//   - TypeError{} (not a uint)
 func ReadUint64Bytes(b []byte) (u uint64, o []byte, err error) {
 	l := len(b)
 	if l < 1 {
@@ -679,10 +709,12 @@ func ReadUint64Bytes(b []byte) (u uint64, o []byte, err error) {
 
 // ReadUint32Bytes tries to read a uint32
 // from 'b' and return the value and the remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (too few bytes)
-// - TypeError{} (not a uint)
-// - UintOverflow{} (value too large for uint32)
+//
+//   - ErrShortBytes (too few bytes)
+//   - TypeError{} (not a uint)
+//   - UintOverflow{} (value too large for uint32)
 func ReadUint32Bytes(b []byte) (uint32, []byte, error) {
 	v, o, err := ReadUint64Bytes(b)
 	if v > math.MaxUint32 {
@@ -693,10 +725,12 @@ func ReadUint32Bytes(b []byte) (uint32, []byte, error) {
 
 // ReadUint16Bytes tries to read a uint16
 // from 'b' and return the value and the remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (too few bytes)
-// - TypeError{} (not a uint)
-// - UintOverflow{} (value too large for uint16)
+//
+//   - ErrShortBytes (too few bytes)
+//   - TypeError{} (not a uint)
+//   - UintOverflow{} (value too large for uint16)
 func ReadUint16Bytes(b []byte) (uint16, []byte, error) {
 	v, o, err := ReadUint64Bytes(b)
 	if v > math.MaxUint16 {
@@ -707,10 +741,12 @@ func ReadUint16Bytes(b []byte) (uint16, []byte, error) {
 
 // ReadUint8Bytes tries to read a uint8
 // from 'b' and return the value and the remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (too few bytes)
-// - TypeError{} (not a uint)
-// - UintOverflow{} (value too large for uint8)
+//
+//   - ErrShortBytes (too few bytes)
+//   - TypeError{} (not a uint)
+//   - UintOverflow{} (value too large for uint8)
 func ReadUint8Bytes(b []byte) (uint8, []byte, error) {
 	v, o, err := ReadUint64Bytes(b)
 	if v > math.MaxUint8 {
@@ -721,10 +757,12 @@ func ReadUint8Bytes(b []byte) (uint8, []byte, error) {
 
 // ReadUintBytes tries to read a uint
 // from 'b' and return the value and the remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (too few bytes)
-// - TypeError{} (not a uint)
-// - UintOverflow{} (value too large for uint; 32-bit platforms only)
+//
+//   - ErrShortBytes (too few bytes)
+//   - TypeError{} (not a uint)
+//   - UintOverflow{} (value too large for uint; 32-bit platforms only)
 func ReadUintBytes(b []byte) (uint, []byte, error) {
 	if smallint {
 		u, b, err := ReadUint32Bytes(b)
@@ -742,9 +780,11 @@ func ReadByteBytes(b []byte) (byte, []byte, error) {
 // ReadBytesBytes reads a 'bin' object
 // from 'b' and returns its vaue and
 // the remaining bytes in 'b'.
+//
 // Possible errors:
-// - ErrShortBytes (too few bytes)
-// - TypeError{} (not a 'bin' object)
+//
+//   - ErrShortBytes (too few bytes)
+//   - TypeError{} (not a 'bin' object)
 func ReadBytesBytes(b []byte, scratch []byte) (v []byte, o []byte, err error) {
 	return readBytesBytes(b, scratch, false)
 }
@@ -813,9 +853,11 @@ func readBytesBytes(b []byte, scratch []byte, zc bool) (v []byte, o []byte, err 
 // ReadBytesZC extracts the messagepack-encoded
 // binary field without copying. The returned []byte
 // points to the same memory as the input slice.
+//
 // Possible errors:
-// - ErrShortBytes (b not long enough)
-// - TypeError{} (object not 'bin')
+//
+//   - ErrShortBytes (b not long enough)
+//   - TypeError{} (object not 'bin')
 func ReadBytesZC(b []byte) (v []byte, o []byte, err error) {
 	return readBytesBytes(b, nil, true)
 }
@@ -873,9 +915,11 @@ func ReadExactBytes(b []byte, into []byte) (o []byte, err error) {
 // ReadStringZC reads a messagepack string field
 // without copying. The returned []byte points
 // to the same memory as the input slice.
+//
 // Possible errors:
-// - ErrShortBytes (b not long enough)
-// - TypeError{} (object not 'str')
+//
+//   - ErrShortBytes (b not long enough)
+//   - TypeError{} (object not 'str')
 func ReadStringZC(b []byte) (v []byte, o []byte, err error) {
 	l := len(b)
 	if l < 1 {
@@ -933,10 +977,12 @@ func ReadStringZC(b []byte) (v []byte, o []byte, err error) {
 // ReadStringBytes reads a 'str' object
 // from 'b' and returns its value and the
 // remaining bytes in 'b'.
+//
 // Possible errors:
-// - ErrShortBytes (b not long enough)
-// - TypeError{} (not 'str' type)
-// - InvalidPrefixError
+//
+//   - ErrShortBytes (b not long enough)
+//   - TypeError{} (not 'str' type)
+//   - InvalidPrefixError
 func ReadStringBytes(b []byte) (string, []byte, error) {
 	v, o, err := ReadStringZC(b)
 	return string(v), o, err
@@ -946,11 +992,13 @@ func ReadStringBytes(b []byte) (string, []byte, error) {
 // into a slice of bytes. 'v' is the value of
 // the 'str' object, which may reside in memory
 // pointed to by 'scratch.' 'o' is the remaining bytes
-// in 'b.''
+// in 'b'.
+//
 // Possible errors:
-// - ErrShortBytes (b not long enough)
-// - TypeError{} (not 'str' type)
-// - InvalidPrefixError (unknown type marker)
+//
+//   - ErrShortBytes (b not long enough)
+//   - TypeError{} (not 'str' type)
+//   - InvalidPrefixError (unknown type marker)
 func ReadStringAsBytes(b []byte, scratch []byte) (v []byte, o []byte, err error) {
 	var tmp []byte
 	tmp, o, err = ReadStringZC(b)
@@ -961,11 +1009,13 @@ func ReadStringAsBytes(b []byte, scratch []byte) (v []byte, o []byte, err error)
 // ReadComplex128Bytes reads a complex128
 // extension object from 'b' and returns the
 // remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (not enough bytes in 'b')
-// - TypeError{} (object not a complex128)
-// - InvalidPrefixError
-// - ExtensionTypeError{} (object an extension of the correct size, but not a complex128)
+//
+//   - ErrShortBytes (not enough bytes in 'b')
+//   - TypeError{} (object not a complex128)
+//   - InvalidPrefixError
+//   - ExtensionTypeError{} (object an extension of the correct size, but not a complex128)
 func ReadComplex128Bytes(b []byte) (c complex128, o []byte, err error) {
 	if len(b) < 18 {
 		err = ErrShortBytes
@@ -988,10 +1038,12 @@ func ReadComplex128Bytes(b []byte) (c complex128, o []byte, err error) {
 // ReadComplex64Bytes reads a complex64
 // extension object from 'b' and returns the
 // remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (not enough bytes in 'b')
-// - TypeError{} (object not a complex64)
-// - ExtensionTypeError{} (object an extension of the correct size, but not a complex64)
+//
+//   - ErrShortBytes (not enough bytes in 'b')
+//   - TypeError{} (object not a complex64)
+//   - ExtensionTypeError{} (object an extension of the correct size, but not a complex64)
 func ReadComplex64Bytes(b []byte) (c complex64, o []byte, err error) {
 	if len(b) < 10 {
 		err = ErrShortBytes
@@ -1014,10 +1066,12 @@ func ReadComplex64Bytes(b []byte) (c complex64, o []byte, err error) {
 // ReadTimeBytes reads a time.Time
 // extension object from 'b' and returns the
 // remaining bytes.
+//
 // Possible errors:
-// - ErrShortBytes (not enough bytes in 'b')
-// - TypeError{} (object not a complex64)
-// - ExtensionTypeError{} (object an extension of the correct size, but not a time.Time)
+//
+//   - ErrShortBytes (not enough bytes in 'b')
+//   - TypeError{} (object not a complex64)
+//   - ExtensionTypeError{} (object an extension of the correct size, but not a time.Time)
 func ReadTimeBytes(b []byte) (t time.Time, o []byte, err error) {
 	if len(b) < 15 {
 		err = ErrShortBytes
@@ -1186,9 +1240,11 @@ func ReadIntfBytes(b []byte) (i interface{}, o []byte, err error) {
 // returns the remaining bytes. If the object
 // is a map or array, all of its elements
 // will be skipped.
-// Possible Errors:
-// - ErrShortBytes (not enough bytes in b)
-// - InvalidPrefixError (bad encoding)
+//
+// Possible errors:
+//
+//   - ErrShortBytes (not enough bytes in b)
+//   - InvalidPrefixError (bad encoding)
 func Skip(b []byte) ([]byte, error) {
 	sz, asz, err := getSize(b)
 	if err != nil {

--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -12,7 +12,7 @@ var big = binary.BigEndian
 // NextType returns the type of the next
 // object in the slice. If the length
 // of the input is zero, it returns
-// InvalidType.
+// [InvalidType].
 func NextType(b []byte) Type {
 	if len(b) == 0 {
 		return InvalidType
@@ -55,7 +55,7 @@ func IsNil(b []byte) bool {
 // data without interpreting its contents.
 type Raw []byte
 
-// MarshalMsg implements msgp.Marshaler.
+// MarshalMsg implements [Marshaler].
 // It appends the raw contents of 'raw'
 // to the provided byte slice. If 'raw'
 // is 0 bytes, 'nil' will be appended instead.
@@ -69,7 +69,7 @@ func (r Raw) MarshalMsg(b []byte) ([]byte, error) {
 	return o, nil
 }
 
-// UnmarshalMsg implements msgp.Unmarshaler.
+// UnmarshalMsg implements [Unmarshaler].
 // It sets the contents of *Raw to be the next
 // object in the provided byte slice.
 func (r *Raw) UnmarshalMsg(b []byte) ([]byte, error) {
@@ -91,7 +91,7 @@ func (r *Raw) UnmarshalMsg(b []byte) ([]byte, error) {
 	return out, nil
 }
 
-// EncodeMsg implements msgp.Encodable.
+// EncodeMsg implements [Encodable].
 // It writes the raw bytes to the writer.
 // If r is empty, it writes 'nil' instead.
 func (r Raw) EncodeMsg(w *Writer) error {
@@ -102,7 +102,7 @@ func (r Raw) EncodeMsg(w *Writer) error {
 	return err
 }
 
-// DecodeMsg implements msgp.Decodable.
+// DecodeMsg implements [Decodable].
 // It sets the value of *Raw to be the
 // next object on the wire.
 func (r *Raw) DecodeMsg(f *Reader) error {
@@ -114,7 +114,7 @@ func (r *Raw) DecodeMsg(f *Reader) error {
 	return err
 }
 
-// Msgsize implements msgp.Sizer
+// Msgsize implements [Sizer].
 func (r Raw) Msgsize() int {
 	l := len(r)
 	if l == 0 {
@@ -144,7 +144,7 @@ func appendNext(f *Reader, d *[]byte) error {
 	return nil
 }
 
-// MarshalJSON implements json.Marshaler
+// MarshalJSON implements [json.Marshaler].
 func (r *Raw) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
 	_, err := UnmarshalAsJSON(&buf, []byte(*r))
@@ -156,8 +156,8 @@ func (r *Raw) MarshalJSON() ([]byte, error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (too few bytes)
-//   - TypeError{} (not a map)
+//   - [ErrShortBytes] (too few bytes)
+//   - [TypeError] (not a map)
 func ReadMapHeaderBytes(b []byte) (sz uint32, o []byte, err error) {
 	l := len(b)
 	if l < 1 {
@@ -202,8 +202,8 @@ func ReadMapHeaderBytes(b []byte) (sz uint32, o []byte, err error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (too few bytes)
-//   - TypeError{} (not a str or bin)
+//   - [ErrShortBytes] (too few bytes)
+//   - [TypeError] (not a str or bin)
 func ReadMapKeyZC(b []byte) ([]byte, []byte, error) {
 	o, x, err := ReadStringZC(b)
 	if err != nil {
@@ -221,8 +221,8 @@ func ReadMapKeyZC(b []byte) ([]byte, []byte, error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (too few bytes)
-//   - TypeError{} (not an array)
+//   - [ErrShortBytes] (too few bytes)
+//   - [TypeError] (not an array)
 func ReadArrayHeaderBytes(b []byte) (sz uint32, o []byte, err error) {
 	if len(b) < 1 {
 		return 0, nil, ErrShortBytes
@@ -264,8 +264,8 @@ func ReadArrayHeaderBytes(b []byte) (sz uint32, o []byte, err error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (too few bytes)
-//   - TypeError{} (not a bin object)
+//   - [ErrShortBytes] (too few bytes)
+//   - [TypeError] (not a bin object)
 func ReadBytesHeader(b []byte) (sz uint32, o []byte, err error) {
 	if len(b) < 1 {
 		return 0, nil, ErrShortBytes
@@ -306,9 +306,9 @@ func ReadBytesHeader(b []byte) (sz uint32, o []byte, err error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (too few bytes)
-//   - TypeError{} (not a 'nil')
-//   - InvalidPrefixError
+//   - [ErrShortBytes] (too few bytes)
+//   - [TypeError] (not a 'nil')
+//   - [InvalidPrefixError]
 func ReadNilBytes(b []byte) ([]byte, error) {
 	if len(b) < 1 {
 		return nil, ErrShortBytes
@@ -324,8 +324,8 @@ func ReadNilBytes(b []byte) ([]byte, error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (too few bytes)
-//   - TypeError{} (not a float64)
+//   - [ErrShortBytes] (too few bytes)
+//   - [TypeError] (not a float64)
 func ReadFloat64Bytes(b []byte) (f float64, o []byte, err error) {
 	if len(b) < 9 {
 		if len(b) >= 5 && b[0] == mfloat32 {
@@ -359,8 +359,8 @@ func ReadFloat64Bytes(b []byte) (f float64, o []byte, err error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (too few bytes)
-//   - TypeError{} (not a float32)
+//   - [ErrShortBytes] (too few bytes)
+//   - [TypeError] (not a float32)
 func ReadFloat32Bytes(b []byte) (f float32, o []byte, err error) {
 	if len(b) < 5 {
 		err = ErrShortBytes
@@ -382,8 +382,8 @@ func ReadFloat32Bytes(b []byte) (f float32, o []byte, err error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (too few bytes)
-//   - TypeError{} (not a bool)
+//   - [ErrShortBytes] (too few bytes)
+//   - [TypeError] (not a bool)
 func ReadBoolBytes(b []byte) (bool, []byte, error) {
 	if len(b) < 1 {
 		return false, b, ErrShortBytes
@@ -403,7 +403,7 @@ func ReadBoolBytes(b []byte) (bool, []byte, error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (too few bytes)
+//   - [ErrShortBytes] (too few bytes)
 //   - TypeError (not a int)
 func ReadDurationBytes(b []byte) (d time.Duration, o []byte, err error) {
 	i, o, err := ReadInt64Bytes(b)
@@ -415,8 +415,8 @@ func ReadDurationBytes(b []byte) (d time.Duration, o []byte, err error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (too few bytes)
-//   - TypeError (not a int)
+//   - [ErrShortBytes] (too few bytes)
+//   - [TypeError] (not a int)
 func ReadInt64Bytes(b []byte) (i int64, o []byte, err error) {
 	l := len(b)
 	if l < 1 {
@@ -524,9 +524,9 @@ func ReadInt64Bytes(b []byte) (i int64, o []byte, err error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (too few bytes)
-//   - TypeError{} (not a int)
-//   - IntOverflow{} (value doesn't fit in int32)
+//   - [ErrShortBytes] (too few bytes)
+//   - [TypeError] (not a int)
+//   - [IntOverflow] (value doesn't fit in int32)
 func ReadInt32Bytes(b []byte) (int32, []byte, error) {
 	i, o, err := ReadInt64Bytes(b)
 	if i > math.MaxInt32 || i < math.MinInt32 {
@@ -540,9 +540,9 @@ func ReadInt32Bytes(b []byte) (int32, []byte, error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (too few bytes)
-//   - TypeError{} (not a int)
-//   - IntOverflow{} (value doesn't fit in int16)
+//   - [ErrShortBytes] (too few bytes)
+//   - [TypeError] (not a int)
+//   - [IntOverflow] (value doesn't fit in int16)
 func ReadInt16Bytes(b []byte) (int16, []byte, error) {
 	i, o, err := ReadInt64Bytes(b)
 	if i > math.MaxInt16 || i < math.MinInt16 {
@@ -556,9 +556,9 @@ func ReadInt16Bytes(b []byte) (int16, []byte, error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (too few bytes)
-//   - TypeError{} (not a int)
-//   - IntOverflow{} (value doesn't fit in int8)
+//   - [ErrShortBytes] (too few bytes)
+//   - [TypeError] (not a int)
+//   - [IntOverflow] (value doesn't fit in int8)
 func ReadInt8Bytes(b []byte) (int8, []byte, error) {
 	i, o, err := ReadInt64Bytes(b)
 	if i > math.MaxInt8 || i < math.MinInt8 {
@@ -572,9 +572,9 @@ func ReadInt8Bytes(b []byte) (int8, []byte, error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (too few bytes)
-//   - TypeError{} (not a int)
-//   - IntOverflow{} (value doesn't fit in int; 32-bit platforms only)
+//   - [ErrShortBytes] (too few bytes)
+//   - [TypeError] (not a int)
+//   - [IntOverflow] (value doesn't fit in int; 32-bit platforms only)
 func ReadIntBytes(b []byte) (int, []byte, error) {
 	if smallint {
 		i, b, err := ReadInt32Bytes(b)
@@ -589,8 +589,8 @@ func ReadIntBytes(b []byte) (int, []byte, error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (too few bytes)
-//   - TypeError{} (not a uint)
+//   - [ErrShortBytes] (too few bytes)
+//   - [TypeError] (not a uint)
 func ReadUint64Bytes(b []byte) (u uint64, o []byte, err error) {
 	l := len(b)
 	if l < 1 {
@@ -712,9 +712,9 @@ func ReadUint64Bytes(b []byte) (u uint64, o []byte, err error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (too few bytes)
-//   - TypeError{} (not a uint)
-//   - UintOverflow{} (value too large for uint32)
+//   - [ErrShortBytes] (too few bytes)
+//   - [TypeError] (not a uint)
+//   - [UintOverflow] (value too large for uint32)
 func ReadUint32Bytes(b []byte) (uint32, []byte, error) {
 	v, o, err := ReadUint64Bytes(b)
 	if v > math.MaxUint32 {
@@ -728,9 +728,9 @@ func ReadUint32Bytes(b []byte) (uint32, []byte, error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (too few bytes)
-//   - TypeError{} (not a uint)
-//   - UintOverflow{} (value too large for uint16)
+//   - [ErrShortBytes] (too few bytes)
+//   - [TypeError] (not a uint)
+//   - [UintOverflow] (value too large for uint16)
 func ReadUint16Bytes(b []byte) (uint16, []byte, error) {
 	v, o, err := ReadUint64Bytes(b)
 	if v > math.MaxUint16 {
@@ -744,9 +744,9 @@ func ReadUint16Bytes(b []byte) (uint16, []byte, error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (too few bytes)
-//   - TypeError{} (not a uint)
-//   - UintOverflow{} (value too large for uint8)
+//   - [ErrShortBytes] (too few bytes)
+//   - [TypeError] (not a uint)
+//   - [UintOverflow] (value too large for uint8)
 func ReadUint8Bytes(b []byte) (uint8, []byte, error) {
 	v, o, err := ReadUint64Bytes(b)
 	if v > math.MaxUint8 {
@@ -760,9 +760,9 @@ func ReadUint8Bytes(b []byte) (uint8, []byte, error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (too few bytes)
-//   - TypeError{} (not a uint)
-//   - UintOverflow{} (value too large for uint; 32-bit platforms only)
+//   - [ErrShortBytes] (too few bytes)
+//   - [TypeError] (not a uint)
+//   - [UintOverflow] (value too large for uint; 32-bit platforms only)
 func ReadUintBytes(b []byte) (uint, []byte, error) {
 	if smallint {
 		u, b, err := ReadUint32Bytes(b)
@@ -783,8 +783,8 @@ func ReadByteBytes(b []byte) (byte, []byte, error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (too few bytes)
-//   - TypeError{} (not a 'bin' object)
+//   - [ErrShortBytes] (too few bytes)
+//   - [TypeError] (not a 'bin' object)
 func ReadBytesBytes(b []byte, scratch []byte) (v []byte, o []byte, err error) {
 	return readBytesBytes(b, scratch, false)
 }
@@ -856,8 +856,8 @@ func readBytesBytes(b []byte, scratch []byte, zc bool) (v []byte, o []byte, err 
 //
 // Possible errors:
 //
-//   - ErrShortBytes (b not long enough)
-//   - TypeError{} (object not 'bin')
+//   - [ErrShortBytes] (b not long enough)
+//   - [TypeError] (object not 'bin')
 func ReadBytesZC(b []byte) (v []byte, o []byte, err error) {
 	return readBytesBytes(b, nil, true)
 }
@@ -918,8 +918,8 @@ func ReadExactBytes(b []byte, into []byte) (o []byte, err error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (b not long enough)
-//   - TypeError{} (object not 'str')
+//   - [ErrShortBytes] (b not long enough)
+//   - [TypeError] (object not 'str')
 func ReadStringZC(b []byte) (v []byte, o []byte, err error) {
 	l := len(b)
 	if l < 1 {
@@ -980,9 +980,9 @@ func ReadStringZC(b []byte) (v []byte, o []byte, err error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (b not long enough)
-//   - TypeError{} (not 'str' type)
-//   - InvalidPrefixError
+//   - [ErrShortBytes] (b not long enough)
+//   - [TypeError] (not 'str' type)
+//   - [InvalidPrefixError]
 func ReadStringBytes(b []byte) (string, []byte, error) {
 	v, o, err := ReadStringZC(b)
 	return string(v), o, err
@@ -996,9 +996,9 @@ func ReadStringBytes(b []byte) (string, []byte, error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (b not long enough)
-//   - TypeError{} (not 'str' type)
-//   - InvalidPrefixError (unknown type marker)
+//   - [ErrShortBytes] (b not long enough)
+//   - [TypeError] (not 'str' type)
+//   - [InvalidPrefixError] (unknown type marker)
 func ReadStringAsBytes(b []byte, scratch []byte) (v []byte, o []byte, err error) {
 	var tmp []byte
 	tmp, o, err = ReadStringZC(b)
@@ -1012,10 +1012,10 @@ func ReadStringAsBytes(b []byte, scratch []byte) (v []byte, o []byte, err error)
 //
 // Possible errors:
 //
-//   - ErrShortBytes (not enough bytes in 'b')
-//   - TypeError{} (object not a complex128)
-//   - InvalidPrefixError
-//   - ExtensionTypeError{} (object an extension of the correct size, but not a complex128)
+//   - [ErrShortBytes] (not enough bytes in 'b')
+//   - [TypeError] (object not a complex128)
+//   - [InvalidPrefixError]
+//   - [ExtensionTypeError] (object an extension of the correct size, but not a complex128)
 func ReadComplex128Bytes(b []byte) (c complex128, o []byte, err error) {
 	if len(b) < 18 {
 		err = ErrShortBytes
@@ -1041,9 +1041,9 @@ func ReadComplex128Bytes(b []byte) (c complex128, o []byte, err error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (not enough bytes in 'b')
-//   - TypeError{} (object not a complex64)
-//   - ExtensionTypeError{} (object an extension of the correct size, but not a complex64)
+//   - [ErrShortBytes] (not enough bytes in 'b')
+//   - [TypeError] (object not a complex64)
+//   - [ExtensionTypeError] (object an extension of the correct size, but not a complex64)
 func ReadComplex64Bytes(b []byte) (c complex64, o []byte, err error) {
 	if len(b) < 10 {
 		err = ErrShortBytes
@@ -1069,9 +1069,9 @@ func ReadComplex64Bytes(b []byte) (c complex64, o []byte, err error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (not enough bytes in 'b')
-//   - TypeError{} (object not a complex64)
-//   - ExtensionTypeError{} (object an extension of the correct size, but not a time.Time)
+//   - [ErrShortBytes] (not enough bytes in 'b')
+//   - [TypeError] (object not a complex64)
+//   - [ExtensionTypeError] (object an extension of the correct size, but not a time.Time)
 func ReadTimeBytes(b []byte) (t time.Time, o []byte, err error) {
 	if len(b) < 15 {
 		err = ErrShortBytes
@@ -1243,8 +1243,8 @@ func ReadIntfBytes(b []byte) (i interface{}, o []byte, err error) {
 //
 // Possible errors:
 //
-//   - ErrShortBytes (not enough bytes in b)
-//   - InvalidPrefixError (bad encoding)
+//   - [ErrShortBytes] (not enough bytes in b)
+//   - [InvalidPrefixError] (bad encoding)
 func Skip(b []byte) ([]byte, error) {
 	sz, asz, err := getSize(b)
 	if err != nil {

--- a/msgp/read_bytes_test.go
+++ b/msgp/read_bytes_test.go
@@ -270,8 +270,10 @@ func TestReadInt64Bytes(t *testing.T) {
 	var buf bytes.Buffer
 	wr := NewWriter(&buf)
 
-	ints := []int64{-100000, -5000, -5, 0, 8, 240, int64(tuint16), int64(tuint32), int64(tuint64),
-		-5, -30, 0, 1, 127, 300, 40921, 34908219}
+	ints := []int64{
+		-100000, -5000, -5, 0, 8, 240, int64(tuint16), int64(tuint32), int64(tuint64),
+		-5, -30, 0, 1, 127, 300, 40921, 34908219,
+	}
 
 	uints := []uint64{0, 8, 240, uint64(tuint16), uint64(tuint32), uint64(tuint64)}
 

--- a/msgp/read_bytes_test.go
+++ b/msgp/read_bytes_test.go
@@ -238,7 +238,6 @@ func TestReadBoolBytes(t *testing.T) {
 		en.WriteBool(v)
 		en.Flush()
 		out, left, err := ReadBoolBytes(buf.Bytes())
-
 		if err != nil {
 			t.Errorf("test case %d: %s", i, err)
 		}
@@ -481,7 +480,7 @@ func TestReadBytesBytes(t *testing.T) {
 	var buf bytes.Buffer
 	en := NewWriter(&buf)
 
-	tests := [][]byte{[]byte{}, []byte("some bytes"), []byte("some more bytes")}
+	tests := [][]byte{{}, []byte("some bytes"), []byte("some more bytes")}
 	var scratch []byte
 
 	for i, v := range tests {
@@ -505,7 +504,7 @@ func TestReadZCBytes(t *testing.T) {
 	var buf bytes.Buffer
 	en := NewWriter(&buf)
 
-	tests := [][]byte{[]byte{}, []byte("some bytes"), []byte("some more bytes")}
+	tests := [][]byte{{}, []byte("some bytes"), []byte("some more bytes")}
 
 	for i, v := range tests {
 		buf.Reset()
@@ -721,7 +720,6 @@ func TestReadIntfBytes(t *testing.T) {
 			t.Errorf("ReadIntf(): %v in; %v out", v, out)
 		}
 	}
-
 }
 
 func BenchmarkSkipBytes(b *testing.B) {

--- a/msgp/read_test.go
+++ b/msgp/read_test.go
@@ -77,7 +77,6 @@ func TestReadIntf(t *testing.T) {
 			t.Errorf("%v in; %v out", ts, v)
 		}
 	}
-
 }
 
 func TestReadMapHeader(t *testing.T) {
@@ -857,7 +856,6 @@ func TestSkip(t *testing.T) {
 		t.Errorf("expected %q; got %q", io.EOF, err)
 		t.Errorf("returned type %q", tp)
 	}
-
 }
 
 func BenchmarkSkip(b *testing.B) {

--- a/msgp/read_test.go
+++ b/msgp/read_test.go
@@ -24,7 +24,7 @@ func TestReadIntf(t *testing.T) {
 	// always read out as int64, and
 	// unsigned integers as uint64
 
-	var testCases = []interface{}{
+	testCases := []interface{}{
 		float64(128.032),
 		float32(9082.092),
 		int64(-40),

--- a/msgp/unsafe.go
+++ b/msgp/unsafe.go
@@ -1,3 +1,4 @@
+//go:build !purego && !appengine
 // +build !purego,!appengine
 
 package msgp

--- a/msgp/write.go
+++ b/msgp/write.go
@@ -626,12 +626,12 @@ func (mw *Writer) WriteTime(t time.Time) error {
 
 // WriteIntf writes the concrete type of 'v'.
 // WriteIntf will error if 'v' is not one of the following:
-//  - A bool, float, string, []byte, int, uint, or complex
-//  - A map of supported types (with string keys)
-//  - An array or slice of supported types
-//  - A pointer to a supported type
-//  - A type that satisfies the msgp.Encodable interface
-//  - A type that satisfies the msgp.Extension interface
+//   - A bool, float, string, []byte, int, uint, or complex
+//   - A map of supported types (with string keys)
+//   - An array or slice of supported types
+//   - A pointer to a supported type
+//   - A type that satisfies the msgp.Encodable interface
+//   - A type that satisfies the msgp.Extension interface
 func (mw *Writer) WriteIntf(v interface{}) error {
 	if v == nil {
 		return mw.WriteNil()

--- a/msgp/write_bytes.go
+++ b/msgp/write_bytes.go
@@ -340,13 +340,13 @@ func AppendMapStrIntf(b []byte, m map[string]interface{}) ([]byte, error) {
 
 // AppendIntf appends the concrete type of 'i' to the
 // provided []byte. 'i' must be one of the following:
-//  - 'nil'
-//  - A bool, float, string, []byte, int, uint, or complex
-//  - A map[string]interface{} or map[string]string
-//  - A []T, where T is another supported type
-//  - A *T, where T is another supported type
-//  - A type that satisfieds the msgp.Marshaler interface
-//  - A type that satisfies the msgp.Extension interface
+//   - 'nil'
+//   - A bool, float, string, []byte, int, uint, or complex
+//   - A map[string]interface{} or map[string]string
+//   - A []T, where T is another supported type
+//   - A *T, where T is another supported type
+//   - A type that satisfieds the msgp.Marshaler interface
+//   - A type that satisfies the msgp.Extension interface
 func AppendIntf(b []byte, i interface{}) ([]byte, error) {
 	if i == nil {
 		return AppendNil(b), nil

--- a/msgp/write_test.go
+++ b/msgp/write_test.go
@@ -34,8 +34,10 @@ func TestWriteMapHeader(t *testing.T) {
 		{0, []byte{mfixmap}},
 		{1, []byte{mfixmap | byte(1)}},
 		{100, []byte{mmap16, byte(uint16(100) >> 8), byte(uint16(100))}},
-		{tuint32,
-			[]byte{mmap32,
+		{
+			tuint32,
+			[]byte{
+				mmap32,
 				byte(tuint32 >> 24),
 				byte(tuint32 >> 16),
 				byte(tuint32 >> 8),

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -126,10 +126,10 @@ func (f *FileSet) applyDirectives() {
 // into just one level of indirection.
 // In other words, if we have:
 //
-//  type A uint64
-//  type B A
-//  type C B
-//  type D C
+//	type A uint64
+//	type B A
+//	type C B
+//	type D C
 //
 // ... then we want to end up
 // figuring out that D is just a uint64.
@@ -164,7 +164,6 @@ func (f *FileSet) resolve(ls linkset) {
 // process takes the contents of f.Specs and
 // uses them to populate f.Identities
 func (f *FileSet) process() {
-
 	deferred := make(linkset)
 parse:
 	for name, def := range f.Specs {
@@ -268,23 +267,18 @@ func (f *FileSet) PrintTo(p *gen.Printer) error {
 // getTypeSpecs extracts all of the *ast.TypeSpecs in the file
 // into fs.Identities, but does not set the actual element
 func (fs *FileSet) getTypeSpecs(f *ast.File) {
-
 	// collect all imports...
 	fs.Imports = append(fs.Imports, f.Imports...)
 
 	// check all declarations...
 	for i := range f.Decls {
-
 		// for GenDecls...
 		if g, ok := f.Decls[i].(*ast.GenDecl); ok {
-
 			// and check the specs...
 			for _, s := range g.Specs {
-
 				// for ast.TypeSpecs....
 				if ts, ok := s.(*ast.TypeSpec); ok {
 					switch ts.Type.(type) {
-
 					// this is the list of parse-able
 					// type specs
 					case *ast.StructType,
@@ -293,7 +287,6 @@ func (fs *FileSet) getTypeSpecs(f *ast.File) {
 						*ast.MapType,
 						*ast.Ident:
 						fs.Specs[ts.Name.Name] = ts.Type
-
 					}
 				}
 			}
@@ -432,9 +425,9 @@ func (fs *FileSet) getFieldsFromEmbeddedStruct(f ast.Expr) []gen.StructField {
 //
 // so, for a struct like
 //
-//	type A struct {
-//		io.Writer
-//  }
+//		type A struct {
+//			io.Writer
+//	 }
 //
 // we want "Writer"
 func embedded(f ast.Expr) string {
@@ -578,7 +571,7 @@ var Logf func(s string, v ...interface{})
 func infof(s string, v ...interface{}) {
 	if Logf != nil {
 		pushstate(s)
-		Logf("info: " + strings.Join(logctx, ": "), v...)
+		Logf("info: "+strings.Join(logctx, ": "), v...)
 		popstate()
 	}
 }
@@ -586,7 +579,7 @@ func infof(s string, v ...interface{}) {
 func warnf(s string, v ...interface{}) {
 	if Logf != nil {
 		pushstate(s)
-		Logf("warn: " + strings.Join(logctx, ": "), v...)
+		Logf("warn: "+strings.Join(logctx, ": "), v...)
 		popstate()
 	}
 }
@@ -602,4 +595,3 @@ func pushstate(s string) {
 func popstate() {
 	logctx = logctx[:len(logctx)-1]
 }
-

--- a/printer/print.go
+++ b/printer/print.go
@@ -52,7 +52,7 @@ func format(file string, data []byte) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(file, out, 0600)
+	return ioutil.WriteFile(file, out, 0o600)
 }
 
 func goformat(file string, data []byte) <-chan error {

--- a/tinygotest/testdata/roundtrip/main.go
+++ b/tinygotest/testdata/roundtrip/main.go
@@ -65,7 +65,6 @@ func (e *Example) Setup() {
 	e.Omitted = "nope"
 
 	e.OmitEmptyString = "here"
-
 }
 
 func (e *Example) Eq(e2 *Example) bool {
@@ -143,7 +142,6 @@ func (e *Example) Eq(e2 *Example) bool {
 var buf [256]byte
 
 func main() {
-
 	var e Example
 	e.Setup()
 
@@ -192,5 +190,4 @@ func main() {
 	if bytes.Compare(wbuf.Bytes(), b1) != 0 {
 		panic("writer and marshal produced different results")
 	}
-
 }

--- a/tinygotest/testdata/simple_bytes_append/main.go
+++ b/tinygotest/testdata/simple_bytes_append/main.go
@@ -10,7 +10,6 @@ type Example struct {
 var buf [64]byte
 
 func main() {
-
 	e := Example{
 		I: 1,
 		S: "2",
@@ -28,5 +27,4 @@ func main() {
 		print(b[i], " ")
 	}
 	println()
-
 }

--- a/tinygotest/testdata/simple_bytes_read/main.go
+++ b/tinygotest/testdata/simple_bytes_read/main.go
@@ -8,7 +8,6 @@ type Example struct {
 }
 
 func main() {
-
 	b := []byte{130, 161, 105, 1, 161, 115, 161, 50}
 
 	e := Example{}
@@ -53,5 +52,4 @@ func main() {
 	}
 
 	println("done")
-
 }

--- a/tinygotest/testdata/simple_marshal/main.go
+++ b/tinygotest/testdata/simple_marshal/main.go
@@ -8,7 +8,6 @@ type Example struct {
 }
 
 func main() {
-
 	e := Example{
 		I: 1,
 		S: "2",
@@ -23,5 +22,4 @@ func main() {
 		print(b[i], " ")
 	}
 	println()
-
 }

--- a/tinygotest/testdata/simple_roundtrip/main.go
+++ b/tinygotest/testdata/simple_roundtrip/main.go
@@ -11,7 +11,6 @@ type Example struct {
 }
 
 func main() {
-
 	e := Example{
 		I: 1,
 		S: "2",
@@ -35,5 +34,4 @@ func main() {
 	}
 
 	println("done, len(b):", len(b))
-
 }

--- a/tinygotest/testdata/simple_unmarshal/main.go
+++ b/tinygotest/testdata/simple_unmarshal/main.go
@@ -8,7 +8,6 @@ type Example struct {
 }
 
 func main() {
-
 	b := []byte{130, 161, 105, 1, 161, 115, 161, 50}
 
 	var e2 Example
@@ -25,5 +24,4 @@ func main() {
 	}
 
 	println("done, len(b):", len(b))
-
 }

--- a/tinygotest/tinygo_test.go
+++ b/tinygotest/tinygo_test.go
@@ -1,3 +1,4 @@
+//go:build (amd64 && go1.18) || (darwin && go1.18)
 // +build amd64,go1.18 darwin,go1.18
 
 package tinygotest
@@ -68,7 +69,6 @@ func TestSimpleRoundtripBuild(t *testing.T) {
 	if sz > 20000 {
 		t.Errorf("arduino-nano33.bin is larger than expected: %d", sz)
 	}
-
 }
 
 // simple_marshal is just the MarshalMsg part
@@ -183,7 +183,6 @@ func goGenerate(t *testing.T, dir string) {
 }
 
 func tinygoBuild(t *testing.T, dir string, targets ...string) {
-
 	t.Helper()
 
 	wd, err := os.Getwd()
@@ -222,7 +221,6 @@ func tinygoBuild(t *testing.T, dir string, targets ...string) {
 			t.Fatal(err)
 		}
 	}
-
 }
 
 var spacePad = strings.Repeat(" ", 64)


### PR DESCRIPTION
supersedes / closes https://github.com/tinylib/msgp/pull/234

### gofmt for current versions of go and remove stray whitespace

gofmt the code for current versions of go:

- adds updated build-tag comments as used by current versions, but keeping
  the old format lines to remain compatible with old go versions.
- format some godoc comments to fix rendeing on pkg.go.dev
- uses the (now preferred) `0o` notation for octal values.

also remove stray whitespace to make more linters happy.

before:

<img width="1014" alt="Screenshot 2022-12-11 at 15 15 53" src="https://user-images.githubusercontent.com/1804568/206909017-66c40da8-349e-466e-935d-4bf73e89bc76.png">


after:

<img width="964" alt="Screenshot 2022-12-11 at 15 16 12" src="https://user-images.githubusercontent.com/1804568/206909020-76ad9306-0884-45d9-880e-d66495b79fa6.png">

### fix some godoc comments, and add docs links

Use the "docs links" (`[<reference>]`) format so that the documentation
generates links to the types referenced.

With this patch:

<img width="957" alt="Screenshot 2022-12-11 at 15 25 09" src="https://user-images.githubusercontent.com/1804568/206909435-159de1ab-902b-42fc-9ebe-585093b6792c.png">


### gofumpt code

Format the code with "gofumpt" (https://github.com/mvdan/gofumpt),
which provides a superset of go's default gofmt with some slightly
more opinionated formatting rules (but making more linters happy).

Also updated one string to use a string-literal for readability.

:warning: for reviewers; happy to either drop this commit (if not desirable
or to squash it with the "gofmt" commit).

### replace deprecated os.SEEK_SET for io.SeekStart

These consts deprecated in https://go-review.googlesource.com/21540
(go1.7) in favor of the consts defined in `io`.

### go.mod: update go version to 1.15 to match what's tested

CI tests against go1.15 as minimum version, so update the go.mod
to reflect that. Older versions of Go should still be able to use
the module, as it's not enforced (mostly an indicator as the known
minimum compatible version).

### README: update link to docs website, and add docs reference badge

godoc.org moved to pkg.go.dev, so updating the link; while updating the
file also added a badge to link to the module's reference on pkg.go.dev.