### PR TITLE
Allow non-string-keyed maps by converting the keys

### DIFF
--- a/gen/elem.go
+++ b/gen/elem.go
@@ -258,9 +258,10 @@ func (a *Array) IfZeroExpr() string { return "" }
 // Map is a map[string]Elem
 type Map struct {
 	common
-	Keyidx string // key variable name
-	Validx string // value variable name
-	Value  Elem   // value element
+	Keyidx  string // key variable name
+	Validx  string // value variable name
+	Value   Elem   // value element
+	KeyType string // key type
 }
 
 func (m *Map) SetVarname(s string) {
@@ -281,7 +282,7 @@ func (m *Map) TypeName() string {
 	if m.common.alias != "" {
 		return m.common.alias
 	}
-	m.common.Alias("map[string]" + m.Value.TypeName())
+	m.common.Alias(fmt.Sprintf("map[%s]%s", m.KeyType, m.Value.TypeName()))
 	return m.common.alias
 }
 
@@ -301,6 +302,30 @@ func (m *Map) IfZeroExpr() string { return m.Varname() + " == nil" }
 
 // AllowNil is true for maps.
 func (m *Map) AllowNil() bool { return true }
+
+func (m *Map) KeyStringExpr() string {
+	if m.KeyType == "string" {
+		return m.Keyidx
+	} else {
+		return fmt.Sprintf("%s.String()", m.Keyidx)
+	}
+}
+
+func (m *Map) KeyOrigTypeExpr() string {
+	if m.KeyType == "string" {
+		return m.Keyidx
+	} else {
+		return fmt.Sprintf("*(new(%s).FromString(%s))", m.KeyType, m.Keyidx)
+	}
+}
+
+func (m *Map) KeySizeExpr() string {
+	if m.KeyType == "string" {
+		return fmt.Sprintf("len(%s)", m.Keyidx)
+	} else {
+		return fmt.Sprintf("%s.StrMsgSize()", m.Keyidx)
+	}
+}
 
 type Slice struct {
 	common

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -307,7 +307,7 @@ func (m *Map) KeyStringExpr() string {
 	if m.KeyType == "string" {
 		return m.Keyidx
 	} else {
-		return fmt.Sprintf("%s.String()", m.Keyidx)
+		return fmt.Sprintf("%s.MsgpStrMapKey()", m.Keyidx)
 	}
 }
 
@@ -315,7 +315,7 @@ func (m *Map) KeyOrigTypeExpr() string {
 	if m.KeyType == "string" {
 		return m.Keyidx
 	} else {
-		return fmt.Sprintf("*(new(%s).FromString(%s))", m.KeyType, m.Keyidx)
+		return fmt.Sprintf("*(new(%s).MsgpFromStrMapKey(%s)).(*%s)", m.KeyType, m.Keyidx, m.KeyType)
 	}
 }
 
@@ -323,7 +323,7 @@ func (m *Map) KeySizeExpr() string {
 	if m.KeyType == "string" {
 		return fmt.Sprintf("len(%s)", m.Keyidx)
 	} else {
-		return fmt.Sprintf("%s.StrMsgSize()", m.Keyidx)
+		return fmt.Sprintf("%s.MsgpStrMapKeySize()", m.Keyidx)
 	}
 }
 

--- a/gen/encode.go
+++ b/gen/encode.go
@@ -217,7 +217,7 @@ func (e *encodeGen) gMap(m *Map) {
 	e.writeAndCheck(mapHeader, lenAsUint32, vname)
 
 	e.p.printf("\nfor %s, %s := range %s {", m.Keyidx, m.Validx, vname)
-	e.writeAndCheck(stringTyp, literalFmt, m.Keyidx)
+	e.writeAndCheck(stringTyp, literalFmt, m.KeyStringExpr())
 	e.ctx.PushVar(m.Keyidx)
 	next(e, m.Value)
 	e.ctx.Pop()

--- a/gen/marshal.go
+++ b/gen/marshal.go
@@ -221,7 +221,7 @@ func (m *marshalGen) gMap(s *Map) {
 	vname := s.Varname()
 	m.rawAppend(mapHeader, lenAsUint32, vname)
 	m.p.printf("\nfor %s, %s := range %s {", s.Keyidx, s.Validx, vname)
-	m.rawAppend(stringTyp, literalFmt, s.Keyidx)
+	m.rawAppend(stringTyp, literalFmt, s.KeyStringExpr())
 	m.ctx.PushVar(s.Keyidx)
 	next(m, s.Value)
 	m.ctx.Pop()

--- a/gen/size.go
+++ b/gen/size.go
@@ -176,7 +176,7 @@ func (s *sizeGen) gMap(m *Map) {
 	s.p.printf("\nif %s != nil {", vn)
 	s.p.printf("\nfor %s, %s := range %s {", m.Keyidx, m.Validx, vn)
 	s.p.printf("\n_ = %s", m.Validx) // we may not use the value
-	s.p.printf("\ns += msgp.StringPrefixSize + len(%s)", m.Keyidx)
+	s.p.printf("\ns += msgp.StringPrefixSize + %s", m.KeySizeExpr())
 	s.state = expr
 	s.ctx.PushVar(m.Keyidx)
 	next(s, m.Value)

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -341,7 +341,7 @@ func (p *printer) mapAssign(m *Map) {
 	if !p.ok() {
 		return
 	}
-	p.printf("\n%s[%s] = %s", m.Varname(), m.Keyidx, m.Validx)
+	p.printf("\n%s[%s] = %s", m.Varname(), m.KeyOrigTypeExpr(), m.Validx)
 }
 
 // clear map keys

--- a/msgp/non_str_map_key.go
+++ b/msgp/non_str_map_key.go
@@ -1,0 +1,10 @@
+package msgp
+
+// NonStrMapKey must be implemented to allow non-string Go types to be used as MessagePack map keys.
+// Msgp maps must have string keys for JSON interop.
+// NonStrMapKey enables conversion from type to string and vice versa.
+type NonStrMapKey interface {
+	MsgpStrMapKey() string
+	MsgpFromStrMapKey(s string) NonStrMapKey
+	MsgpStrMapKeySize() int
+}

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -479,9 +479,16 @@ func (fs *FileSet) parseExpr(e ast.Expr) gen.Elem {
 	switch e := e.(type) {
 
 	case *ast.MapType:
-		if k, ok := e.Key.(*ast.Ident); ok && k.Name == "string" {
+		switch k := e.Key.(type) {
+		case *ast.Ident:
 			if in := fs.parseExpr(e.Value); in != nil {
-				return &gen.Map{Value: in}
+				return &gen.Map{Value: in, KeyType: k.Name}
+			}
+		case *ast.SelectorExpr:
+			if in := fs.parseExpr(e.Value); in != nil {
+				if moduleIdent, ok := k.X.(*ast.Ident); ok {
+					return &gen.Map{Value: in, KeyType: fmt.Sprintf("%s.%s", moduleIdent.Name, k.Sel.Name)}
+				}
 			}
 		}
 		return nil

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -486,9 +486,7 @@ func (fs *FileSet) parseExpr(e ast.Expr) gen.Elem {
 			}
 		case *ast.SelectorExpr:
 			if in := fs.parseExpr(e.Value); in != nil {
-				if moduleIdent, ok := k.X.(*ast.Ident); ok {
-					return &gen.Map{Value: in, KeyType: fmt.Sprintf("%s.%s", moduleIdent.Name, k.Sel.Name)}
-				}
+				return &gen.Map{Value: in, KeyType: stringify(k)}
 			}
 		}
 		return nil


### PR DESCRIPTION
Non-string keys can be automatically converted to and from string by providing a NonStrMapKey interface implementation for that type.
Related to #232