### PR TITLE
Support illumos.

### DIFF
--- a/msgp/file.go
+++ b/msgp/file.go
@@ -1,5 +1,5 @@
-//go:build (linux || darwin || dragonfly || freebsd || netbsd || openbsd) && !appengine && !tinygo
-// +build linux darwin dragonfly freebsd netbsd openbsd
+//go:build (linux || darwin || dragonfly || freebsd || illumos || netbsd || openbsd) && !appengine && !tinygo
+// +build linux darwin dragonfly freebsd illumos netbsd openbsd
 // +build !appengine
 // +build !tinygo
 

--- a/msgp/file_test.go
+++ b/msgp/file_test.go
@@ -1,5 +1,5 @@
-//go:build linux || darwin || dragonfly || freebsd || netbsd || openbsd
-// +build linux darwin dragonfly freebsd netbsd openbsd
+//go:build linux || darwin || dragonfly || freebsd || illumos || netbsd || openbsd
+// +build linux darwin dragonfly freebsd illumos netbsd openbsd
 
 package msgp_test
 


### PR DESCRIPTION
You may prefer to change this completely to instead be `!windows`, I didn't do this as I don't know your reasoning for having a static OS list, but it would avoid having to add other OS manually in the future.

I cross-compiled this on macOS:

```
$ GOOS=illumos GOARCH=amd64 go test -c
```

and ran the resulting `msgp.test` on an illumos host:

```
$ ./msgp.test 
PASS
```

to verify.

Thanks!