### PR TITLE
Add "newtime" directive to use official messagepack time format

### DIFF
--- a/_generated/newtime.go
+++ b/_generated/newtime.go
@@ -1,0 +1,36 @@
+package _generated
+
+import "time"
+
+//go:generate msgp -v
+
+//msgp:newtime
+
+type NewTime struct {
+	T     time.Time
+	Array []time.Time
+	Map   map[string]time.Time
+}
+
+func (t1 NewTime) Equal(t2 NewTime) bool {
+	if !t1.T.Equal(t2.T) {
+		return false
+	}
+	if len(t1.Array) != len(t2.Array) {
+		return false
+	}
+	for i := range t1.Array {
+		if !t1.Array[i].Equal(t2.Array[i]) {
+			return false
+		}
+	}
+	if len(t1.Map) != len(t2.Map) {
+		return false
+	}
+	for k, v := range t1.Map {
+		if !t2.Map[k].Equal(v) {
+			return false
+		}
+	}
+	return true
+}

--- a/_generated/newtime_test.go
+++ b/_generated/newtime_test.go
@@ -1,0 +1,130 @@
+package _generated
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestNewTime(t *testing.T) {
+	value := NewTime{
+		T:     time.Now().UTC(),
+		Array: []time.Time{time.Now().UTC(), time.Now().UTC()},
+		Map: map[string]time.Time{
+			"a": time.Now().UTC(),
+		},
+	}
+	encoded, err := value.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkExtMinusOne(t, encoded)
+	var got NewTime
+	_, err = got.UnmarshalMsg(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !value.Equal(got) {
+		t.Errorf("UnmarshalMsg got %v want %v", value, got)
+	}
+
+	var buf bytes.Buffer
+	w := msgp.NewWriter(&buf)
+	err = value.EncodeMsg(w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Flush()
+	checkExtMinusOne(t, buf.Bytes())
+
+	got = NewTime{}
+	r := msgp.NewReader(&buf)
+	err = got.DecodeMsg(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !value.Equal(got) {
+		t.Errorf("DecodeMsg got %v want %v", value, got)
+	}
+}
+
+func checkExtMinusOne(t *testing.T, b []byte) {
+	r := msgp.NewReader(bytes.NewBuffer(b))
+	_, err := r.ReadMapHeader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := r.ReadMapKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for !bytes.Equal(key, []byte("T")) {
+		key, err = r.ReadMapKey(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	n, _, err := r.ReadExtensionRaw()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != -1 {
+		t.Fatalf("got %v want -1", n)
+	}
+	t.Log("Was -1 extension")
+}
+
+func TestNewTimeRandom(t *testing.T) {
+	rng := rand.New(rand.NewSource(0))
+	runs := int(1e6)
+	if testing.Short() {
+		runs = 1e4
+	}
+	for i := 0; i < runs; i++ {
+		nanos := rng.Int63n(999999999 + 1)
+		secs := rng.Uint64()
+		// Tweak the distribution, so we get more than average number of
+		// length 4 and 8 timestamps.
+		if rng.Intn(5) == 0 {
+			secs %= uint64(time.Now().Unix())
+			if rng.Intn(2) == 0 {
+				nanos = 0
+			}
+		}
+
+		value := NewTime{
+			T: time.Unix(int64(secs), nanos),
+		}
+		encoded, err := value.MarshalMsg(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got NewTime
+		_, err = got.UnmarshalMsg(encoded)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !value.Equal(got) {
+			t.Fatalf("UnmarshalMsg got %v want %v", value, got)
+		}
+		var buf bytes.Buffer
+		w := msgp.NewWriter(&buf)
+		err = value.EncodeMsg(w)
+		if err != nil {
+			t.Fatal(err)
+		}
+		w.Flush()
+		got = NewTime{}
+		r := msgp.NewReader(&buf)
+		err = got.DecodeMsg(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !value.Equal(got) {
+			t.Fatalf("DecodeMsg got %v want %v", value, got)
+		}
+	}
+}

--- a/gen/encode.go
+++ b/gen/encode.go
@@ -31,6 +31,9 @@ func (e *encodeGen) writeAndCheck(typ string, argfmt string, arg interface{}) {
 	if e.ctx.compFloats && typ == "Float64" {
 		typ = "Float"
 	}
+	if e.ctx.newTime && typ == "Time" {
+		typ = "TimeExt"
+	}
 
 	e.p.printf("\nerr = en.Write%s(%s)", typ, fmt.Sprintf(argfmt, arg))
 	e.p.wrapErrCheck(e.ctx.ArgsStr())

--- a/gen/marshal.go
+++ b/gen/marshal.go
@@ -66,6 +66,10 @@ func (m *marshalGen) rawAppend(typ string, argfmt string, arg interface{}) {
 	if m.ctx.compFloats && typ == "Float64" {
 		typ = "Float"
 	}
+	if m.ctx.newTime && typ == "Time" {
+		typ = "TimeExt"
+	}
+
 	m.p.printf("\no = msgp.Append%s(o, %s)", typ, fmt.Sprintf(argfmt, arg))
 }
 

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -79,6 +79,7 @@ type Printer struct {
 	gens          []generator
 	CompactFloats bool
 	ClearOmitted  bool
+	NewTime       bool
 }
 
 func NewPrinter(m Method, out io.Writer, tests io.Writer) *Printer {
@@ -148,7 +149,11 @@ func (p *Printer) Print(e Elem) error {
 		// collisions between idents created during SetVarname and idents created during Print,
 		// hence the separate prefixes.
 		resetIdent("zb")
-		err := g.Execute(e, Context{compFloats: p.CompactFloats, clearOmitted: p.ClearOmitted})
+		err := g.Execute(e, Context{
+			compFloats:   p.CompactFloats,
+			clearOmitted: p.ClearOmitted,
+			newTime:      p.NewTime,
+		})
 		resetIdent("za")
 
 		if err != nil {
@@ -178,6 +183,7 @@ type Context struct {
 	path         []contextItem
 	compFloats   bool
 	clearOmitted bool
+	newTime      bool
 }
 
 func (c *Context) PushString(s string) {

--- a/msgp/errors.go
+++ b/msgp/errors.go
@@ -212,6 +212,31 @@ func (u UintOverflow) Resumable() bool { return true }
 
 func (u UintOverflow) withContext(ctx string) error { u.ctx = addCtx(u.ctx, ctx); return u }
 
+// InvalidTimestamp is returned when an invalid timestamp is encountered
+type InvalidTimestamp struct {
+	Nanos       int64 // value of the nano, if invalid
+	FieldLength int   // Unexpected field length.
+	ctx         string
+}
+
+// Error implements the error interface
+func (u InvalidTimestamp) Error() (str string) {
+	if u.Nanos > 0 {
+		str = "msgp: timestamp nanosecond field value " + strconv.FormatInt(u.Nanos, 10) + " exceeds maximum allows of 999999999"
+	} else if u.FieldLength >= 0 {
+		str = "msgp: invalid timestamp field length " + strconv.FormatInt(int64(u.FieldLength), 10) + " - must be 4, 8 or 12"
+	}
+	if u.ctx != "" {
+		str += " at " + u.ctx
+	}
+	return str
+}
+
+// Resumable is always 'true' for overflows
+func (u InvalidTimestamp) Resumable() bool { return true }
+
+func (u InvalidTimestamp) withContext(ctx string) error { u.ctx = addCtx(u.ctx, ctx); return u }
+
 // UintBelowZero is returned when a call
 // would cast a signed integer below zero
 // to an unsigned integer.

--- a/msgp/json_bytes.go
+++ b/msgp/json_bytes.go
@@ -72,7 +72,7 @@ func writeNext(w jsWriter, msg []byte, scratch []byte, depth int) ([]byte, []byt
 		if err != nil {
 			return nil, scratch, err
 		}
-		if et == TimeExtension {
+		if et == TimeExtension || et == MsgTimeExtension {
 			t = TimeType
 		}
 	}
@@ -276,7 +276,7 @@ func rwExtensionBytes(w jsWriter, msg []byte, scratch []byte, depth int) ([]byte
 	}
 
 	// if it's time.Time
-	if et == TimeExtension {
+	if et == TimeExtension || et == MsgTimeExtension {
 		var tm time.Time
 		tm, msg, err = ReadTimeBytes(msg)
 		if err != nil {

--- a/msgp/read.go
+++ b/msgp/read.go
@@ -260,7 +260,7 @@ func (m *Reader) NextType() (Type, error) {
 			return Complex64Type, nil
 		case Complex128Extension:
 			return Complex128Type, nil
-		case TimeExtension:
+		case TimeExtension, MsgTimeExtension:
 			return TimeType, nil
 		}
 	}
@@ -1287,7 +1287,7 @@ func (m *Reader) ReadTime() (t time.Time, err error) {
 		t = time.Unix(sec, int64(nsec)).Local()
 		_, err = m.R.Skip(15)
 		return
-	case -1:
+	case MsgTimeExtension:
 		switch length {
 		case 4, 8, 12:
 			var tmp [12]byte

--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -29,7 +29,7 @@ func NextType(b []byte) Type {
 			tp = int8(b[spec.size-1])
 		}
 		switch tp {
-		case TimeExtension:
+		case TimeExtension, MsgTimeExtension:
 			return TimeType
 		case Complex128Extension:
 			return Complex128Type
@@ -1094,7 +1094,7 @@ func ReadTimeBytes(b []byte) (t time.Time, o []byte, err error) {
 		sec, nsec := getUnix(b)
 		t = time.Unix(sec, int64(nsec)).Local()
 		return
-	case -1:
+	case MsgTimeExtension:
 		switch len(b) {
 		case 4:
 			t = time.Unix(int64(binary.BigEndian.Uint32(b)), 0).Local()

--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -1069,29 +1069,64 @@ func ReadComplex64Bytes(b []byte) (c complex64, o []byte, err error) {
 // ReadTimeBytes reads a time.Time
 // extension object from 'b' and returns the
 // remaining bytes.
+// Both the official and the format in this package will be read.
 //
 // Possible errors:
 //
 //   - [ErrShortBytes] (not enough bytes in 'b')
-//   - [TypeError] (object not a complex64)
+//   - [TypeError] (object not a time extension 5 or -1)
 //   - [ExtensionTypeError] (object an extension of the correct size, but not a time.Time)
 func ReadTimeBytes(b []byte) (t time.Time, o []byte, err error) {
-	if len(b) < 15 {
+	if len(b) < 6 {
 		err = ErrShortBytes
 		return
 	}
-	if b[0] != mext8 || b[1] != 12 {
-		err = badPrefix(TimeType, b[0])
+	typ, o, b, err := readExt(b)
+	if err != nil {
 		return
 	}
-	if int8(b[2]) != TimeExtension {
+	switch typ {
+	case TimeExtension:
+		if len(b) != 12 {
+			err = ErrShortBytes
+			return
+		}
+		sec, nsec := getUnix(b)
+		t = time.Unix(sec, int64(nsec)).Local()
+		return
+	case -1:
+		switch len(b) {
+		case 4:
+			t = time.Unix(int64(binary.BigEndian.Uint32(b)), 0).Local()
+			return
+		case 8:
+			v := binary.BigEndian.Uint64(b)
+			nanos := int64(v >> 34)
+			if nanos > 999999999 {
+				// In timestamp 64 and timestamp 96 formats, nanoseconds must not be larger than 999999999.
+				err = InvalidTimestamp{Nanos: nanos}
+				return
+			}
+			t = time.Unix(int64(v&(1<<34-1)), nanos).Local()
+			return
+		case 12:
+			nanos := int64(binary.BigEndian.Uint32(b))
+			if nanos > 999999999 {
+				// In timestamp 64 and timestamp 96 formats, nanoseconds must not be larger than 999999999.
+				err = InvalidTimestamp{Nanos: nanos}
+				return
+			}
+			ux := int64(binary.BigEndian.Uint64(b[4:]))
+			t = time.Unix(ux, nanos).Local()
+			return
+		default:
+			err = InvalidTimestamp{FieldLength: len(b)}
+			return
+		}
+	default:
 		err = errExt(int8(b[2]), TimeExtension)
 		return
 	}
-	sec, nsec := getUnix(b[3:])
-	t = time.Unix(sec, int64(nsec)).Local()
-	o = b[15:]
-	return
 }
 
 // ReadMapStrIntfBytes reads a map[string]interface{}

--- a/msgp/write.go
+++ b/msgp/write.go
@@ -636,7 +636,7 @@ func (mw *Writer) WriteTime(t time.Time) error {
 	return nil
 }
 
-// WriteTimeExt will write t using the offical webpack extension spec.
+// WriteTimeExt will write t using the official msgpack extension spec.
 // https://github.com/msgpack/msgpack/blob/master/spec.md#timestamp-extension-type
 func (mw *Writer) WriteTimeExt(t time.Time) error {
 	// Time rounded towards zero.

--- a/msgp/write.go
+++ b/msgp/write.go
@@ -1,6 +1,7 @@
 package msgp
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"io"
@@ -632,6 +633,48 @@ func (mw *Writer) WriteTime(t time.Time) error {
 	mw.buf[o+1] = 12
 	mw.buf[o+2] = TimeExtension
 	putUnix(mw.buf[o+3:], t.Unix(), int32(t.Nanosecond()))
+	return nil
+}
+
+// WriteTimeExt will write t using the offical webpack extension spec.
+// https://github.com/msgpack/msgpack/blob/master/spec.md#timestamp-extension-type
+func (mw *Writer) WriteTimeExt(t time.Time) error {
+	// Time rounded towards zero.
+	secPrec := t.Truncate(time.Second)
+	remain := t.Sub(secPrec).Nanoseconds()
+	asSecs := secPrec.Unix()
+	switch {
+	case remain == 0 && asSecs > 0 && asSecs <= math.MaxUint32:
+		// 4 bytes
+		o, err := mw.require(6)
+		if err != nil {
+			return err
+		}
+		mw.buf[o] = mfixext4
+		mw.buf[o+1] = byte(msgTimeExtension)
+		binary.BigEndian.PutUint32(mw.buf[o+2:], uint32(asSecs))
+		return nil
+	case asSecs < 0 || asSecs >= (1<<34):
+		// 12 bytes
+		o, err := mw.require(12 + 3)
+		if err != nil {
+			return err
+		}
+		mw.buf[o] = mext8
+		mw.buf[o+1] = 12
+		mw.buf[o+2] = byte(msgTimeExtension)
+		binary.BigEndian.PutUint32(mw.buf[o+3:], uint32(remain))
+		binary.BigEndian.PutUint64(mw.buf[o+3+4:], uint64(asSecs))
+	default:
+		// 8 bytes
+		o, err := mw.require(10)
+		if err != nil {
+			return err
+		}
+		mw.buf[o] = mfixext8
+		mw.buf[o+1] = byte(msgTimeExtension)
+		binary.BigEndian.PutUint64(mw.buf[o+2:], uint64(asSecs)|(uint64(remain)<<34))
+	}
 	return nil
 }
 

--- a/msgp/write_bytes.go
+++ b/msgp/write_bytes.go
@@ -323,7 +323,7 @@ func AppendTime(b []byte, t time.Time) []byte {
 	return o
 }
 
-// AppendTimeExt will write t using the official webpack extension spec.
+// AppendTimeExt will write t using the official msgpack extension spec.
 // https://github.com/msgpack/msgpack/blob/master/spec.md#timestamp-extension-type
 func AppendTimeExt(b []byte, t time.Time) []byte {
 	// Time rounded towards zero.

--- a/msgp/write_bytes_test.go
+++ b/msgp/write_bytes_test.go
@@ -420,6 +420,16 @@ func BenchmarkAppendTime(b *testing.B) {
 	}
 }
 
+func BenchmarkAppendTimeExt(b *testing.B) {
+	t := time.Now()
+	buf := make([]byte, 0, 15)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		AppendTimeExt(buf[0:0], t)
+	}
+}
+
 // TestEncodeDecode does a back-and-forth test of encoding and decoding and compare the value with a given output.
 func TestEncodeDecode(t *testing.T) {
 	for _, tc := range []struct {

--- a/parse/directives.go
+++ b/parse/directives.go
@@ -28,6 +28,7 @@ var directives = map[string]directive{
 	"tuple":         astuple,
 	"compactfloats": compactfloats,
 	"clearomitted":  clearomitted,
+	"newtime":       newtime,
 }
 
 // map of all recognized directives which will be applied
@@ -198,5 +199,11 @@ func compactfloats(text []string, f *FileSet) error {
 //msgp:clearomitted
 func clearomitted(text []string, f *FileSet) error {
 	f.ClearOmitted = true
+	return nil
+}
+
+//msgp:newtime
+func newtime(text []string, f *FileSet) error {
+	f.NewTime = true
 	return nil
 }

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -23,6 +23,7 @@ type FileSet struct {
 	Imports       []*ast.ImportSpec   // imports
 	CompactFloats bool                // Use smaller floats when feasible
 	ClearOmitted  bool                // Set omitted fields to zero value
+	NewTime       bool                // Set to use -1 extension for time.Time
 	tagName       string              // tag to read field names from
 	pointerRcv    bool                // generate with pointer receivers.
 }
@@ -273,6 +274,7 @@ loop:
 	}
 	p.CompactFloats = f.CompactFloats
 	p.ClearOmitted = f.ClearOmitted
+	p.NewTime = f.NewTime
 }
 
 func (f *FileSet) PrintTo(p *gen.Printer) error {
@@ -530,7 +532,7 @@ func (fs *FileSet) parseExpr(e ast.Expr) gen.Elem {
 	case *ast.Ident:
 		b := gen.Ident(e.Name)
 
-		// work to resove this expression
+		// work to resolve this expression
 		// can be done later, once we've resolved
 		// everything else.
 		if b.Value == gen.IDENT {


### PR DESCRIPTION
This adds `msgp:newtime` file directive that will encode all time fields using the -1 extension as defined in the [(revised) messagepack spec](https://github.com/msgpack/msgpack/blob/master/spec.md#timestamp-extension-type)

ReadTime/ReadTimeBytes will now support both types natively, and will accept either as input.

Extensions should remain unaffected.

Fixes #300