### PR TITLE
Add "clearomitted" directive

### DIFF
--- a/_generated/clearomitted.go
+++ b/_generated/clearomitted.go
@@ -1,0 +1,97 @@
+package _generated
+
+import (
+	"encoding/json"
+	"time"
+)
+
+//go:generate msgp
+
+//msgp:clearomitted
+
+// check some specific cases for omitzero
+
+type ClearOmitted0 struct {
+	AStruct    ClearOmittedA  `msg:"astruct,omitempty"`    // leave this one omitempty
+	BStruct    ClearOmittedA  `msg:"bstruct,omitzero"`     // and compare to this
+	AStructPtr *ClearOmittedA `msg:"astructptr,omitempty"` // a pointer case omitempty
+	BStructPtr *ClearOmittedA `msg:"bstructptr,omitzero"`  // a pointer case omitzero
+	AExt       OmitZeroExt    `msg:"aext,omitzero"`        // external type case
+
+	// more
+	APtrNamedStr        *NamedStringCO                     `msg:"aptrnamedstr,omitzero"`
+	ANamedStruct        NamedStructCO                      `msg:"anamedstruct,omitzero"`
+	APtrNamedStruct     *NamedStructCO                     `msg:"aptrnamedstruct,omitzero"`
+	EmbeddableStructCO  `msg:",flatten,omitzero"`          // embed flat
+	EmbeddableStructCO2 `msg:"embeddablestruct2,omitzero"` // embed non-flat
+	ATime               time.Time                          `msg:"atime,omitzero"`
+	ASlice              []int                              `msg:"aslice,omitempty"`
+	AMap                map[string]int                     `msg:"amap,omitempty"`
+	ABin                []byte                             `msg:"abin,omitempty"`
+	AInt                int                                `msg:"aint,omitempty"`
+	AString             string                             `msg:"atring,omitempty"`
+	Adur                time.Duration                      `msg:"adur,omitempty"`
+	AJSON               json.Number                        `msg:"ajson,omitempty"`
+
+	ClearOmittedTuple ClearOmittedTuple `msg:"ozt"` // the inside of a tuple should ignore both omitempty and omitzero
+}
+
+type ClearOmittedA struct {
+	A string        `msg:"a,omitempty"`
+	B NamedStringCO `msg:"b,omitzero"`
+	C NamedStringCO `msg:"c,omitzero"`
+}
+
+func (o *ClearOmittedA) IsZero() bool {
+	if o == nil {
+		return true
+	}
+	return *o == (ClearOmittedA{})
+}
+
+type NamedStructCO struct {
+	A string `msg:"a,omitempty"`
+	B string `msg:"b,omitempty"`
+}
+
+func (ns *NamedStructCO) IsZero() bool {
+	if ns == nil {
+		return true
+	}
+	return *ns == (NamedStructCO{})
+}
+
+type NamedStringCO string
+
+func (ns *NamedStringCO) IsZero() bool {
+	if ns == nil {
+		return true
+	}
+	return *ns == ""
+}
+
+type EmbeddableStructCO struct {
+	SomeEmbed string `msg:"someembed2,omitempty"`
+}
+
+func (es EmbeddableStructCO) IsZero() bool { return es == (EmbeddableStructCO{}) }
+
+type EmbeddableStructCO2 struct {
+	SomeEmbed2 string `msg:"someembed2,omitempty"`
+}
+
+func (es EmbeddableStructCO2) IsZero() bool { return es == (EmbeddableStructCO2{}) }
+
+//msgp:tuple ClearOmittedTuple
+
+// ClearOmittedTuple is flagged for tuple output, it should ignore all omitempty and omitzero functionality
+// since it's fundamentally incompatible.
+type ClearOmittedTuple struct {
+	FieldA string        `msg:"fielda,omitempty"`
+	FieldB NamedStringCO `msg:"fieldb,omitzero"`
+	FieldC NamedStringCO `msg:"fieldc,omitzero"`
+}
+
+type ClearOmitted1 struct {
+	T1 ClearOmittedTuple `msg:"t1"`
+}

