### PR TITLE
Fix tinygo installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,13 @@ all: install $(GGEN) $(MGEN)
 # travis CI enters here
 travis:
 	arch
-	if [ `arch` == 'x86_64' ]; then sudo apt update; sudo apt install build-essential; wget https://github.com/tinygo-org/tinygo/releases/download/v0.18.0/tinygo_0.18.0_amd64.deb; sudo dpkg -i tinygo_0.18.0_amd64.deb; export PATH=$PATH:/usr/local/tinygo/bin; fi
+	if [ `arch` == 'x86_64' ]; then \
+		sudo apt-get -y -q update; \
+		sudo apt-get -y -q install build-essential; \
+		wget -q https://github.com/tinygo-org/tinygo/releases/download/v0.18.0/tinygo_0.18.0_amd64.deb; \
+		sudo dpkg -i tinygo_0.18.0_amd64.deb; \
+		export PATH=$$PATH:/usr/local/tinygo/bin; \
+	fi
 	go get -d -t ./...
 	go build -o "$${GOPATH%%:*}/bin/msgp" .
 	go generate ./msgp

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ travis:
 	if [ `arch` == 'x86_64' ]; then \
 		sudo apt-get -y -q update; \
 		sudo apt-get -y -q install build-essential; \
-		wget -q https://github.com/tinygo-org/tinygo/releases/download/v0.18.0/tinygo_0.18.0_amd64.deb; \
-		sudo dpkg -i tinygo_0.18.0_amd64.deb; \
+		wget -q https://github.com/tinygo-org/tinygo/releases/download/v0.26.0/tinygo_0.26.0_amd64.deb; \
+		sudo dpkg -i tinygo_0.26.0_amd64.deb; \
 		export PATH=$$PATH:/usr/local/tinygo/bin; \
 	fi
 	go get -d -t ./...

--- a/tinygotest/tinygo_test.go
+++ b/tinygotest/tinygo_test.go
@@ -1,4 +1,4 @@
-// +build amd64 darwin
+// +build amd64,go1.18 darwin,go1.18
 
 package tinygotest
 


### PR DESCRIPTION
CI doesn't currently run on this repository, so this went unnoticed. While working on setting up GitHub actions, I ran into issues with running the tinygo tests;

### Makefile: fixes for installation of tinygo

The Makefile was using `apt`, which does not provide a stable API, and for
scripting purposes, `apt-get` is the recommended utility;

    WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

The `$PATH` variable was considered a Make variable, which caused expansion
to happen to soon, causing it to be evaluated as:

    export PATH=ATH:/usr/local/tinygo/bin

This patch:

- wraps the statements for readability
- replaces `apt` for `apt-get`
- escapes the `$PATH` (`$$`)
- adds `-q` flags to `apt-get` and `wget` to suppress progress-bars


### Update tinygo version to v0.26.0 to fix version detection

tinygo failed to detect the go version;

    tinygo_test.go:22: empty: tinygo build [build -o=nativebin .]; output: error: could not read version from GOROOT (/opt/hostedtoolcache/go/1.19.3/x64): Invalid go version output:
        // Code generated by go tool dist; DO NOT EDIT.
        
        package sys
        
        const StackGuardMultiplierDefault = 1

It looks like this was due to changes in go, and fixed in tinygo v0.23 and up:
https://github.com/tinygo-org/tinygo/commit/e060e588abf40cc29f07dac0a30e9c0a8c71bf5e

This version of tinygo requires go1.18 or up, so adding a build-constraint
for the test:

    tinygo_test.go:28: empty: tinygo [build -target=arduino-nano33 -o=arduino-nano33.bin .]
    tinygo_test.go:28: empty: tinygo build [build -target=arduino-nano33 -o=arduino-nano33.bin .]; 
    output: error: requires go version 1.18 through 1.19, got go1.14
