### PR TITLE
Support custom struct tags

### DIFF
--- a/_generated/custom_tag.go
+++ b/_generated/custom_tag.go
@@ -1,0 +1,9 @@
+package _generated
+
+//go:generate msgp
+//msgp:tag mytag
+
+type CustomTag struct {
+	Foo string `mytag:"foo_custom_name"`
+	Bar int    `mytag:"bar1234"`
+}

--- a/_generated/custom_tag.go
+++ b/_generated/custom_tag.go
@@ -2,8 +2,14 @@ package _generated
 
 //go:generate msgp
 //msgp:tag mytag
+//msgp:tag anothertag CustomTag2
 
 type CustomTag struct {
 	Foo string `mytag:"foo_custom_name"`
 	Bar int    `mytag:"bar1234"`
+}
+
+type CustomTag2 struct {
+	Foo string `anothertag:"foo_msgp_name" mytag:"foo_legacy_name"`
+	Bar int    `anothertag:"bar5678" mytag:"not_used"`
 }

--- a/_generated/custom_tag.go
+++ b/_generated/custom_tag.go
@@ -2,14 +2,8 @@ package _generated
 
 //go:generate msgp
 //msgp:tag mytag
-//msgp:tag anothertag CustomTag2
 
 type CustomTag struct {
 	Foo string `mytag:"foo_custom_name"`
 	Bar int    `mytag:"bar1234"`
-}
-
-type CustomTag2 struct {
-	Foo string `anothertag:"foo_msgp_name" mytag:"foo_legacy_name"`
-	Bar int    `anothertag:"bar5678" mytag:"not_used"`
 }

--- a/_generated/custom_tag_test.go
+++ b/_generated/custom_tag_test.go
@@ -1,0 +1,64 @@
+package _generated
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"bytes"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestCustomTag(t *testing.T) {
+	t.Run("File Scope", func(t *testing.T) {
+		ts := CustomTag{
+			Foo: "foostring13579",
+			Bar: 999_999}
+		encDecCustomTag(t, ts, "mytag")
+	})
+}
+
+func encDecCustomTag(t *testing.T, testStruct msgp.Encodable, tag string) {
+	var b bytes.Buffer
+	msgp.Encode(&b, testStruct)
+
+	// Check tag names using JSON as an intermediary layer
+	// TODO: is there a way to avoid the JSON layer? We'd need to directly decode raw msgpack -> map[string]any
+	refJSON, err := json.Marshal(testStruct)
+	if err != nil {
+		t.Error(fmt.Sprintf("error encoding struct as JSON: %v", err))
+	}
+	ref := make(map[string]any)
+	// Encoding and decoding the original struct via JSON is necessary
+	// for field comparisons to work, since JSON -> map[string]any
+	// relies on type inferences such as all numbers being float64s
+	json.Unmarshal(refJSON, &ref)
+
+	var encJSON bytes.Buffer
+	msgp.UnmarshalAsJSON(&encJSON, b.Bytes())
+	encoded := make(map[string]any)
+	json.Unmarshal(encJSON.Bytes(), &encoded)
+
+	tsType := reflect.TypeOf(testStruct)
+	for i := 0; i < tsType.NumField(); i++ {
+		// Check encoded field name
+		field := tsType.Field(i)
+		encodedValue, ok := encoded[field.Tag.Get(tag)]
+		if !ok {
+			t.Error("missing encoded value for field", field.Name)
+			continue
+		}
+		// Check encoded field value (against original value post-JSON enc + dec)
+		jsonName, ok := field.Tag.Lookup("json")
+		if !ok {
+			jsonName = field.Name
+		}
+		refValue := ref[jsonName]
+		if !reflect.DeepEqual(refValue, encodedValue) {
+			t.Error(fmt.Sprintf("incorrect encoded value for field %s. reference: %v, encoded: %v",
+				field.Name, refValue, encodedValue))
+		}
+	}
+}

