### PR TITLE
Improve read speed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/tinylib/msgp
 go 1.20
 
 require (
-	github.com/philhofer/fwd v1.1.3-0.20240612014219-fbbf4953d986
+	github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c
 	golang.org/x/tools v0.22.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/philhofer/fwd v1.1.3-0.20240612014219-fbbf4953d986 h1:jYi87L8j62qkXzaYHAQAhEapgukhenIMZRBKTNRLHJ4=
-github.com/philhofer/fwd v1.1.3-0.20240612014219-fbbf4953d986/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
+github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c h1:dAMKvw0MlJT1GshSTtih8C2gDs04w8dReiOGXrGLNoY=
+github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
 golang.org/x/mod v0.18.0 h1:5+9lSbEzPSdWkH32vYPBwEpX8KwDbM52Ud9xBUvNlb0=
 golang.org/x/mod v0.18.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=

--- a/msgp/json.go
+++ b/msgp/json.go
@@ -346,14 +346,12 @@ func rwExtension(dst jsWriter, src *Reader) (n int, err error) {
 }
 
 func rwString(dst jsWriter, src *Reader) (n int, err error) {
-	var p []byte
-	p, err = src.R.Peek(1)
+	lead, err := src.R.PeekByte()
 	if err != nil {
 		return
 	}
-	lead := p[0]
 	var read int
-
+	var p []byte
 	if isfixstr(lead) {
 		read = int(rfixstr(lead))
 		src.R.Skip(1)

--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -229,29 +229,30 @@ func ReadArrayHeaderBytes(b []byte) (sz uint32, o []byte, err error) {
 		return 0, nil, ErrShortBytes
 	}
 	lead := b[0]
+	b = b[1:]
 	if isfixarray(lead) {
 		sz = uint32(rfixarray(lead))
-		o = b[1:]
+		o = b
 		return
 	}
 
 	switch lead {
 	case marray16:
-		if len(b) < 3 {
+		if len(b) < 2 {
 			err = ErrShortBytes
 			return
 		}
-		sz = uint32(big.Uint16(b[1:]))
-		o = b[3:]
+		sz = uint32(big.Uint16(b))
+		o = b[2:]
 		return
 
 	case marray32:
-		if len(b) < 5 {
+		if len(b) < 4 {
 			err = ErrShortBytes
 			return
 		}
-		sz = big.Uint32(b[1:])
-		o = b[5:]
+		sz = big.Uint32(b)
+		o = b[4:]
 		return
 
 	default:
@@ -872,7 +873,6 @@ func ReadExactBytes(b []byte, into []byte) (o []byte, err error) {
 
 	lead := b[0]
 	var read uint32
-	var skip int
 	b = b[1:]
 	switch lead {
 	case mbin8:
@@ -881,8 +881,8 @@ func ReadExactBytes(b []byte, into []byte) (o []byte, err error) {
 			return
 		}
 
-		read = uint32(b[1])
-		skip = 1
+		read = uint32(b[0])
+		b = b[1:]
 
 	case mbin16:
 		if len(b) < 2 {
@@ -890,7 +890,7 @@ func ReadExactBytes(b []byte, into []byte) (o []byte, err error) {
 			return
 		}
 		read = uint32(big.Uint16(b))
-		skip = 2
+		b = b[2:]
 
 	case mbin32:
 		if len(b) < 4 {
@@ -898,7 +898,7 @@ func ReadExactBytes(b []byte, into []byte) (o []byte, err error) {
 			return
 		}
 		read = big.Uint32(b)
-		skip = 4
+		b = b[4:]
 
 	default:
 		err = badPrefix(BinType, lead)
@@ -910,7 +910,7 @@ func ReadExactBytes(b []byte, into []byte) (o []byte, err error) {
 		return
 	}
 
-	o = b[skip+copy(into, b[skip:]):]
+	o = b[copy(into, b):]
 	return
 }
 

--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -166,29 +166,30 @@ func ReadMapHeaderBytes(b []byte) (sz uint32, o []byte, err error) {
 	}
 
 	lead := b[0]
+	b = b[1:]
 	if isfixmap(lead) {
 		sz = uint32(rfixmap(lead))
-		o = b[1:]
+		o = b
 		return
 	}
 
 	switch lead {
 	case mmap16:
-		if l < 3 {
+		if len(b) < 2 {
 			err = ErrShortBytes
 			return
 		}
-		sz = uint32(big.Uint16(b[1:]))
-		o = b[3:]
+		sz = uint32(big.Uint16(b))
+		o = b[2:]
 		return
 
 	case mmap32:
-		if l < 5 {
+		if len(b) < 4 {
 			err = ErrShortBytes
 			return
 		}
-		sz = big.Uint32(b[1:])
-		o = b[5:]
+		sz = big.Uint32(b)
+		o = b[4:]
 		return
 
 	default:
@@ -418,99 +419,99 @@ func ReadDurationBytes(b []byte) (d time.Duration, o []byte, err error) {
 //   - [ErrShortBytes] (too few bytes)
 //   - [TypeError] (not a int)
 func ReadInt64Bytes(b []byte) (i int64, o []byte, err error) {
-	l := len(b)
-	if l < 1 {
+	if len(b) < 1 {
 		return 0, nil, ErrShortBytes
 	}
 
 	lead := b[0]
+	b = b[1:]
 	if isfixint(lead) {
 		i = int64(rfixint(lead))
-		o = b[1:]
+		o = b
 		return
 	}
 	if isnfixint(lead) {
 		i = int64(rnfixint(lead))
-		o = b[1:]
+		o = b
 		return
 	}
 
 	switch lead {
 	case mint8:
-		if l < 2 {
+		if len(b) < 1 {
 			err = ErrShortBytes
 			return
 		}
-		i = int64(getMint8(b))
-		o = b[2:]
+		i = int64(int8(b[0]))
+		o = b[1:]
 		return
 
 	case muint8:
-		if l < 2 {
+		if len(b) < 1 {
 			err = ErrShortBytes
 			return
 		}
-		i = int64(getMuint8(b))
-		o = b[2:]
+		i = int64(b[0])
+		o = b[1:]
 		return
 
 	case mint16:
-		if l < 3 {
+		if len(b) < 2 {
 			err = ErrShortBytes
 			return
 		}
-		i = int64(getMint16(b))
-		o = b[3:]
+		i = int64(int16(big.Uint16(b)))
+		o = b[2:]
 		return
 
 	case muint16:
-		if l < 3 {
+		if len(b) < 2 {
 			err = ErrShortBytes
 			return
 		}
-		i = int64(getMuint16(b))
-		o = b[3:]
+		i = int64(big.Uint16(b))
+		o = b[2:]
 		return
 
 	case mint32:
-		if l < 5 {
+		if len(b) < 4 {
 			err = ErrShortBytes
 			return
 		}
-		i = int64(getMint32(b))
-		o = b[5:]
+		i = int64(int32(big.Uint32(b)))
+		o = b[4:]
 		return
 
 	case muint32:
-		if l < 5 {
+		if len(b) < 4 {
 			err = ErrShortBytes
 			return
 		}
-		i = int64(getMuint32(b))
-		o = b[5:]
+		i = int64(big.Uint32(b))
+		o = b[4:]
 		return
 
 	case mint64:
-		if l < 9 {
+		if len(b) < 8 {
 			err = ErrShortBytes
 			return
 		}
-		i = int64(getMint64(b))
-		o = b[9:]
+		i = int64(big.Uint64(b))
+		o = b[8:]
 		return
 
 	case muint64:
-		if l < 9 {
+		if len(b) < 8 {
 			err = ErrShortBytes
 			return
 		}
-		u := getMuint64(b)
+		u := big.Uint64(b)
 		if u > math.MaxInt64 {
 			err = UintOverflow{Value: u, FailedBitsize: 64}
 			return
 		}
 		i = int64(u)
-		o = b[9:]
+		o = b[8:]
 		return
 
 	default:
@@ -592,109 +593,109 @@ func ReadIntBytes(b []byte) (int, []byte, error) {
 //   - [ErrShortBytes] (too few bytes)
 //   - [TypeError] (not a uint)
 func ReadUint64Bytes(b []byte) (u uint64, o []byte, err error) {
-	l := len(b)
-	if l < 1 {
+	if len(b) < 1 {
 		return 0, nil, ErrShortBytes
 	}
 
 	lead := b[0]
+	b = b[1:]
 	if isfixint(lead) {
 		u = uint64(rfixint(lead))
-		o = b[1:]
+		o = b
 		return
 	}
 
 	switch lead {
 	case mint8:
-		if l < 2 {
+		if len(b) < 1 {
 			err = ErrShortBytes
 			return
 		}
-		v := int64(getMint8(b))
+		v := int64(int8(b[0]))
 		if v < 0 {
 			err = UintBelowZero{Value: v}
 			return
 		}
 		u = uint64(v)
-		o = b[2:]
+		o = b[1:]
 		return
 
 	case muint8:
-		if l < 2 {
+		if len(b) < 1 {
 			err = ErrShortBytes
 			return
 		}
-		u = uint64(getMuint8(b))
-		o = b[2:]
+		u = uint64(b[0])
+		o = b[1:]
 		return
 
 	case mint16:
-		if l < 3 {
+		if len(b) < 2 {
 			err = ErrShortBytes
 			return
 		}
-		v := int64(getMint16(b))
+		v := int64((int16(b[0]) << 8) | int16(b[1]))
 		if v < 0 {
 			err = UintBelowZero{Value: v}
 			return
 		}
 		u = uint64(v)
-		o = b[3:]
+		o = b[2:]
 		return
 
 	case muint16:
-		if l < 3 {
+		if len(b) < 2 {
 			err = ErrShortBytes
 			return
 		}
-		u = uint64(getMuint16(b))
-		o = b[3:]
+		u = uint64(big.Uint16(b))
+		o = b[2:]
 		return
 
 	case mint32:
-		if l < 5 {
+		if len(b) < 4 {
 			err = ErrShortBytes
 			return
 		}
-		v := int64(getMint32(b))
+		v := int64(int32(big.Uint32(b)))
 		if v < 0 {
 			err = UintBelowZero{Value: v}
 			return
 		}
 		u = uint64(v)
-		o = b[5:]
+		o = b[4:]
 		return
 
 	case muint32:
-		if l < 5 {
+		if len(b) < 4 {
 			err = ErrShortBytes
 			return
 		}
-		u = uint64(getMuint32(b))
-		o = b[5:]
+		u = uint64(big.Uint32(b))
+		o = b[4:]
 		return
 
 	case mint64:
-		if l < 9 {
+		if len(b) < 8 {
 			err = ErrShortBytes
 			return
 		}
-		v := int64(getMint64(b))
+		v := int64(big.Uint64(b))
 		if v < 0 {
 			err = UintBelowZero{Value: v}
 			return
 		}
 		u = uint64(v)
-		o = b[9:]
+		o = b[8:]
 		return
 
 	case muint64:
-		if l < 9 {
+		if len(b) < 8 {
 			err = ErrShortBytes
 			return
 		}
-		u = getMuint64(b)
-		o = b[9:]
+		u = big.Uint64(b)
+		o = b[8:]
 		return
 
 	default:
@@ -796,32 +797,33 @@ func readBytesBytes(b []byte, scratch []byte, zc bool) (v []byte, o []byte, err 
 	}
 
 	lead := b[0]
+	b = b[1:]
 	var read int
 	switch lead {
 	case mbin8:
-		if l < 2 {
+		if len(b) < 1 {
 			err = ErrShortBytes
 			return
 		}
 
-		read = int(b[1])
-		b = b[2:]
+		read = int(b[0])
+		b = b[1:]
 
 	case mbin16:
-		if l < 3 {
+		if len(b) < 2 {
 			err = ErrShortBytes
 			return
 		}
-		read = int(big.Uint16(b[1:]))
-		b = b[3:]
+		read = int(big.Uint16(b))
+		b = b[2:]
 
 	case mbin32:
-		if l < 5 {
+		if len(b) < 4 {
 			err = ErrShortBytes
 			return
 		}
-		read = int(big.Uint32(b[1:]))
-		b = b[5:]
+		read = int(big.Uint32(b))
+		b = b[4:]
 
 	default:
 		err = badPrefix(BinType, lead)
@@ -863,8 +865,7 @@ func ReadBytesZC(b []byte) (v []byte, o []byte, err error) {
 }
 
 func ReadExactBytes(b []byte, into []byte) (o []byte, err error) {
-	l := len(b)
-	if l < 1 {
+	if len(b) < 1 {
 		err = ErrShortBytes
 		return
 	}
@@ -872,31 +873,32 @@ func ReadExactBytes(b []byte, into []byte) (o []byte, err error) {
 	lead := b[0]
 	var read uint32
 	var skip int
+	b = b[1:]
 	switch lead {
 	case mbin8:
-		if l < 2 {
+		if len(b) < 1 {
 			err = ErrShortBytes
 			return
 		}
 
 		read = uint32(b[1])
-		skip = 2
+		skip = 1
 
 	case mbin16:
-		if l < 3 {
+		if len(b) < 2 {
 			err = ErrShortBytes
 			return
 		}
-		read = uint32(big.Uint16(b[1:]))
-		skip = 3
+		read = uint32(big.Uint16(b))
+		skip = 2
 
 	case mbin32:
-		if l < 5 {
+		if len(b) < 4 {
 			err = ErrShortBytes
 			return
 		}
-		read = uint32(big.Uint32(b[1:]))
-		skip = 5
+		read = big.Uint32(b)
+		skip = 4
 
 	default:
 		err = badPrefix(BinType, lead)
@@ -921,42 +923,41 @@ func ReadExactBytes(b []byte, into []byte) (o []byte, err error) {
 //   - [ErrShortBytes] (b not long enough)
 //   - [TypeError] (object not 'str')
 func ReadStringZC(b []byte) (v []byte, o []byte, err error) {
-	l := len(b)
-	if l < 1 {
+	if len(b) < 1 {
 		return nil, nil, ErrShortBytes
 	}
 
 	lead := b[0]
 	var read int
 
+	b = b[1:]
 	if isfixstr(lead) {
 		read = int(rfixstr(lead))
-		b = b[1:]
 	} else {
 		switch lead {
 		case mstr8:
-			if l < 2 {
+			if len(b) < 1 {
 				err = ErrShortBytes
 				return
 			}
-			read = int(b[1])
-			b = b[2:]
+			read = int(b[0])
+			b = b[1:]
 
 		case mstr16:
-			if l < 3 {
+			if len(b) < 2 {
 				err = ErrShortBytes
 				return
 			}
-			read = int(big.Uint16(b[1:]))
-			b = b[3:]
+			read = int(big.Uint16(b))
+			b = b[2:]
 
 		case mstr32:
-			if l < 5 {
+			if len(b) < 4 {
 				err = ErrShortBytes
 				return
 			}
-			read = int(big.Uint32(b[1:]))
-			b = b[5:]
+			read = int(big.Uint32(b))
+			b = b[4:]
 
 		default:
 			err = TypeError{Method: StrType, Encoded: getType(lead)}

--- a/msgp/read_bytes_test.go
+++ b/msgp/read_bytes_test.go
@@ -472,7 +472,7 @@ func TestReadIntBytesOverflows(t *testing.T) {
 				_, _, err = ReadUint8Bytes(buf.Bytes())
 			}
 			if !v.errCheck(err, v.failBits) {
-				t.Fatal(err)
+				t.Fatal(err, v.rdBits, v.failBits)
 			}
 		})
 	}

--- a/msgp/write_test.go
+++ b/msgp/write_test.go
@@ -20,8 +20,9 @@ var (
 
 func RandBytes(sz int) []byte {
 	out := make([]byte, sz)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := range out {
-		out[i] = byte(rand.Int63n(math.MaxInt64) % 256)
+		out[i] = byte(rng.Uint32())
 	}
 	return out
 }


### PR DESCRIPTION
Utilize https://github.com/philhofer/fwd/pull/32 to peek bytes

Eliminate bounds checks, mostly on reading sizes, but also integers.

```
benchmark                            old MB/s     new MB/s     speedup
BenchmarkReadMapHeaderBytes-32       1136.75      1136.89      1.00x
BenchmarkReadArrayHeaderBytes-32     1133.52      1149.34      1.01x
BenchmarkTestReadBytesHeader-32      1200.18      1171.21      0.98x
BenchmarkReadNilByte-32              2907.50      2176.63      0.75x
BenchmarkReadFloat64Bytes-32         4308.86      3869.64      0.90x
BenchmarkReadFloat32Bytes-32         2354.55      2332.21      0.99x
BenchmarkReadBoolBytes-32            863.66       1124.07      1.30x
BenchmarkReadTimeBytes-32            3710.27      3668.07      0.99x
BenchmarkReadMapHeader-32            228.74       391.76       1.71x
BenchmarkReadArrayHeader-32          243.90       454.31       1.86x
BenchmarkReadNil-32                  127.42       191.55       1.50x
BenchmarkReadFloat64-32              1046.08      1142.49      1.09x
BenchmarkReadFloat32-32              595.67       669.65       1.12x
BenchmarkReadInt64-32                422.29       798.35       1.89x
BenchmarkReadUintWithInt64-32        186.59       371.28       1.99x
BenchmarkReadUint64-32               282.87       377.76       1.34x
BenchmarkReadIntWithUint64-32        465.30       684.49       1.47x
BenchmarkRead16Bytes-32              1021.15      1021.38      1.00x
BenchmarkRead256Bytes-32             5324.42      6166.06      1.16x
BenchmarkRead2048Bytes-32            8405.41      8382.61      1.00x
BenchmarkRead16StringAsBytes-32      1102.72      1321.71      1.20x
BenchmarkRead256StringAsBytes-32     6959.78      6627.49      0.95x
BenchmarkRead16String-32             320.75       378.46       1.18x
BenchmarkRead256String-32            2066.40      2242.78      1.09x
BenchmarkReadComplex64-32            900.13       1064.21      1.18x
BenchmarkReadComplex128-32           1809.88      2028.11      1.12x
BenchmarkReadTime-32                 1362.46      1425.79      1.05x
```

Apologies for the noisy benchmark. `BenchmarkReadNilByte` and `BenchmarkReadFloat64Byte` does not touch new code, so it seems to be "micro-bench-itis", where random deltas show up. Bench takes ~30m to run for whatever reason.

The compiler is not clever enough to track back to `l := len(b)`, so it inserts a bounds check. Also `len(b) < 3` and `big.Uint16(b[1:])` causes a bounds check. So we rewrite those to avoid it.

This should cover the lowest hanging fruits.