### PR TITLE
Add directive to decode/unmarshal to UTC

### DIFF
--- a/_generated/def.go
+++ b/_generated/def.go
@@ -20,6 +20,8 @@ import (
 // a struct definition is
 // by adding it to this file.
 
+//msgp:timezone utc
+
 type Block [32]byte
 
 // tests edge-cases with

--- a/_generated/gen_test.go
+++ b/_generated/gen_test.go
@@ -132,6 +132,9 @@ func Test1EncodeDecode(t *testing.T) {
 		t.Logf("out: %#v", tnew)
 		t.Fatal("objects not equal")
 	}
+	if tnew.Time.Location() != time.UTC {
+		t.Errorf("time location not UTC: %v", tnew.Time.Location())
+	}
 
 	tanother := new(TestType)
 
@@ -152,6 +155,10 @@ func Test1EncodeDecode(t *testing.T) {
 		t.Logf("out: %v", tanother)
 		t.Fatal("objects not equal")
 	}
+	if tanother.Time.Location() != time.UTC {
+		t.Errorf("time location not UTC: %v", tanother.Time.Location())
+	}
+
 }
 
 func TestIssue168(t *testing.T) {

--- a/_generated/newtime.go
+++ b/_generated/newtime.go
@@ -5,6 +5,7 @@ import "time"
 //go:generate msgp -v
 
 //msgp:newtime
+//msgp:timezone local
 
 type NewTime struct {
 	T     time.Time

--- a/_generated/newtime_test.go
+++ b/_generated/newtime_test.go
@@ -30,6 +30,9 @@ func TestNewTime(t *testing.T) {
 	if !value.Equal(got) {
 		t.Errorf("UnmarshalMsg got %v want %v", value, got)
 	}
+	if got.T.Location() != time.Local {
+		t.Errorf("DecodeMsg got %v want %v", got.T.Location(), time.Local)
+	}
 
 	var buf bytes.Buffer
 	w := msgp.NewWriter(&buf)
@@ -48,6 +51,9 @@ func TestNewTime(t *testing.T) {
 	}
 	if !value.Equal(got) {
 		t.Errorf("DecodeMsg got %v want %v", value, got)
+	}
+	if got.T.Location() != time.Local {
+		t.Errorf("DecodeMsg got %v want %v", got.T.Location(), time.Local)
 	}
 }
 

--- a/gen/decode.go
+++ b/gen/decode.go
@@ -218,6 +218,9 @@ func (d *decodeGen) gBase(b *BaseElem) {
 	case Ext:
 		d.p.printf("\nerr = dc.ReadExtension(%s)", vname)
 	default:
+		if b.Value == Time && d.ctx.asUTC {
+			bname += "UTC"
+		}
 		if b.Convert {
 			d.p.printf("\n%s, err = dc.Read%s()", tmp, bname)
 		} else {

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -80,6 +80,7 @@ type Printer struct {
 	CompactFloats bool
 	ClearOmitted  bool
 	NewTime       bool
+	AsUTC         bool
 }
 
 func NewPrinter(m Method, out io.Writer, tests io.Writer) *Printer {
@@ -153,6 +154,7 @@ func (p *Printer) Print(e Elem) error {
 			compFloats:   p.CompactFloats,
 			clearOmitted: p.ClearOmitted,
 			newTime:      p.NewTime,
+			asUTC:        p.AsUTC,
 		})
 		resetIdent("za")
 
@@ -184,6 +186,7 @@ type Context struct {
 	compFloats   bool
 	clearOmitted bool
 	newTime      bool
+	asUTC        bool
 }
 
 func (c *Context) PushString(s string) {

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -229,6 +229,12 @@ func (u *unmarshalGen) gBase(b *BaseElem) {
 			lowered = b.ToBase() + "(" + lowered + ")"
 		}
 		u.p.printf("\nbts, err = %s.UnmarshalMsg(bts)", lowered)
+	case Time:
+		if u.ctx.asUTC {
+			u.p.printf("\n%s, bts, err = msgp.Read%sUTCBytes(bts)", refname, b.BaseName())
+		} else {
+			u.p.printf("\n%s, bts, err = msgp.Read%sBytes(bts)", refname, b.BaseName())
+		}
 	default:
 		u.p.printf("\n%s, bts, err = msgp.Read%sBytes(bts)", refname, b.BaseName())
 	}

--- a/msgp/read.go
+++ b/msgp/read.go
@@ -1260,6 +1260,13 @@ func (m *Reader) ReadMapStrIntf(mp map[string]interface{}) (err error) {
 	return
 }
 
+// ReadTimeUTC reads a time.Time object from the reader.
+// The returned time's location will be set to UTC.
+func (m *Reader) ReadTimeUTC() (t time.Time, err error) {
+	t, err = m.ReadTime()
+	return t.UTC(), err
+}
+
 // ReadTime reads a time.Time object from the reader.
 // The returned time's location will be set to time.Local.
 func (m *Reader) ReadTime() (t time.Time, err error) {

--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -1066,6 +1066,12 @@ func ReadComplex64Bytes(b []byte) (c complex64, o []byte, err error) {
 	return
 }
 
+// ReadTimeUTCBytes does the same as ReadTimeBytes, but returns the value as UTC.
+func ReadTimeUTCBytes(b []byte) (t time.Time, o []byte, err error) {
+	t, o, err = ReadTimeBytes(b)
+	return t.UTC(), o, err
+}
+
 // ReadTimeBytes reads a time.Time
 // extension object from 'b' and returns the
 // remaining bytes.

--- a/parse/directives.go
+++ b/parse/directives.go
@@ -29,6 +29,7 @@ var directives = map[string]directive{
 	"compactfloats": compactfloats,
 	"clearomitted":  clearomitted,
 	"newtime":       newtime,
+	"timezone":      newtimezone,
 }
 
 // map of all recognized directives which will be applied
@@ -205,5 +206,21 @@ func clearomitted(text []string, f *FileSet) error {
 //msgp:newtime
 func newtime(text []string, f *FileSet) error {
 	f.NewTime = true
+	return nil
+}
+
+//msgp:timezone
+func newtimezone(text []string, f *FileSet) error {
+	if len(text) != 2 {
+		return fmt.Errorf("timezone directive should have only 1 argument; found %d", len(text)-1)
+	}
+	switch strings.ToLower(strings.TrimSpace(text[1])) {
+	case "local":
+		f.AsUTC = false
+	case "utc":
+		f.AsUTC = true
+	default:
+		return fmt.Errorf("timezone directive should be either 'local' or 'utc'; found %q", text[1])
+	}
 	return nil
 }

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -24,6 +24,7 @@ type FileSet struct {
 	CompactFloats bool                // Use smaller floats when feasible
 	ClearOmitted  bool                // Set omitted fields to zero value
 	NewTime       bool                // Set to use -1 extension for time.Time
+	AsUTC         bool                // Set timezone to UTC instead of local
 	tagName       string              // tag to read field names from
 	pointerRcv    bool                // generate with pointer receivers.
 }
@@ -275,6 +276,7 @@ loop:
 	p.CompactFloats = f.CompactFloats
 	p.ClearOmitted = f.ClearOmitted
 	p.NewTime = f.NewTime
+	p.AsUTC = f.AsUTC
 }
 
 func (f *FileSet) PrintTo(p *gen.Printer) error {


### PR DESCRIPTION
Adds `//msgp:timezone utc` that will decode and unmarshal to UTC time.

Default is `//msgp:timezone local`. If someone is feeling adventurous they can expand on these 2 settings, but this should cover 99.99% of use cases.

Avoids nasty hacks, time setting `time.Local` or having to do reflection to go through structs.

Want for a new function, since it was a much cleaner solution than trying to convert after reading.