### PR TITLE
fix: read.go ReadBytesHeader avoid nil slice deref

### DIFF
--- a/msgp/read.go
+++ b/msgp/read.go
@@ -983,7 +983,7 @@ func (m *Reader) ReadBytesHeader() (sz uint32, err error) {
 		sz = uint32(big.Uint32(p[1:]))
 		return
 	default:
-		err = badPrefix(BinType, p[0])
+		err = badPrefix(BinType, lead)
 		return
 	}
 }


### PR DESCRIPTION
I believe p[0] is wrong for returning error. Check another badPrefix calls in this file, and its signature.