### PR TITLE
omitisempty support

### DIFF
--- a/_generated/omitisempty.go
+++ b/_generated/omitisempty.go
@@ -1,0 +1,60 @@
+package _generated
+
+import "time"
+
+//go:generate msgp
+
+// check some specific cases for omitisempty
+
+type OmitIsEmpty0 struct {
+	ABool      bool               `msg:"abool,omitisempty"`      // unaliased primitives should act exactly as omitempty
+	ABoolPtr   *bool              `msg:"aboolptr,omitisempty"`   // pointers to primitives will do unnecessary interface check for now but function correctly
+	AStruct    OmitIsEmptyA       `msg:"astruct,omitempty"`      // leave this one omitempty
+	BStruct    OmitIsEmptyA       `msg:"bstruct,omitisempty"`    // and compare to this
+	AStructPtr *OmitIsEmptyA      `msg:"astructptr,omitempty"`   // a pointer case omitempty
+	BStructPtr *OmitIsEmptyA      `msg:"bstructptr,omitisempty"` // a pointer case omitisempty
+	AExt       OmitIsEmptyExt     `msg:"aext,omitisempty"`       // external type case
+	AExtPtr    *OmitIsEmptyExtPtr `msg:"aextptr,omitisempty"`    // external type pointer case
+
+	// check a bunch of other types just to make sure none of the output breaks on compilation
+
+	AInt              int               `msg:"aint,omitisempty"`
+	AInt8             int8              `msg:"aint8,omitisempty"`
+	AInt16            int16             `msg:"aint16,omitisempty"`
+	AInt32            int32             `msg:"aint32,omitisempty"`
+	AInt64            int64             `msg:"aint64,omitisempty"`
+	AUint             uint              `msg:"auint,omitisempty"`
+	AUint8            uint8             `msg:"auint8,omitisempty"`
+	AUint16           uint16            `msg:"auint16,omitisempty"`
+	AUint32           uint32            `msg:"auint32,omitisempty"`
+	AUint64           uint64            `msg:"auint64,omitisempty"`
+	AFloat32          float32           `msg:"afloat32,omitisempty"`
+	AFloat64          float64           `msg:"afloat64,omitisempty"`
+	AComplex64        complex64         `msg:"acomplex64,omitisempty"`
+	AComplex128       complex128        `msg:"acomplex128,omitisempty"`
+	ANamedBool        bool              `msg:"anamedbool,omitisempty"`
+	ANamedInt         int               `msg:"anamedint,omitisempty"`
+	ANamedFloat64     float64           `msg:"anamedfloat64,omitisempty"`
+	AMapStrStr        map[string]string `msg:"amapstrstr,omitisempty"`
+	APtrNamedStr      *NamedString      `msg:"aptrnamedstr,omitisempty"`
+	AString           string            `msg:"astring,omitisempty"`
+	ANamedString      string            `msg:"anamedstring,omitisempty"`
+	AByteSlice        []byte            `msg:"abyteslice,omitisempty"`
+	ASliceString      []string          `msg:"aslicestring,omitisempty"`
+	ASliceNamedString []NamedString     `msg:"aslicenamedstring,omitisempty"`
+	ANamedStruct      NamedStruct       `msg:"anamedstruct,omitisempty"`
+	APtrNamedStruct   *NamedStruct      `msg:"aptrnamedstruct,omitisempty"`
+	AUnnamedStruct    struct {
+		A string `msg:"a,omitisempty"`
+	} `msg:"aunnamedstruct,omitisempty"` // omitisempty not supported on unnamed struct
+	EmbeddableStruct  `msg:",flatten,omitisempty"`          // embed flat
+	EmbeddableStruct2 `msg:"embeddablestruct2,omitisempty"` // embed non-flat
+	AArrayInt         [5]int                                `msg:"aarrayint,omitisempty"` // not supported
+	ATime             time.Time                             `msg:"atime,omitisempty"`
+}
+
+type OmitIsEmptyA struct {
+	A int    `msg:"a,omitempty"`
+	B int    `msg:"b,omitisempty"`
+	C string `msg:"c,omitisempty"`
+}

