### PR TITLE
all: remove dead code and fix linting issues

### DIFF
--- a/gen/decode.go
+++ b/gen/decode.go
@@ -63,7 +63,6 @@ func (d *decodeGen) gStruct(s *Struct) {
 	} else {
 		d.structAsMap(s)
 	}
-	return
 }
 
 func (d *decodeGen) assignAndCheck(name string, typ string) {

--- a/gen/encode.go
+++ b/gen/encode.go
@@ -78,7 +78,6 @@ func (e *encodeGen) gStruct(s *Struct) {
 	} else {
 		e.structmap(s)
 	}
-	return
 }
 
 func (e *encodeGen) tuple(s *Struct) {

--- a/gen/marshal.go
+++ b/gen/marshal.go
@@ -84,7 +84,6 @@ func (m *marshalGen) gStruct(s *Struct) {
 	} else {
 		m.mapstruct(s)
 	}
-	return
 }
 
 func (m *marshalGen) tuple(s *Struct) {

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -62,25 +62,6 @@ func (m Method) String() string {
 	}
 }
 
-func strtoMeth(s string) Method {
-	switch s {
-	case "encode":
-		return Encode
-	case "decode":
-		return Decode
-	case "marshal":
-		return Marshal
-	case "unmarshal":
-		return Unmarshal
-	case "size":
-		return Size
-	case "test":
-		return Test
-	default:
-		return 0
-	}
-}
-
 const (
 	Decode      Method                       = 1 << iota // msgp.Decodable
 	Encode                                               // msgp.Encodable

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -71,7 +71,6 @@ func (u *unmarshalGen) gStruct(s *Struct) {
 	} else {
 		u.mapstruct(s)
 	}
-	return
 }
 
 func (u *unmarshalGen) tuple(s *Struct) {

--- a/msgp/elsize.go
+++ b/msgp/elsize.go
@@ -120,11 +120,11 @@ type varmode int8
 
 const (
 	constsize varmode = 0  // constant size (size bytes + uint8(varmode) objects)
-	extra8            = -1 // has uint8(p[1]) extra bytes
-	extra16           = -2 // has be16(p[1:]) extra bytes
-	extra32           = -3 // has be32(p[1:]) extra bytes
-	map16v            = -4 // use map16
-	map32v            = -5 // use map32
-	array16v          = -6 // use array16
-	array32v          = -7 // use array32
+	extra8    varmode = -1 // has uint8(p[1]) extra bytes
+	extra16   varmode = -2 // has be16(p[1:]) extra bytes
+	extra32   varmode = -3 // has be32(p[1:]) extra bytes
+	map16v    varmode = -4 // use map16
+	map32v    varmode = -5 // use map32
+	array16v  varmode = -6 // use array16
+	array32v  varmode = -7 // use array32
 )

--- a/msgp/file_test.go
+++ b/msgp/file_test.go
@@ -68,7 +68,7 @@ func BenchmarkWriteReadFile(b *testing.B) {
 
 	// let's not run out of disk space...
 	if b.N > 10000000 {
-		b.N = 10000000
+		b.N = 10000000 //nolint:staticcheck // ignoring "SA3001: should not assign to b.N (staticcheck)" as this should not usually happen.
 	}
 
 	fname := "bench-tmpfile"

--- a/msgp/file_test.go
+++ b/msgp/file_test.go
@@ -5,10 +5,12 @@ package msgp_test
 import (
 	"bytes"
 	"crypto/rand"
-	"github.com/tinylib/msgp/msgp"
+	"io"
 	prand "math/rand"
 	"os"
 	"testing"
+
+	"github.com/tinylib/msgp/msgp"
 )
 
 type rawBytes []byte
@@ -48,7 +50,7 @@ func TestReadWriteFile(t *testing.T) {
 	}
 
 	var out rawBytes
-	f.Seek(0, os.SEEK_SET)
+	f.Seek(0, io.SeekStart)
 	err = msgp.ReadFile(&out, f)
 	if err != nil {
 		t.Fatal(err)

--- a/msgp/json_bytes.go
+++ b/msgp/json_bytes.go
@@ -223,27 +223,6 @@ func rwUintBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error)
 	return msg, scratch, err
 }
 
-func rwFloatBytes(w jsWriter, msg []byte, f64 bool, scratch []byte) ([]byte, []byte, error) {
-	var f float64
-	var err error
-	var sz int
-	if f64 {
-		sz = 64
-		f, msg, err = ReadFloat64Bytes(msg)
-	} else {
-		sz = 32
-		var v float32
-		v, msg, err = ReadFloat32Bytes(msg)
-		f = float64(v)
-	}
-	if err != nil {
-		return msg, scratch, err
-	}
-	scratch = strconv.AppendFloat(scratch, f, 'f', -1, sz)
-	_, err = w.Write(scratch)
-	return msg, scratch, err
-}
-
 func rwFloat32Bytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
 	var f float32
 	var err error

--- a/msgp/read_test.go
+++ b/msgp/read_test.go
@@ -364,10 +364,7 @@ func TestReadIntOverflows(t *testing.T) {
 		case UintOverflow:
 			bits = err.FailedBitsize
 		}
-		if bits == failBits {
-			return true
-		}
-		return false
+		return bits == failBits
 	}
 
 	belowZeroErr := func(err error, failBits int) bool {

--- a/msgp/write.go
+++ b/msgp/write.go
@@ -753,60 +753,6 @@ func (mw *Writer) writeSlice(v reflect.Value) (err error) {
 	return
 }
 
-func (mw *Writer) writeStruct(v reflect.Value) error {
-	if enc, ok := v.Interface().(Encodable); ok {
-		return enc.EncodeMsg(mw)
-	}
-	return errors.New("msgp: unsupported type: " + v.Type().String())
-}
-
-func (mw *Writer) writeVal(v reflect.Value) error {
-	if !isSupported(v.Kind()) {
-		return errors.New("msgp: msgp/enc: type not supported: " + v.Type().String())
-	}
-
-	// shortcut for nil values
-	if v.IsNil() {
-		return mw.WriteNil()
-	}
-	switch v.Kind() {
-	case reflect.Bool:
-		return mw.WriteBool(v.Bool())
-
-	case reflect.Float32, reflect.Float64:
-		return mw.WriteFloat64(v.Float())
-
-	case reflect.Complex64, reflect.Complex128:
-		return mw.WriteComplex128(v.Complex())
-
-	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int8:
-		return mw.WriteInt64(v.Int())
-
-	case reflect.Interface, reflect.Ptr:
-		if v.IsNil() {
-			mw.WriteNil()
-		}
-		return mw.writeVal(v.Elem())
-
-	case reflect.Map:
-		return mw.writeMap(v)
-
-	case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint8:
-		return mw.WriteUint64(v.Uint())
-
-	case reflect.String:
-		return mw.WriteString(v.String())
-
-	case reflect.Slice, reflect.Array:
-		return mw.writeSlice(v)
-
-	case reflect.Struct:
-		return mw.writeStruct(v)
-
-	}
-	return errors.New("msgp: msgp/enc: type not supported: " + v.Type().String())
-}
-
 // is the reflect.Kind encodable?
 func isSupported(k reflect.Kind) bool {
 	switch k {


### PR DESCRIPTION
### gen: remove strtoMeth() (unused)

This function was added in 9b8e5157921bd8b18ebbd15b121e383379d0c209, but
looks to be unused.

    gen/spec.go:65:6: func `strtoMeth` is unused (unused)
    func strtoMeth(s string) Method {
         ^

### msgp: remove (*Writer).writeVal, (*Writer).writeStruct (unused)


msgp: remove (*Writer).writeVal

This method was added in c1ffc473f483bc8c1e9619d0a86eaee0237759d9, when
it was called by MsgWriter.Encode().

This method was refactored in 8fb918a939a73cd46449037189c826778548885b,
which inlined the logic, and renamed it to MsgWriter.WriteIntf.

    msgp/write.go:763:19: func `(*Writer).writeVal` is unused (unused)
    func (mw *Writer) writeVal(v reflect.Value) error {
                      ^

msgp: remove (*Writer).writeStruct (unused)

This method was also added in c1ffc473f483bc8c1e9619d0a86eaee0237759d9,
when it was used by (*Writer).writeVal and MsgWriter.WriteIntf. Commit
8fb918a939a73cd46449037189c826778548885b removed its use from WriteIntf,
and with the removal of (*Writer).writeVal, there are no remaining uses.

    msgp/write.go:756:19: func `(*Writer).writeStruct` is unused (unused)
    func (mw *Writer) writeStruct(v reflect.Value) error {
                      ^


### msgp: remove rwFloatBytes (unused)

This function was added in a62e40321a91c38cdcb58138ec58db28f52572c4, but
later split to dedicated rwFloat32Bytes and rwFloat64Bytes functions in
293864c19beb3d1bb4dfb04a55d0da43aab6a14e.

    msgp/json_bytes.go:226:6: func `rwFloatBytes` is unused (unused)
    func rwFloatBytes(w jsWriter, msg []byte, f64 bool, scratch []byte) ([]byte, []byte, error) {
         ^


### all: fix linting issues (gosimple, staticcheck)

Fixing some minor linting issues

    msgp/read_test.go:367:3: S1008: should use 'return bits == failBits' instead of 'if bits == failBits { return true }; return false' (gosimple)
            if bits == failBits {
            ^
    gen/decode.go:66:2: S1023: redundant `return` statement (gosimple)
        return
        ^
    gen/encode.go:81:2: S1023: redundant `return` statement (gosimple)
        return
        ^
    gen/marshal.go:87:2: S1023: redundant `return` statement (gosimple)
        return
        ^
    msgp/elsize.go:122:2: SA9004: only the first constant in this group has an explicit type (staticcheck)
        constsize varmode = 0  // constant size (size bytes + uint8(varmode) objects)
        ^
    msgp/file_test.go:51:12: SA1019: os.SEEK_SET has been deprecated since Go 1.7: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd. (staticcheck)
        f.Seek(0, os.SEEK_SET)
                  ^


msgp: BenchmarkWriteReadFile: ignore SA3001 (staticcheck)

Perhaps it's not "good" practice to do this, but from the looks of it, it
looks like _not_ doing this would be worse. Alternatively, we could panic()
in case the chosen value would potentially DOS the system.

From https://staticcheck.io/docs/checks#SA3001

> SA3001 - Assigning to b.N in benchmarks distorts the results
>
> The testing package dynamically sets b.N to improve the reliability of
> benchmarks and uses it in computations to determine the duration of a
> single operation. Benchmark code must not alter b.N as this would
> falsify results.

    msgp/file_test.go:71:3: SA3001: should not assign to b.N (staticcheck)
            b.N = 10000000
            ^
