### PR TITLE
Use unsafe.string instead of unsafe.pointer

### DIFF
--- a/msgp/unsafe.go
+++ b/msgp/unsafe.go
@@ -24,7 +24,11 @@ const (
 // THIS IS EVIL CODE.
 // YOU HAVE BEEN WARNED.
 func UnsafeString(b []byte) string {
-	return *(*string)(unsafe.Pointer(&b))
+	l := len(b)
+	if l == 0 {
+		return ""
+	}
+	return unsafe.String(&b[0], l)
 }
 
 // UnsafeBytes returns the string as a byte slice


### PR DESCRIPTION
This only a cosmetic change, the speed seems to be exactly the same

Closes #371 