### PR TITLE
Add recursion limit for dynamic code

### DIFF
--- a/msgp/defs.go
+++ b/msgp/defs.go
@@ -32,6 +32,10 @@ const (
 	last5  = 0x1f
 	first3 = 0xe0
 	last7  = 0x7f
+
+	// recursionLimit is the limit of recursive calls.
+	// This limits the call depth of dynamic code, like Skip and interface conversions.
+	recursionLimit = 100000
 )
 
 func isfixint(b byte) bool {

--- a/msgp/errors.go
+++ b/msgp/errors.go
@@ -13,6 +13,10 @@ var (
 	// contain the contents of the message
 	ErrShortBytes error = errShort{}
 
+	// ErrRecursion is returned when the maximum recursion limit is reached for an operation.
+	// This should only realistically be seen on adversarial data trying to exhaust the stack.
+	ErrRecursion error = errRecursion{}
+
 	// this error is only returned
 	// if we reach code that should
 	// be unreachable
@@ -133,6 +137,11 @@ func (f errFatal) Error() string {
 func (f errFatal) Resumable() bool { return false }
 
 func (f errFatal) withContext(ctx string) error { f.ctx = addCtx(f.ctx, ctx); return f }
+
+type errRecursion struct{}
+
+func (e errRecursion) Error() string   { return "msgp: recursion limit reached" }
+func (e errRecursion) Resumable() bool { return false }
 
 // ArrayError is an error returned
 // when decoding a fix-sized array

--- a/msgp/json.go
+++ b/msgp/json.go
@@ -109,6 +109,13 @@ func rwMap(dst jsWriter, src *Reader) (n int, err error) {
 		return dst.WriteString("{}")
 	}
 
+	// This is potentially a recursive call.
+	if done, err := src.recursiveCall(); err != nil {
+		return 0, err
+	} else {
+		defer done()
+	}
+
 	err = dst.WriteByte('{')
 	if err != nil {
 		return
@@ -162,6 +169,13 @@ func rwArray(dst jsWriter, src *Reader) (n int, err error) {
 	if err != nil {
 		return
 	}
+	// This is potentially a recursive call.
+	if done, err := src.recursiveCall(); err != nil {
+		return 0, err
+	} else {
+		defer done()
+	}
+
 	var sz uint32
 	var nn int
 	sz, err = src.ReadArrayHeader()

--- a/msgp/json_bytes.go
+++ b/msgp/json_bytes.go
@@ -9,12 +9,12 @@ import (
 	"time"
 )
 
-var unfuns [_maxtype]func(jsWriter, []byte, []byte) ([]byte, []byte, error)
+var unfuns [_maxtype]func(jsWriter, []byte, []byte, int) ([]byte, []byte, error)
 
 func init() {
 	// NOTE(pmh): this is best expressed as a jump table,
 	// but gc doesn't do that yet. revisit post-go1.5.
-	unfuns = [_maxtype]func(jsWriter, []byte, []byte) ([]byte, []byte, error){
+	unfuns = [_maxtype]func(jsWriter, []byte, []byte, int) ([]byte, []byte, error){
 		StrType:        rwStringBytes,
 		BinType:        rwBytesBytes,
 		MapType:        rwMapBytes,
@@ -51,7 +51,7 @@ func UnmarshalAsJSON(w io.Writer, msg []byte) ([]byte, error) {
 		dst = bufio.NewWriterSize(w, 512)
 	}
 	for len(msg) > 0 && err == nil {
-		msg, scratch, err = writeNext(dst, msg, scratch)
+		msg, scratch, err = writeNext(dst, msg, scratch, 0)
 	}
 	if !cast && err == nil {
 		err = dst.(*bufio.Writer).Flush()
@@ -59,7 +59,7 @@ func UnmarshalAsJSON(w io.Writer, msg []byte) ([]byte, error) {
 	return msg, err
 }
 
-func writeNext(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+func writeNext(w jsWriter, msg []byte, scratch []byte, depth int) ([]byte, []byte, error) {
 	if len(msg) < 1 {
 		return msg, scratch, ErrShortBytes
 	}
@@ -76,10 +76,13 @@ func writeNext(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
 			t = TimeType
 		}
 	}
-	return unfuns[t](w, msg, scratch)
+	return unfuns[t](w, msg, scratch, depth)
 }
 
-func rwArrayBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+func rwArrayBytes(w jsWriter, msg []byte, scratch []byte, depth int) ([]byte, []byte, error) {
+	if depth >= recursionLimit {
+		return msg, scratch, ErrRecursion
+	}
 	sz, msg, err := ReadArrayHeaderBytes(msg)
 	if err != nil {
 		return msg, scratch, err
@@ -95,7 +98,7 @@ func rwArrayBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error
 				return msg, scratch, err
 			}
 		}
-		msg, scratch, err = writeNext(w, msg, scratch)
+		msg, scratch, err = writeNext(w, msg, scratch, depth+1)
 		if err != nil {
 			return msg, scratch, err
 		}
@@ -104,7 +107,10 @@ func rwArrayBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error
 	return msg, scratch, err
 }
 
-func rwMapBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+func rwMapBytes(w jsWriter, msg []byte, scratch []byte, depth int) ([]byte, []byte, error) {
+	if depth >= recursionLimit {
+		return msg, scratch, ErrRecursion
+	}
 	sz, msg, err := ReadMapHeaderBytes(msg)
 	if err != nil {
 		return msg, scratch, err
@@ -120,7 +126,7 @@ func rwMapBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) 
 				return msg, scratch, err
 			}
 		}
-		msg, scratch, err = rwMapKeyBytes(w, msg, scratch)
+		msg, scratch, err = rwMapKeyBytes(w, msg, scratch, depth)
 		if err != nil {
 			return msg, scratch, err
 		}
@@ -128,7 +134,7 @@ func rwMapBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) 
 		if err != nil {
 			return msg, scratch, err
 		}
-		msg, scratch, err = writeNext(w, msg, scratch)
+		msg, scratch, err = writeNext(w, msg, scratch, depth+1)
 		if err != nil {
 			return msg, scratch, err
 		}
@@ -137,17 +143,17 @@ func rwMapBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) 
 	return msg, scratch, err
 }
 
-func rwMapKeyBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
-	msg, scratch, err := rwStringBytes(w, msg, scratch)
+func rwMapKeyBytes(w jsWriter, msg []byte, scratch []byte, depth int) ([]byte, []byte, error) {
+	msg, scratch, err := rwStringBytes(w, msg, scratch, depth)
 	if err != nil {
 		if tperr, ok := err.(TypeError); ok && tperr.Encoded == BinType {
-			return rwBytesBytes(w, msg, scratch)
+			return rwBytesBytes(w, msg, scratch, depth)
 		}
 	}
 	return msg, scratch, err
 }
 
-func rwStringBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+func rwStringBytes(w jsWriter, msg []byte, scratch []byte, depth int) ([]byte, []byte, error) {
 	str, msg, err := ReadStringZC(msg)
 	if err != nil {
 		return msg, scratch, err
@@ -156,7 +162,7 @@ func rwStringBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, erro
 	return msg, scratch, err
 }
 
-func rwBytesBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+func rwBytesBytes(w jsWriter, msg []byte, scratch []byte, depth int) ([]byte, []byte, error) {
 	bts, msg, err := ReadBytesZC(msg)
 	if err != nil {
 		return msg, scratch, err
@@ -180,7 +186,7 @@ func rwBytesBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error
 	return msg, scratch, err
 }
 
-func rwNullBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+func rwNullBytes(w jsWriter, msg []byte, scratch []byte, depth int) ([]byte, []byte, error) {
 	msg, err := ReadNilBytes(msg)
 	if err != nil {
 		return msg, scratch, err
@@ -189,7 +195,7 @@ func rwNullBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error)
 	return msg, scratch, err
 }
 
-func rwBoolBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+func rwBoolBytes(w jsWriter, msg []byte, scratch []byte, depth int) ([]byte, []byte, error) {
 	b, msg, err := ReadBoolBytes(msg)
 	if err != nil {
 		return msg, scratch, err
@@ -202,7 +208,7 @@ func rwBoolBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error)
 	return msg, scratch, err
 }
 
-func rwIntBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+func rwIntBytes(w jsWriter, msg []byte, scratch []byte, depth int) ([]byte, []byte, error) {
 	i, msg, err := ReadInt64Bytes(msg)
 	if err != nil {
 		return msg, scratch, err
@@ -212,7 +218,7 @@ func rwIntBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) 
 	return msg, scratch, err
 }
 
-func rwUintBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+func rwUintBytes(w jsWriter, msg []byte, scratch []byte, depth int) ([]byte, []byte, error) {
 	u, msg, err := ReadUint64Bytes(msg)
 	if err != nil {
 		return msg, scratch, err
@@ -222,7 +228,7 @@ func rwUintBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error)
 	return msg, scratch, err
 }
 
-func rwFloat32Bytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+func rwFloat32Bytes(w jsWriter, msg []byte, scratch []byte, depth int) ([]byte, []byte, error) {
 	var f float32
 	var err error
 	f, msg, err = ReadFloat32Bytes(msg)
@@ -234,7 +240,7 @@ func rwFloat32Bytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, err
 	return msg, scratch, err
 }
 
-func rwFloat64Bytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+func rwFloat64Bytes(w jsWriter, msg []byte, scratch []byte, depth int) ([]byte, []byte, error) {
 	var f float64
 	var err error
 	f, msg, err = ReadFloat64Bytes(msg)
@@ -246,7 +252,7 @@ func rwFloat64Bytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, err
 	return msg, scratch, err
 }
 
-func rwTimeBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+func rwTimeBytes(w jsWriter, msg []byte, scratch []byte, depth int) ([]byte, []byte, error) {
 	var t time.Time
 	var err error
 	t, msg, err = ReadTimeBytes(msg)
@@ -261,7 +267,7 @@ func rwTimeBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error)
 	return msg, scratch, err
 }
 
-func rwExtensionBytes(w jsWriter, msg []byte, scratch []byte) ([]byte, []byte, error) {
+func rwExtensionBytes(w jsWriter, msg []byte, scratch []byte, depth int) ([]byte, []byte, error) {
 	var err error
 	var et int8
 	et, err = peekExtension(msg)


### PR DESCRIPTION
Prevent adversarial stack exhaustion on:

Decoder:

* CopyNext
* Skip
* ReadIntf
* ReadMapStrIntf
* WriteToJSON

Standalone:

* Skip
* ReadMapStrIntfBytes
* ReadIntfBytes
* CopyToJSON
* UnmarshalAsJSON

Limit is set to 100K recursive map/slice operations. I know it is insanely high, but we are really just trying to not run out of stack.