### PR TITLE
Support "allownil" for byte slices

### DIFF
--- a/gen/elem.go
+++ b/gen/elem.go
@@ -530,6 +530,8 @@ func (s *BaseElem) Alias(typ string) {
 	}
 }
 
+func (s *BaseElem) AllowNil() bool { return s.Value == Bytes }
+
 func (s *BaseElem) SetVarname(a string) {
 	// extensions whose parents
 	// are not pointers need to


### PR DESCRIPTION
Since byte slices are considered a base element and not a slice in terms of parsing we must handle it separately.

Already tested with "AByteSlice" in `_generate/allownil.go`:

```
	// string "abyteslice"
	o = append(o, 0xaa, 0x61, 0x62, 0x79, 0x74, 0x65, 0x73, 0x6c, 0x69, 0x63, 0x65)
	if z.AByteSlice == nil { // allownil: if nil
		o = msgp.AppendNil(o)
	} else {
		o = msgp.AppendBytes(o, z.AByteSlice)
	}
```

```
		case "abyteslice":
			if msgp.IsNil(bts) {
				bts = bts[1:]
				z.AByteSlice = nil
			} else {
				z.AByteSlice, bts, err = msgp.ReadBytesBytes(bts, z.AByteSlice)
				if err != nil {
					err = msgp.WrapError(err, "AByteSlice")
					return
				}
			}
```

(similar for En/Decode)