--- a/_generated/omitisempty_ext.go
+++ b/_generated/omitisempty_ext.go
@@ -1,0 +1,114 @@
+package _generated
+
+import (
+	"github.com/tinylib/msgp/msgp"
+)
+
+// this has "external" types that will show up
+// has generic IDENT during code generation
+
+type OmitIsEmptyExt struct {
+	a int // custom type
+}
+
+// IsEmpty will return true if a is positive
+func (o OmitIsEmptyExt) IsEmpty() bool { return o.a <= 0 }
+
+// EncodeMsg implements msgp.Encodable
+func (o OmitIsEmptyExt) EncodeMsg(en *msgp.Writer) (err error) {
+	if o.a > 0 {
+		return en.WriteInt(o.a)
+	}
+	return en.WriteNil()
+}
+
+// DecodeMsg implements msgp.Decodable
+func (o *OmitIsEmptyExt) DecodeMsg(dc *msgp.Reader) (err error) {
+	if dc.IsNil() {
+		err = dc.ReadNil()
+		if err != nil {
+			return
+		}
+		o.a = 0
+		return
+	}
+	o.a, err = dc.ReadInt()
+	return err
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (o OmitIsEmptyExt) MarshalMsg(b []byte) (ret []byte, err error) {
+	ret = msgp.Require(b, o.Msgsize())
+	if o.a > 0 {
+		return msgp.AppendInt(ret, o.a), nil
+	}
+	return msgp.AppendNil(ret), nil
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (o *OmitIsEmptyExt) UnmarshalMsg(bts []byte) (ret []byte, err error) {
+	if msgp.IsNil(bts) {
+		bts, err = msgp.ReadNilBytes(bts)
+		return bts, err
+	}
+	o.a, bts, err = msgp.ReadIntBytes(bts)
+	return bts, err
+}
+
+// Msgsize implements msgp.Msgsizer
+func (o OmitIsEmptyExt) Msgsize() (s int) {
+	return msgp.IntSize
+}
+
+type OmitIsEmptyExtPtr struct {
+	a int // custom type
+}
+
+// IsEmpty will return true if a is positive
+func (o *OmitIsEmptyExtPtr) IsEmpty() bool { return o == nil || o.a <= 0 }
+
+// EncodeMsg implements msgp.Encodable
+func (o *OmitIsEmptyExtPtr) EncodeMsg(en *msgp.Writer) (err error) {
+	if o.a > 0 {
+		return en.WriteInt(o.a)
+	}
+	return en.WriteNil()
+}
+
+// DecodeMsg implements msgp.Decodable
+func (o *OmitIsEmptyExtPtr) DecodeMsg(dc *msgp.Reader) (err error) {
+	if dc.IsNil() {
+		err = dc.ReadNil()
+		if err != nil {
+			return
+		}
+		o.a = 0
+		return
+	}
+	o.a, err = dc.ReadInt()
+	return err
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (o *OmitIsEmptyExtPtr) MarshalMsg(b []byte) (ret []byte, err error) {
+	ret = msgp.Require(b, o.Msgsize())
+	if o.a > 0 {
+		return msgp.AppendInt(ret, o.a), nil
+	}
+	return msgp.AppendNil(ret), nil
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (o *OmitIsEmptyExtPtr) UnmarshalMsg(bts []byte) (ret []byte, err error) {
+	if msgp.IsNil(bts) {
+		bts, err = msgp.ReadNilBytes(bts)
+		return bts, err
+	}
+	o.a, bts, err = msgp.ReadIntBytes(bts)
+	return bts, err
+}
+
+// Msgsize implements msgp.Msgsizer
+func (o *OmitIsEmptyExtPtr) Msgsize() (s int) {
+	return msgp.IntSize
+}

--- a/_generated/omitisempty_test.go
+++ b/_generated/omitisempty_test.go
@@ -1,0 +1,51 @@
+package _generated
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestOmitIsEmpty(t *testing.T) {
+
+	t.Run("OmitIsEmptyExt_not_empty", func(t *testing.T) {
+
+		z := OmitIsEmpty0{AExt: OmitIsEmptyExt{a: 1}}
+		b, err := z.MarshalMsg(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Contains(b, []byte("aext")) {
+			t.Errorf("expected to find aext in bytes %X", b)
+		}
+		z = OmitIsEmpty0{}
+		_, err = z.UnmarshalMsg(b)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if z.AExt.a != 1 {
+			t.Errorf("z.AExt.a expected 1 but got %d", z.AExt.a)
+		}
+
+	})
+
+	t.Run("OmitIsEmptyExt_negative", func(t *testing.T) {
+
+		z := OmitIsEmpty0{AExt: OmitIsEmptyExt{a: -1}} // negative value should act as empty, via IsEmpty() call
+		b, err := z.MarshalMsg(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if bytes.Contains(b, []byte("aext")) {
+			t.Errorf("expected to not find aext in bytes %X", b)
+		}
+		z = OmitIsEmpty0{}
+		_, err = z.UnmarshalMsg(b)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if z.AExt.a != 0 {
+			t.Errorf("z.AExt.a expected 0 but got %d", z.AExt.a)
+		}
+
+	})
+}


### PR DESCRIPTION
This PR adds support for an `omitisempty` tag, which works like `omitempty` but emits additional checks for emptiness using the interface `{ IsEmpty() bool }`.

This should have no effect on code generated without `omitisempty`.  But when `omitisempty` is included on a field, the result is to perform the existing emptiness check on that field plus `|| checkIsEmptyf(x)`, which calls IsEmpty() via interface if possible.  This also emits the definition of checkIsEmpty (3 lines) once at the top of each MarshalMsg or EncodeMsg method as appropriate.

I've also include some test coverage (could use more work, but I think what's here is pretty good proof this is a viable feature and doesn't break anything).

Some additional notes on the implementation:

* The biggest change is the IfZeroExpr method was refactor to take an argument which triggers the omitisempty behavior.  This meant changing the Elem interface, all of its implementations and all calls to it.  That's where most of the work is being done to decide how to perform empty checks in which cases.
* From there, the changes to encode.go and marshal.go were relatively simple.  I had to add a mechanism to only output `checkIsEmptyIntf` once per function, but ended up being easy since encodeGen and marshalGen each provide a good place to manage this state.
* There is some inefficiency in cases where someone uses omitisempty on a type that cannot possibly support an IsEmpty method (a primitive type) - in some places I was able to optimize this away and have it not perform the impossible check but a lot of cases still do this call that will always return false.  I figure this is not a big deal since omitisempty is entirely opt-in on the part of the user.
