### PR TITLE
Add native json.Number support

### DIFF
--- a/_generated/def.go
+++ b/_generated/def.go
@@ -1,6 +1,7 @@
 package _generated
 
 import (
+	"encoding/json"
 	"os"
 	"time"
 
@@ -298,4 +299,10 @@ type StructByteSlice struct {
 	AComplex64  []complex64  `msg:",allownil"`
 	AComplex128 []complex128 `msg:",allownil"`
 	AStruct     []Fixed      `msg:",allownil"`
+}
+
+type NumberJSONSample struct {
+	Single json.Number
+	Array  []json.Number
+	Map    map[string]json.Number
 }

--- a/_generated/def.go
+++ b/_generated/def.go
@@ -305,4 +305,5 @@ type NumberJSONSample struct {
 	Single json.Number
 	Array  []json.Number
 	Map    map[string]json.Number
+	OE     json.Number `msg:",omitempty"`
 }

--- a/_generated/def_test.go
+++ b/_generated/def_test.go
@@ -2,6 +2,7 @@ package _generated
 
 import (
 	"bytes"
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -72,5 +73,109 @@ func TestRuneMarshalUnmarshal(t *testing.T) {
 	}
 	if !reflect.DeepEqual(tt.RuneSlice, out.RuneSlice) {
 		t.Errorf("rune slice mismatch")
+	}
+}
+
+func TestJSONNumber(t *testing.T) {
+	test := NumberJSONSample{
+		Single: "-42",
+		Array:  []json.Number{"0", "-0", "1", "-1", "0.1", "-0.1", "1234", "-1234", "12.34", "-12.34", "12E0", "12E1", "12e34", "12E-0", "12e+1", "12e-34", "-12E0", "-12E1", "-12e34", "-12E-0", "-12e+1", "-12e-34", "1.2E0", "1.2E1", "1.2e34", "1.2E-0", "1.2e+1", "1.2e-34", "-1.2E0", "-1.2E1", "-1.2e34", "-1.2E-0", "-1.2e+1", "-1.2e-34", "0E0", "0E1", "0e34", "0E-0", "0e+1", "0e-34", "-0E0", "-0E1", "-0e34", "-0E-0", "-0e+1", "-0e-34"},
+		Map: map[string]json.Number{
+			"a": json.Number("50.2"),
+		},
+	}
+
+	// This is not guaranteed to be symmetric
+	encoded, err := test.MarshalMsg(nil)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	var v NumberJSONSample
+	_, err = v.UnmarshalMsg(encoded)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	// Test two values
+	if v.Single != "-42" {
+		t.Errorf("want %v, got %v", "-42", v.Single)
+	}
+	if v.Map["a"] != "50.2" {
+		t.Errorf("want %v, got %v", "50.2", v.Map["a"])
+	}
+
+	var jsBuf bytes.Buffer
+	remain, err := msgp.UnmarshalAsJSON(&jsBuf, encoded)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	if len(remain) != 0 {
+		t.Errorf("remain should be empty")
+	}
+	wantjs := `{"Single":-42,"Array":[0,0,1,-1,0.1,-0.1,1234,-1234,12.34,-12.34,12,120,120000000000000000000000000000000000,12,120,0.0000000000000000000000000000000012,-12,-120,-120000000000000000000000000000000000,-12,-120,-0.0000000000000000000000000000000012,1.2,12,12000000000000000000000000000000000,1.2,12,0.00000000000000000000000000000000012,-1.2,-12,-12000000000000000000000000000000000,-1.2,-12,-0.00000000000000000000000000000000012,0,0,0,0,0,0,-0,-0,-0,-0,-0,-0],"Map":{"a":50.2}}`
+	if jsBuf.String() != wantjs {
+		t.Errorf("jsBuf.String() = \n%s, want \n%s", jsBuf.String(), wantjs)
+	}
+	// Test encoding
+	var buf bytes.Buffer
+	en := msgp.NewWriter(&buf)
+	err = test.EncodeMsg(en)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	en.Flush()
+	encoded = buf.Bytes()
+
+	dc := msgp.NewReader(&buf)
+	err = v.DecodeMsg(dc)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	// Test two values
+	if v.Single != "-42" {
+		t.Errorf("want %s, got %s", "-42", v.Single)
+	}
+	if v.Map["a"] != "50.2" {
+		t.Errorf("want %s, got %s", "50.2", v.Map["a"])
+	}
+
+	jsBuf.Reset()
+	remain, err = msgp.UnmarshalAsJSON(&jsBuf, encoded)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	if len(remain) != 0 {
+		t.Errorf("remain should be empty")
+	}
+	if jsBuf.String() != wantjs {
+		t.Errorf("jsBuf.String() = \n%s, want \n%s", jsBuf.String(), wantjs)
+	}
+
+	// Try interface encoder
+	jd := json.NewDecoder(&jsBuf)
+	jd.UseNumber()
+	var jsIntf map[string]any
+	err = jd.Decode(&jsIntf)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	// Ensure we encode correctly
+	_ = (jsIntf["Single"]).(json.Number)
+
+	fromInt, err := msgp.AppendIntf(nil, jsIntf)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	// Take the value from the JSON interface encoder and unmarshal back into our struct.
+	v = NumberJSONSample{}
+	_, err = v.UnmarshalMsg(fromInt)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	if v.Single != "-42" {
+		t.Errorf("want %s, got %s", "-42", v.Single)
+	}
+	if v.Map["a"] != "50.2" {
+		t.Errorf("want %s, got %s", "50.2", v.Map["a"])
 	}
 }

--- a/_generated/replace.go
+++ b/_generated/replace.go
@@ -1,5 +1,7 @@
 package _generated
 
+import "encoding/json"
+
 //go:generate msgp
 //msgp:replace Any with:any
 //msgp:replace MapString with:CompatibleMapString
@@ -74,3 +76,11 @@ type (
 		String  String
 	}
 )