--- a/_generated/custom_tag_test.go
+++ b/_generated/custom_tag_test.go
@@ -16,18 +16,11 @@ func TestCustomTag(t *testing.T) {
 		ts := CustomTag{
 			Foo: "foostring13579",
 			Bar: 999_999}
-		encDecCustomTag(t, ts, "mytag", false)
-	})
-	t.Run("Type Scope", func(t *testing.T) {
-		ts := CustomTag2{
-			Foo: "foostring246810",
-			Bar: 777_777}
-		encDecCustomTag(t, ts, "anothertag", false)
-		encDecCustomTag(t, ts, "mytag", true)
+		encDecCustomTag(t, ts, "mytag")
 	})
 }
 
-func encDecCustomTag(t *testing.T, testStruct msgp.Encodable, tag string, expectError bool) {
+func encDecCustomTag(t *testing.T, testStruct msgp.Encodable, tag string) {
 	var b bytes.Buffer
 	msgp.Encode(&b, testStruct)
 
@@ -53,12 +46,6 @@ func encDecCustomTag(t *testing.T, testStruct msgp.Encodable, tag string, expect
 		// Check encoded field name
 		field := tsType.Field(i)
 		encodedValue, ok := encoded[field.Tag.Get(tag)]
-		if expectError {
-			if ok {
-				t.Error("unexpected encoded field", field.Name)
-			}
-			continue
-		}
 		if !ok {
 			t.Error("missing encoded value for field", field.Name)
 			continue

--- a/_generated/custom_tag_test.go
+++ b/_generated/custom_tag_test.go
@@ -16,11 +16,18 @@ func TestCustomTag(t *testing.T) {
 		ts := CustomTag{
 			Foo: "foostring13579",
 			Bar: 999_999}
-		encDecCustomTag(t, ts, "mytag")
+		encDecCustomTag(t, ts, "mytag", false)
+	})
+	t.Run("Type Scope", func(t *testing.T) {
+		ts := CustomTag2{
+			Foo: "foostring246810",
+			Bar: 777_777}
+		encDecCustomTag(t, ts, "anothertag", false)
+		encDecCustomTag(t, ts, "mytag", true)
 	})
 }
 
-func encDecCustomTag(t *testing.T, testStruct msgp.Encodable, tag string) {
+func encDecCustomTag(t *testing.T, testStruct msgp.Encodable, tag string, expectError bool) {
 	var b bytes.Buffer
 	msgp.Encode(&b, testStruct)
 
@@ -46,6 +53,12 @@ func encDecCustomTag(t *testing.T, testStruct msgp.Encodable, tag string) {
 		// Check encoded field name
 		field := tsType.Field(i)
 		encodedValue, ok := encoded[field.Tag.Get(tag)]
+		if expectError {
+			if ok {
+				t.Error("unexpected encoded field", field.Name)
+			}
+			continue
+		}
 		if !ok {
 			t.Error("missing encoded value for field", field.Name)
 			continue

--- a/parse/directives.go
+++ b/parse/directives.go
@@ -138,9 +138,18 @@ func astuple(text []string, f *FileSet) error {
 
 //msgp:tag {tagname}
 func tag(text []string, f *FileSet) error {
-	if len(text) != 2 {
+	if len(text) < 2 {
 		return nil
 	}
-	f.tagName = strings.TrimSpace(text[1])
+	tag := strings.TrimSpace(text[1])
+	if len(text) == 2 {
+		// file-scope syntax - set custom tag for all types in the file
+		f.tagName = tag
+	} else {
+		// type-scope - set custom tag for types specified
+		for _, item := range text[2:] {
+			f.tagNameTypes[strings.TrimSpace(item)] = tag
+		}
+	}
 	return nil
 }

--- a/parse/directives.go
+++ b/parse/directives.go
@@ -24,7 +24,15 @@ var directives = map[string]directive{
 	"shim":   applyShim,
 	"ignore": ignore,
 	"tuple":  astuple,
-}
+	"tag":    tag}
+
+// map of all recognized directives which will be applied
+// before process() is called
+//
+// to add an early directive, define a func([]string, *FileSet) error
+// and then add it to this list.
+var earlyDirectives = map[string]directive{
+	"tag": tag}
 
 var passDirectives = map[string]passDirective{
 	"ignore": passignore,
@@ -126,5 +134,14 @@ func astuple(text []string, f *FileSet) error {
 			}
 		}
 	}
+	return nil
+}
+
+//msgp:tag {tagname}
+func tag(text []string, f *FileSet) error {
+	if len(text) != 2 {
+		return nil
+	}
+	f.tagName = strings.TrimSpace(text[1])
 	return nil
 }

--- a/parse/directives.go
+++ b/parse/directives.go
@@ -138,18 +138,9 @@ func astuple(text []string, f *FileSet) error {
 
 //msgp:tag {tagname}
 func tag(text []string, f *FileSet) error {
-	if len(text) < 2 {
+	if len(text) != 2 {
 		return nil
 	}
-	tag := strings.TrimSpace(text[1])
-	if len(text) == 2 {
-		// file-scope syntax - set custom tag for all types in the file
-		f.tagName = tag
-	} else {
-		// type-scope - set custom tag for types specified
-		for _, item := range text[2:] {
-			f.tagNameTypes[strings.TrimSpace(item)] = tag
-		}
-	}
+	f.tagName = strings.TrimSpace(text[1])
 	return nil
 }

--- a/parse/directives.go
+++ b/parse/directives.go
@@ -23,8 +23,7 @@ type passDirective func(gen.Method, []string, *gen.Printer) error
 var directives = map[string]directive{
 	"shim":   applyShim,
 	"ignore": ignore,
-	"tuple":  astuple,
-	"tag":    tag}
+	"tuple":  astuple}
 
 // map of all recognized directives which will be applied
 // before process() is called

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -16,12 +16,13 @@ import (
 // A FileSet is the in-memory representation of a
 // parsed file.
 type FileSet struct {
-	Package    string              // package name
-	Specs      map[string]ast.Expr // type specs in file
-	Identities map[string]gen.Elem // processed from specs
-	Directives []string            // raw preprocessor directives
-	Imports    []*ast.ImportSpec   // imports
-	tagName    string              // tag to read field names from
+	Package      string              // package name
+	Specs        map[string]ast.Expr // type specs in file
+	Identities   map[string]gen.Elem // processed from specs
+	Directives   []string            // raw preprocessor directives
+	Imports      []*ast.ImportSpec   // imports
+	tagName      string              // tag to read field names from
+	tagNameTypes map[string]string   // tag to read field names from for explicit types
 }
 
 // File parses a file at the relative path
@@ -34,9 +35,9 @@ func File(name string, unexported bool) (*FileSet, error) {
 	pushstate(name)
 	defer popstate()
 	fs := &FileSet{
-		Specs:      make(map[string]ast.Expr),
-		Identities: make(map[string]gen.Elem),
-	}
+		Specs:        make(map[string]ast.Expr),
+		Identities:   make(map[string]gen.Elem),
+		tagNameTypes: make(map[string]string)}
 
 	fset := token.NewFileSet()
 	finfo, err := os.Stat(name)
@@ -193,7 +194,7 @@ func (f *FileSet) process() {
 parse:
 	for name, def := range f.Specs {
 		pushstate(name)
-		el := f.parseExpr(def)
+		el := f.parseExpr(def, name)
 		if el == nil {
 			warnf("failed to parse")
 			popstate()
@@ -330,14 +331,14 @@ func fieldName(f *ast.Field) string {
 	}
 }
 
-func (fs *FileSet) parseFieldList(fl *ast.FieldList) []gen.StructField {
+func (fs *FileSet) parseFieldList(fl *ast.FieldList, structName string) []gen.StructField {
 	if fl == nil || fl.NumFields() == 0 {
 		return nil
 	}
 	out := make([]gen.StructField, 0, fl.NumFields())
 	for _, field := range fl.List {
 		pushstate(fieldName(field))
-		fds := fs.getField(field)
+		fds := fs.getField(field, structName)
 		if len(fds) > 0 {
 			out = append(out, fds...)
 		} else {
@@ -349,13 +350,15 @@ func (fs *FileSet) parseFieldList(fl *ast.FieldList) []gen.StructField {
 }
 
 // translate *ast.Field into []gen.StructField
-func (fs *FileSet) getField(f *ast.Field) []gen.StructField {
+func (fs *FileSet) getField(f *ast.Field, structName string) []gen.StructField {
 	sf := make([]gen.StructField, 1)
 	var extension, flatten bool
 	// parse tag; otherwise field name is field tag
 	if f.Tag != nil {
 		var body string
-		if fs.tagName != "" {
+		if tagName, ok := fs.tagNameTypes[structName]; ok { // type-scope msgp:tag directive
+			body = reflect.StructTag(strings.Trim(f.Tag.Value, "`")).Get(tagName)
+		} else if fs.tagName != "" { // file-scope msgp:tag directive
 			body = reflect.StructTag(strings.Trim(f.Tag.Value, "`")).Get(fs.tagName)
 		}
 		if body == "" {
@@ -382,7 +385,7 @@ func (fs *FileSet) getField(f *ast.Field) []gen.StructField {
 		sf[0].RawTag = f.Tag.Value
 	}
 
-	ex := fs.parseExpr(f.Type)
+	ex := fs.parseExpr(f.Type, "")
 	if ex == nil {
 		return nil
 	}
@@ -442,7 +445,7 @@ func (fs *FileSet) getFieldsFromEmbeddedStruct(f ast.Expr) []gen.StructField {
 		s := fs.Specs[f.Name]
 		switch s := s.(type) {
 		case *ast.StructType:
-			return fs.parseFieldList(s.Fields)
+			return fs.parseFieldList(s.Fields, f.Name)
 		default:
 			return nil
 		}
@@ -506,12 +509,12 @@ func stringify(e ast.Expr) string {
 // - *ast.StructType (struct {})
 // - *ast.SelectorExpr (a.B)
 // - *ast.InterfaceType (interface {})
-func (fs *FileSet) parseExpr(e ast.Expr) gen.Elem {
+func (fs *FileSet) parseExpr(e ast.Expr, name string) gen.Elem {
 	switch e := e.(type) {
 
 	case *ast.MapType:
 		if k, ok := e.Key.(*ast.Ident); ok && k.Name == "string" {
-			if in := fs.parseExpr(e.Value); in != nil {
+			if in := fs.parseExpr(e.Value, ""); in != nil {
 				return &gen.Map{Value: in}
 			}
 		}
@@ -541,7 +544,7 @@ func (fs *FileSet) parseExpr(e ast.Expr) gen.Elem {
 
 		// return early if we don't know
 		// what the slice element type is
-		els := fs.parseExpr(e.Elt)
+		els := fs.parseExpr(e.Elt, "")
 		if els == nil {
 			return nil
 		}
@@ -574,13 +577,13 @@ func (fs *FileSet) parseExpr(e ast.Expr) gen.Elem {
 		return &gen.Slice{Els: els}
 
 	case *ast.StarExpr:
-		if v := fs.parseExpr(e.X); v != nil {
+		if v := fs.parseExpr(e.X, ""); v != nil {
 			return &gen.Ptr{Value: v}
 		}
 		return nil
 
 	case *ast.StructType:
-		return &gen.Struct{Fields: fs.parseFieldList(e.Fields)}
+		return &gen.Struct{Fields: fs.parseFieldList(e.Fields, name)}
 
 	case *ast.SelectorExpr:
 		return gen.Ident(stringify(e))


### PR DESCRIPTION
Closes #313 

This PR adds support for reading MessagePack field names from a custom struct tag via the `//msgp:tag {tagname}` directive. If the custom tag isn't present for a field, `msg` and `msgpack` are checked next.

Example:
```go
//go:generate msgp
//msgp:tag json

// Heartbeat - A heartbeat message
type Heartbeat struct {
	Service string `json:"service"` // "service" is used for both json and msgp
	Message string `json:"message"`
}
```