--- a/_generated/clearomitted_test.go
+++ b/_generated/clearomitted_test.go
@@ -1,0 +1,93 @@
+package _generated
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestClearOmitted(t *testing.T) {
+	cleared := ClearOmitted0{}
+	encoded, err := cleared.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vPtr := NamedStringCO("value")
+	filled := ClearOmitted0{
+		AStruct:             ClearOmittedA{A: "something"},
+		BStruct:             ClearOmittedA{A: "somthing"},
+		AStructPtr:          &ClearOmittedA{A: "something"},
+		AExt:                OmitZeroExt{25},
+		APtrNamedStr:        &vPtr,
+		ANamedStruct:        NamedStructCO{A: "value"},
+		APtrNamedStruct:     &NamedStructCO{A: "sdf"},
+		EmbeddableStructCO:  EmbeddableStructCO{"value"},
+		EmbeddableStructCO2: EmbeddableStructCO2{"value"},
+		ATime:               time.Now(),
+		ASlice:              []int{1, 2, 3},
+		AMap:                map[string]int{"1": 1},
+		ABin:                []byte{1, 2, 3},
+		ClearOmittedTuple:   ClearOmittedTuple{FieldA: "value"},
+		AInt:                42,
+		AString:             "value",
+		Adur:                time.Second,
+		AJSON:               json.Number(`43.0000000000002`),
+	}
+	dst := filled
+	_, err = dst.UnmarshalMsg(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(dst, cleared) {
+		t.Errorf("\n got=%#v\nwant=%#v", dst, cleared)
+	}
+	// Reset
+	dst = filled
+	err = dst.DecodeMsg(msgp.NewReader(bytes.NewReader(encoded)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(dst, cleared) {
+		t.Errorf("\n got=%#v\nwant=%#v", dst, cleared)
+	}
+
+	// Check that fields aren't accidentally zeroing fields.
+	wantJson, err := json.Marshal(filled)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err = filled.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dst = ClearOmitted0{}
+	_, err = dst.UnmarshalMsg(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := json.Marshal(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, wantJson) {
+		t.Errorf("\n got=%#v\nwant=%#v", string(got), string(wantJson))
+	}
+	// Reset
+	dst = ClearOmitted0{}
+	err = dst.DecodeMsg(msgp.NewReader(bytes.NewReader(encoded)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err = json.Marshal(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, wantJson) {
+		t.Errorf("\n got=%#v\nwant=%#v", string(got), string(wantJson))
+	}
+	t.Log("OK - got", string(got))
+}

--- a/gen/decode.go
+++ b/gen/decode.go
@@ -107,14 +107,13 @@ func (d *decodeGen) structAsMap(s *Struct) {
 	d.p.declare(sz, u32)
 	d.assignAndCheck(sz, mapHeader)
 
-	oeIdentPrefix := randIdent()
 	oeCount := s.CountFieldTagPart("omitempty") + s.CountFieldTagPart("omitzero")
 	if !d.ctx.clearOmitted {
 		oeCount = 0
 	}
 	bm := bmask{
 		bitlen:  oeCount,
-		varname: oeIdentPrefix + "Mask",
+		varname: sz + "Mask",
 	}
 	if oeCount > 0 {
 		// Declare mask

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -516,6 +516,17 @@ func (s *Struct) AnyHasTagPart(pname string) bool {
 	return false
 }
 
+// CountFieldTagPart the count of HasTagPart(p) is true for any field.
+func (s *Struct) CountFieldTagPart(pname string) int {
+	var n int
+	for _, sf := range s.Fields {
+		if sf.HasTagPart(pname) {
+			n++
+		}
+	}
+	return n
+}
+
 type StructField struct {
 	FieldTag      string   // the string inside the `msg:""` tag up to the first comma
 	FieldTagParts []string // the string inside the `msg:""` tag split by commas

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -103,14 +103,13 @@ func (u *unmarshalGen) mapstruct(s *Struct) {
 	u.p.declare(sz, u32)
 	u.assignAndCheck(sz, mapHeader)
 
-	oeIdentPrefix := randIdent()
 	oeCount := s.CountFieldTagPart("omitempty") + s.CountFieldTagPart("omitzero")
 	if !u.ctx.clearOmitted {
 		oeCount = 0
 	}
 	bm := bmask{
 		bitlen:  oeCount,
-		varname: oeIdentPrefix + "Mask",
+		varname: sz + "Mask",
 	}
 	if oeCount > 0 {
 		// Declare mask

--- a/parse/directives.go
+++ b/parse/directives.go
@@ -27,6 +27,7 @@ var directives = map[string]directive{
 	"ignore":        ignore,
 	"tuple":         astuple,
 	"compactfloats": compactfloats,
+	"clearomitted":  clearomitted,
 }
 
 // map of all recognized directives which will be applied
@@ -191,5 +192,11 @@ func pointer(text []string, f *FileSet) error {
 //msgp:compactfloats
 func compactfloats(text []string, f *FileSet) error {
 	f.CompactFloats = true
+	return nil
+}
+
+//msgp:clearomitted
+func clearomitted(text []string, f *FileSet) error {
+	f.ClearOmitted = true
 	return nil
 }

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -21,7 +21,8 @@ type FileSet struct {
 	Identities    map[string]gen.Elem // processed from specs
 	Directives    []string            // raw preprocessor directives
 	Imports       []*ast.ImportSpec   // imports
-	CompactFloats bool                // Use smaller floats when feasible.
+	CompactFloats bool                // Use smaller floats when feasible
+	ClearOmitted  bool                // Set omitted fields to zero value
 	tagName       string              // tag to read field names from
 	pointerRcv    bool                // generate with pointer receivers.
 }
@@ -271,6 +272,7 @@ loop:
 		}
 	}
 	p.CompactFloats = f.CompactFloats
+	p.ClearOmitted = f.ClearOmitted
 }
 
 func (f *FileSet) PrintTo(p *gen.Printer) error {


### PR DESCRIPTION
Adds `//msgp:clearomitted` directive.

This will cause all `omitempty` and `omitzero` fields to be set to the zero value on Unmarshal and Decode, and the field wasn't present in the marshalled data.

This can be useful when de-serializing into reused objects, that can have values set for these, and we want to avoid clearing all fields, but also don't want existing fields to leak through.

Fields are tracked through a bit mask, and zeroed after the unmarshal loop, if no value has been written.

This does not affect marshaling.

<details>
  <summary>DecodeMsg Example</summary>

```go
// DecodeMsg implements msgp.Decodable
func (z *NamedStructCO) DecodeMsg(dc *msgp.Reader) (err error) {
	var field []byte
	_ = field
	var zb0001 uint32
	zb0001, err = dc.ReadMapHeader()
	if err != nil {
		err = msgp.WrapError(err)
		return
	}
	var zb0001Mask uint8 /* 2 bits */
	_ = zb0001Mask
	for zb0001 > 0 {
		zb0001--
		field, err = dc.ReadMapKeyPtr()
		if err != nil {
			err = msgp.WrapError(err)
			return
		}
		switch msgp.UnsafeString(field) {
		case "a":
			z.A, err = dc.ReadString()
			if err != nil {
				err = msgp.WrapError(err, "A")
				return
			}
			zb0001Mask |= 0x1
		case "b":
			z.B, err = dc.ReadString()
			if err != nil {
				err = msgp.WrapError(err, "B")
				return
			}
			zb0001Mask |= 0x2
		default:
			err = dc.Skip()
			if err != nil {
				err = msgp.WrapError(err)
				return
			}
		}
	}
	// Clear omitted fields.
	if zb0001Mask != 0x3 {
		if (zb0001Mask & 0x1) == 0 {
			z.A = ""
		}
		if (zb0001Mask & 0x2) == 0 {
			z.B = ""
		}
	}
	return
}
```

</details>


<details>
  <summary>UnmarshalMsg Example</summary>

```go
// UnmarshalMsg implements msgp.Unmarshaler
func (z *NamedStructCO) UnmarshalMsg(bts []byte) (o []byte, err error) {
	var field []byte
	_ = field
	var zb0001 uint32
	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
	if err != nil {
		err = msgp.WrapError(err)
		return
	}
	var zb0001Mask uint8 /* 2 bits */
	_ = zb0001Mask
	for zb0001 > 0 {
		zb0001--
		field, bts, err = msgp.ReadMapKeyZC(bts)
		if err != nil {
			err = msgp.WrapError(err)
			return
		}
		switch msgp.UnsafeString(field) {
		case "a":
			z.A, bts, err = msgp.ReadStringBytes(bts)
			if err != nil {
				err = msgp.WrapError(err, "A")
				return
			}
			zb0001Mask |= 0x1
		case "b":
			z.B, bts, err = msgp.ReadStringBytes(bts)
			if err != nil {
				err = msgp.WrapError(err, "B")
				return
			}
			zb0001Mask |= 0x2
		default:
			bts, err = msgp.Skip(bts)
			if err != nil {
				err = msgp.WrapError(err)
				return
			}
		}
	}
	// Clear omitted fields.
	if zb0001Mask != 0x3 {
		if (zb0001Mask & 0x1) == 0 {
			z.A = ""
		}
		if (zb0001Mask & 0x2) == 0 {
			z.B = ""
		}
	}
	o = bts
	return
}

```

</details>
  