+
+//msgp:replace json.Number with:string
+
+type NumberJSONSampleReplace struct {
+	Single json.Number
+	Array  []json.Number
+	Map    map[string]json.Number
+}

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -88,10 +88,11 @@ const (
 	Int32
 	Int64
 	Bool
-	Intf     // interface{}
-	Time     // time.Time
-	Duration // time.Duration
-	Ext      // extension
+	Intf       // interface{}
+	Time       // time.Time
+	Duration   // time.Duration
+	Ext        // extension
+	JsonNumber // json.Number
 
 	IDENT // IDENT means an unrecognized identifier
 )
@@ -123,6 +124,7 @@ var primitives = map[string]Primitive{
 	"time.Time":      Time,
 	"time.Duration":  Duration,
 	"msgp.Extension": Ext,
+	"json.Number":    JsonNumber,
 }
 
 // types built into the library
@@ -634,6 +636,9 @@ func (s *BaseElem) BaseName() string {
 	if s.Value == Duration {
 		return "Duration"
 	}
+	if s.Value == JsonNumber {
+		return "JSONNumber"
+	}
 	return s.Value.String()
 }
 
@@ -652,6 +657,8 @@ func (s *BaseElem) BaseType() string {
 		return "time.Time"
 	case Duration:
 		return "time.Duration"
+	case JsonNumber:
+		return "json.Number"
 	case Ext:
 		return "msgp.Extension"
 
@@ -719,9 +726,10 @@ func (s *BaseElem) ZeroExpr() string {
 		return "0"
 	case Bool:
 		return "false"
-
 	case Time:
 		return "(time.Time{})"
+	case JsonNumber:
+		return "(json.Number{})"
 
 	}
 
@@ -783,6 +791,8 @@ func (k Primitive) String() string {
 		return "time.Duration"
 	case Ext:
 		return "Extension"
+	case JsonNumber:
+		return "json.Number"
 	case IDENT:
 		return "Ident"
 	default:

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -729,7 +729,7 @@ func (s *BaseElem) ZeroExpr() string {
 	case Time:
 		return "(time.Time{})"
 	case JsonNumber:
-		return "(json.Number{})"
+		return `""`
 
 	}
 

--- a/gen/marshal.go
+++ b/gen/marshal.go
@@ -304,7 +304,7 @@ func (m *marshalGen) gBase(b *BaseElem) {
 	case IDENT:
 		echeck = true
 		m.p.printf("\no, err = %s.MarshalMsg(o)", vname)
-	case Intf, Ext:
+	case Intf, Ext, JsonNumber:
 		echeck = true
 		m.p.printf("\no, err = msgp.Append%s(o, %s)", b.BaseName(), vname)
 	default:

--- a/msgp/read.go
+++ b/msgp/read.go
@@ -1306,11 +1306,6 @@ func (m *Reader) ReadJSONNumber() (n json.Number, err error) {
 			return json.Number(strconv.FormatFloat(v, 'f', -1, 64)), nil
 		}
 		return "", err
-	case StrType:
-		v, err := m.ReadString()
-		if err == nil {
-			return json.Number(v), nil
-		}
 	}
 	return "", TypeError{Method: NumberType, Encoded: t}
 }

--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -1348,9 +1348,5 @@ func ReadJSONNumberBytes(b []byte) (number json.Number, o []byte, err error) {
 	if err == nil {
 		return json.Number(strconv.FormatFloat(f, 'f', -1, 64)), o, nil
 	}
-	s, o, err := ReadStringBytes(b)
-	if err == nil {
-		return json.Number(s), o, nil
-	}
 	return "", nil, TypeError{Method: NumberType, Encoded: getType(b[0])}
 }

--- a/msgp/size.go
+++ b/msgp/size.go
@@ -25,10 +25,11 @@ const (
 	Complex64Size  = 10
 	Complex128Size = 18
 
-	DurationSize = Int64Size
-	TimeSize     = 15
-	BoolSize     = 1
-	NilSize      = 1
+	DurationSize   = Int64Size
+	TimeSize       = 15
+	BoolSize       = 1
+	NilSize        = 1
+	JSONNumberSize = Int64Size // Same as Float64Size
 
 	MapHeaderSize   = 5
 	ArrayHeaderSize = 5

--- a/msgp/write.go
+++ b/msgp/write.go
@@ -638,8 +638,8 @@ func (mw *Writer) WriteTime(t time.Time) error {
 // WriteJSONNumber writes the json.Number to the stream as either integer or float.
 func (mw *Writer) WriteJSONNumber(n json.Number) error {
 	if n == "" {
-		// Allow writing the empty string to cover the zero value.
-		return mw.push(wfixstr(uint8(0)))
+		// The zero value outputs the 0 integer.
+		return mw.push(0)
 	}
 	ii, err := n.Int64()
 	if err == nil {

--- a/msgp/write.go
+++ b/msgp/write.go
@@ -647,7 +647,7 @@ func (mw *Writer) WriteJSONNumber(n json.Number) error {
 	}
 	ff, err := n.Float64()
 	if err == nil {
-		return mw.WriteFloat64(ff)
+		return mw.WriteFloat(ff)
 	}
 	return err
 }

--- a/msgp/write_bytes.go
+++ b/msgp/write_bytes.go
@@ -470,8 +470,8 @@ func AppendIntf(b []byte, i interface{}) ([]byte, error) {
 // An error will be returned if the json.Number returns error as both integer and float.
 func AppendJSONNumber(b []byte, n json.Number) ([]byte, error) {
 	if n == "" {
-		// Allow writing the empty string to cover the zero value.
-		return append(b, mfixstr), nil
+		// The zero value outputs the 0 integer.
+		return append(b, 0), nil
 	}
 	ii, err := n.Int64()
 	if err == nil {

--- a/msgp/write_bytes.go
+++ b/msgp/write_bytes.go
@@ -479,7 +479,7 @@ func AppendJSONNumber(b []byte, n json.Number) ([]byte, error) {
 	}
 	ff, err := n.Float64()
 	if err == nil {
-		return AppendFloat64(b, ff), nil
+		return AppendFloat(b, ff), nil
 	}
 	return b, err
 }


### PR DESCRIPTION
Allow encoding and decoding of `json.Number` values, either as struct members or as interface members.

Numbers will be encoded as integer, if possible, otherwise float64 is used. The zero value json.Number will be encoded as 0.

It is possible to encode as string with `//msgp:replace json.Number with:string`.

Fixes #292

### Review notes

~I think the only contentious part is that it refuses to encode invalid values, which seems reasonable to me, so the output will either be float or integer or an empty string.~

~Empty string or null, for a "zero value" (not 0)? A bit undecided on this. Open to changes.~