### PR TITLE
support for any maps in msgp.AppendIntf like in (*Writer).WriteIntf

### DIFF
--- a/msgp/write_bytes.go
+++ b/msgp/write_bytes.go
@@ -1,6 +1,7 @@
 package msgp
 
 import (
+	"errors"
 	"math"
 	"reflect"
 	"time"
@@ -342,10 +343,10 @@ func AppendMapStrIntf(b []byte, m map[string]interface{}) ([]byte, error) {
 // provided []byte. 'i' must be one of the following:
 //   - 'nil'
 //   - A bool, float, string, []byte, int, uint, or complex
-//   - A map[string]interface{} or map[string]string
+//   - A map[string]T where T is another supported type
 //   - A []T, where T is another supported type
 //   - A *T, where T is another supported type
-//   - A type that satisfieds the msgp.Marshaler interface
+//   - A type that satisfies the msgp.Marshaler interface
 //   - A type that satisfies the msgp.Extension interface
 func AppendIntf(b []byte, i interface{}) ([]byte, error) {
 	if i == nil {
@@ -414,6 +415,21 @@ func AppendIntf(b []byte, i interface{}) ([]byte, error) {
 	var err error
 	v := reflect.ValueOf(i)
 	switch v.Kind() {
+	case reflect.Map:
+		if v.Type().Key().Kind() != reflect.String {
+			return b, errors.New("msgp: map keys must be strings")
+		}
+		ks := v.MapKeys()
+		b = AppendMapHeader(b, uint32(len(ks)))
+		for _, key := range ks {
+			val := v.MapIndex(key)
+			b = AppendString(b, key.String())
+			b, err = AppendIntf(b, val.Interface())
+			if err != nil {
+				return nil, err
+			}
+		}
+		return b, nil
 	case reflect.Array, reflect.Slice:
 		l := v.Len()
 		b = AppendArrayHeader(b, uint32(l))


### PR DESCRIPTION
Hello :wave:

Previously when using `AppendIntf` with types like `map[string][]any` the function would throw an `ErrUnsupportedType` error.

So I added support for all values in maps using the `reflect` package just like it was already done in `(*Writer).WriteIntf` (by basically copying the code from `(*Writer).writeMap`).

I did not see any tests for this function so I was not comfortable to start writing a new testsuite. Please let me know if you want me to test my code.