### PR TITLE
Fix zeroing interface

### DIFF
--- a/_generated/clearomitted.go
+++ b/_generated/clearomitted.go
@@ -32,6 +32,7 @@ type ClearOmitted0 struct {
 	AString             string                             `msg:"atring,omitempty"`
 	Adur                time.Duration                      `msg:"adur,omitempty"`
 	AJSON               json.Number                        `msg:"ajson,omitempty"`
+	AnAny               any                                `msg:"anany,omitempty"`
 
 	ClearOmittedTuple ClearOmittedTuple `msg:"ozt"` // the inside of a tuple should ignore both omitempty and omitzero
 }

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -752,7 +752,8 @@ func (s *BaseElem) ZeroExpr() string {
 		return "(time.Time{})"
 	case JsonNumber:
 		return `""`
-
+	case Intf:
+		return "nil"
 	}
 
 	return ""


### PR DESCRIPTION
Use correct `x = nil` instead of `x = any{}` to zero interfaces.

Fixes #383