### PR TITLE
Use float32 when lossless for float64

### DIFF
--- a/msgp/edit_test.go
+++ b/msgp/edit_test.go
@@ -120,7 +120,7 @@ func TestReplace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !reflect.DeepEqual(m["thing_two"], 4.0) {
+	if !reflect.DeepEqual(m["thing_two"], float32(4.0)) {
 		t.Errorf("wanted %v; got %v", 4.0, m["thing_two"])
 	}
 

--- a/msgp/read_bytes_test.go
+++ b/msgp/read_bytes_test.go
@@ -694,13 +694,13 @@ func TestReadIntfBytes(t *testing.T) {
 	en := NewWriter(&buf)
 
 	tests := make([]interface{}, 0, 10)
-	tests = append(tests, float64(3.5))
+	tests = append(tests, float64(1e40))
 	tests = append(tests, int64(-49082))
 	tests = append(tests, uint64(34908))
 	tests = append(tests, string("hello!"))
 	tests = append(tests, []byte("blah."))
 	tests = append(tests, map[string]interface{}{
-		"key_one": 3.5,
+		"key_one": float32(3.5),
 		"key_two": "hi.",
 	})
 

--- a/msgp/write.go
+++ b/msgp/write.go
@@ -348,6 +348,17 @@ func (mw *Writer) WriteNil() error {
 
 // WriteFloat64 writes a float64 to the writer
 func (mw *Writer) WriteFloat64(f float64) error {
+	f32 := float32(f)
+	if float64(f32) == f {
+		return mw.prefix32(mfloat32, math.Float32bits(f32))
+	}
+
+	return mw.prefix64(mfloat64, math.Float64bits(f))
+}
+
+// WriteFloat64Only writes a float64 to the writer
+// If the value can be lossless represented as float32 it will be stored as that.
+func (mw *Writer) WriteFloat64Only(f float64) error {
 	return mw.prefix64(mfloat64, math.Float64bits(f))
 }
 

--- a/msgp/write_bytes.go
+++ b/msgp/write_bytes.go
@@ -60,8 +60,21 @@ func AppendArrayHeader(b []byte, sz uint32) []byte {
 // AppendNil appends a 'nil' byte to the slice
 func AppendNil(b []byte) []byte { return append(b, mnil) }
 
-// AppendFloat64 appends a float64 to the slice
+// AppendFloat64 appends a float64 to the slice.
+// If the value can be lossless represented as float32 it will be stored as that.
 func AppendFloat64(b []byte, f float64) []byte {
+	f32 := float32(f)
+	if float64(f32) == f {
+		return AppendFloat32(b, f32)
+	}
+
+	o, n := ensure(b, Float64Size)
+	prefixu64(o[n:], mfloat64, math.Float64bits(f))
+	return o
+}
+
+// AppendFloat64Only appends a float64 to the slice
+func AppendFloat64Only(b []byte, f float64) []byte {
 	o, n := ensure(b, Float64Size)
 	prefixu64(o[n:], mfloat64, math.Float64bits(f))
 	return o


### PR DESCRIPTION
When a float64 can be fully represented as a float32, use that instead.

Encoding is backwards compatible with existing reader. `AppendFloat64Only` is made available to unconditionally write a float64.

Micro-benchmarks are not great:

```
BenchmarkAppendFloat64Only-32    	511061935	         2.324 ns/op	3442.55 MB/s	       0 B/op	       0 allocs/op
BenchmarkAppendFloat64-32    	136697270	         8.704 ns/op	 919.08 MB/s	       0 B/op	       0 allocs/op
```

But microbenchmarks are micro-benchmarks. We take a much bigger cost on `AppendInt64` and other integer functions.

We could make it opt-in, but that would make it pretty much unused.