### PR TITLE
Fix allownil on maps elements

### DIFF
--- a/_generated/allownil.go
+++ b/_generated/allownil.go
@@ -228,3 +228,6 @@ type AllowNilOmitEmpty2 struct {
 	Field00 []string `msg:"field00,allownil,omitempty"`
 	Field01 []string `msg:"field01,allownil,omitempty"`
 }
+
+// Primitive types cannot have allownil for now.
+type NoAllowNil []byte

--- a/gen/decode.go
+++ b/gen/decode.go
@@ -257,6 +257,7 @@ func (d *decodeGen) gMap(m *Map) {
 	d.p.declare(m.Validx, m.Value.TypeName())
 	d.assignAndCheck(m.Keyidx, stringTyp)
 	d.ctx.PushVar(m.Keyidx)
+	m.Value.SetIsAllowNil(false)
 	next(d, m.Value)
 	d.p.mapAssign(m)
 	d.ctx.Pop()

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -146,6 +146,7 @@ func (c *common) Varname() string     { return c.vname }
 func (c *common) Alias(typ string)    { c.alias = typ }
 func (c *common) hidden()             {}
 func (c *common) AllowNil() bool      { return false }
+func (c *common) SetIsAllowNil(bool)  {}
 func (c *common) AlwaysPtr(set *bool) bool {
 	if c != nil && set != nil {
 		c.ptrRcv = *set
@@ -201,6 +202,9 @@ type Elem interface {
 	// AllowNil will return true for types that can be nil but doesn't automatically check.
 	// This is true for slices and maps.
 	AllowNil() bool
+
+	// SetIsAllowNil will set the allownil value, if the type supports it.
+	SetIsAllowNil(bool)
 
 	// AlwaysPtr will return true if receiver should always be a pointer.
 	AlwaysPtr(set *bool) bool

--- a/gen/encode.go
+++ b/gen/encode.go
@@ -241,6 +241,7 @@ func (e *encodeGen) gMap(m *Map) {
 	e.p.printf("\nfor %s, %s := range %s {", m.Keyidx, m.Validx, vname)
 	e.writeAndCheck(stringTyp, literalFmt, m.Keyidx)
 	e.ctx.PushVar(m.Keyidx)
+	m.Value.SetIsAllowNil(false)
 	next(e, m.Value)
 	e.ctx.Pop()
 	e.p.closeblock()

--- a/gen/marshal.go
+++ b/gen/marshal.go
@@ -245,6 +245,7 @@ func (m *marshalGen) gMap(s *Map) {
 	m.p.printf("\nfor %s, %s := range %s {", s.Keyidx, s.Validx, vname)
 	m.rawAppend(stringTyp, literalFmt, s.Keyidx)
 	m.ctx.PushVar(s.Keyidx)
+	s.Value.SetIsAllowNil(false)
 	next(m, s.Value)
 	m.ctx.Pop()
 	m.p.closeblock()

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -141,6 +141,7 @@ func (p *Printer) ApplyDirective(pass Method, t TransformPass) {
 
 // Print prints an Elem.
 func (p *Printer) Print(e Elem) error {
+	e.SetIsAllowNil(false)
 	for _, g := range p.gens {
 		// Elem.SetVarname() is called before the Print() step in parse.FileSet.PrintTo().
 		// Elem.SetVarname() generates identifiers as it walks the Elem. This can cause

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -387,12 +387,7 @@ func (p *printer) rangeBlock(ctx *Context, idx string, iter string, t traversal,
 	ctx.PushVar(idx)
 	// Tags on slices do not extend to the elements, so we always disable allownil on elements.
 	// If we want this to happen in the future, it should be a unique tag.
-	type an interface {
-		SetIsAllowNil(b bool)
-	}
-	if set, ok := inner.(an); ok {
-		set.SetIsAllowNil(false)
-	}
+	inner.SetIsAllowNil(false)
 	p.printf("\n for %s := range %s {", idx, iter)
 	next(t, inner)
 	p.closeblock()

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -269,6 +269,7 @@ func (u *unmarshalGen) gMap(m *Map) {
 	u.p.printf("\nvar %s string; var %s %s; %s--", m.Keyidx, m.Validx, m.Value.TypeName(), sz)
 	u.assignAndCheck(m.Keyidx, stringTyp)
 	u.ctx.PushVar(m.Keyidx)
+	m.Value.SetIsAllowNil(false)
 	next(u, m.Value)
 	u.ctx.Pop()
 	u.p.mapAssign(m)


### PR DESCRIPTION
Similar to #374 map `[]byte` elements and base `[]byte` types would also inherit allownil unintentionally.