### PR TITLE
Fix typo, causing extensions to produce invalid json

### DIFF
--- a/msgp/json.go
+++ b/msgp/json.go
@@ -310,7 +310,7 @@ func rwExtension(dst jsWriter, src *Reader) (n int, err error) {
 	}
 	n++
 
-	nn, err = dst.WriteString(`"type:"`)
+	nn, err = dst.WriteString(`"type":`)
 	n += nn
 	if err != nil {
 		return


### PR DESCRIPTION
Hey!

`msgp.CopyToJSON` can produce invalid json if the msgpack contains an extension. 
Looks to be a typo. Here's the fix

Didn't extensively test, but seems to fix it for the data i throw at it.

Thanks for the project! Just this function to convert to a JSON string has been quite helpful for me