### PR TITLE
Add binary map key and shimming

### DIFF
--- a/_generated/def.go
+++ b/_generated/def.go
@@ -342,3 +342,7 @@ type Flob struct {
 }
 
 type Numberwang int8
+
+//msgp:ignore ExternalString
+type ExternalString string
+type ExternalArr [4]byte

--- a/_generated/map_bin_key.go
+++ b/_generated/map_bin_key.go
@@ -1,0 +1,80 @@
+package _generated
+
+import (
+	"encoding/hex"
+	"time"
+)
+
+//go:generate msgp -unexported -v
+
+//msgp:maps binkeys
+
+type ArrayMapKey [4]byte
+
+//msgp:replace ExternalArr with:[4]byte
+
+//msgp:replace ExternalString with:string
+
+type mapKeyBytes2 [8]byte
+
+//msgp:shim mapKeyBytes2 as:string using:hexEncode2/hexDecode2 witherr:false
+
+type mapKeyShimmed time.Duration
+
+//msgp:shim mapKeyShimmed as:[]byte using:durEncode/durDecode witherr:true
+
+type MyStringType string
+
+type MyMapKeyStruct2 struct {
+	MapString     map[string]int         `msg:",allownil"`
+	MapString2    map[MyStringType]int   `msg:",allownil"`
+	MapString3    map[ExternalString]int `msg:",allownil"`
+	MapString4    map[mapKeyBytes2]int   `msg:",allownil"`
+	MapFloat32    map[float32]int        `msg:",allownil"`
+	MapFloat64    map[float64]int        `msg:",allownil"`
+	MapComplex64  map[complex64]int      `msg:",allownil"`
+	MapComplex128 map[complex128]int     `msg:",allownil"`
+	MapUint       map[uint]int           `msg:",allownil"`
+	MapUint8      map[uint8]int          `msg:",allownil"`
+	MapUint16     map[uint16]int         `msg:",allownil"`
+	MapUint32     map[uint32]int         `msg:",allownil"`
+	MapUint64     map[uint64]int         `msg:",allownil"`
+	MapByte       map[byte]int           `msg:",allownil"`
+	MapInt        map[int]int            `msg:",allownil"`
+	MapInt8       map[int8]int           `msg:",allownil"`
+	MapInt16      map[int16]int          `msg:",allownil"`
+	MapInt32      map[int32]int          `msg:",allownil"`
+	MapInt64      map[int64]int          `msg:",allownil"`
+	MapBool       map[bool]int           `msg:",allownil"`
+
+	// Maps with array keys
+	MapArray  map[[4]byte]int     `msg:",allownil"`
+	MapArray2 map[ArrayMapKey]int `msg:",allownil"`
+	MapArray3 map[ExternalArr]int `msg:",allownil"`
+	MapArray4 map[[4]uint32]int   `msg:",allownil"`
+
+	// Maps with shimmed types
+	MapDuration map[mapKeyShimmed]int `msg:",allownil"`
+}
+
+func hexEncode2(b mapKeyBytes2) string {
+	return hex.EncodeToString(b[:])
+}
+
+func hexDecode2(s string) mapKeyBytes2 {
+	var b [8]byte
+	_, err := hex.Decode(b[:], []byte(s))
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func durEncode(v mapKeyShimmed) []byte {
+	return []byte(time.Duration(v).String())
+}
+
+func durDecode(b []byte) (mapKeyShimmed, error) {
+	v, err := time.ParseDuration(string(b))
+	return mapKeyShimmed(v), err
+}

--- a/_generated/map_bin_key_test.go
+++ b/_generated/map_bin_key_test.go
@@ -1,0 +1,180 @@
+package _generated
+
+import (
+	"bytes"
+	"math"
+	"math/rand/v2"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestBinKeys(t *testing.T) {
+	rng := rand.New(rand.NewPCG(0, 0))
+
+	// Generate a bunch of random maps
+	for i := range 500 {
+		var test MyMapKeyStruct2
+		if i != 0 {
+			// Don't add anything to the first object
+			test.MapString = make(map[string]int)
+			test.MapString2 = make(map[MyStringType]int)
+			test.MapString3 = make(map[ExternalString]int)
+			test.MapFloat32 = make(map[float32]int)
+			test.MapFloat64 = make(map[float64]int)
+			test.MapComplex64 = make(map[complex64]int)
+			test.MapComplex128 = make(map[complex128]int)
+			test.MapUint = make(map[uint]int)
+			test.MapUint8 = make(map[uint8]int)
+			test.MapUint16 = make(map[uint16]int)
+			test.MapUint32 = make(map[uint32]int)
+			test.MapUint64 = make(map[uint64]int)
+			test.MapByte = make(map[byte]int)
+			test.MapInt = make(map[int]int)
+			test.MapInt8 = make(map[int8]int)
+			test.MapInt16 = make(map[int16]int)
+			test.MapInt32 = make(map[int32]int)
+			test.MapInt64 = make(map[int64]int)
+			test.MapBool = make(map[bool]int)
+			test.MapArray = make(map[[4]byte]int)
+			test.MapArray2 = make(map[ArrayMapKey]int)
+			test.MapArray3 = make(map[ExternalArr]int)
+			test.MapArray4 = make(map[[4]uint32]int)
+			test.MapDuration = make(map[mapKeyShimmed]int)
+
+			for range rng.IntN(50) {
+				test.MapString[string(strconv.Itoa(rng.IntN(math.MaxInt32)))] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				test.MapString2[MyStringType(strconv.Itoa(rng.IntN(math.MaxInt32)))] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				test.MapString3[ExternalString(strconv.Itoa(rng.IntN(math.MaxInt32)))] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				test.MapFloat32[float32(rng.Float32())] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				test.MapFloat64[rng.Float64()] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				c := complex(float32(rng.Float32()), float32(rng.Float32()))
+				test.MapComplex64[c] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				c := complex(rng.Float64(), rng.Float64())
+				test.MapComplex128[c] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				test.MapUint[uint(rng.Uint64())] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				test.MapUint8[uint8(rng.Uint64())] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				test.MapUint16[uint16(rng.Uint64())] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				test.MapUint32[rng.Uint32()] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				test.MapUint64[rng.Uint64()] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				test.MapByte[byte(uint8(rng.Uint64()))] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				test.MapInt[rng.IntN(math.MaxInt32)] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				test.MapInt8[int8(rng.IntN(int(math.MaxInt8)+1))] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				test.MapInt16[int16(rng.IntN(int(math.MaxInt16)+1))] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				test.MapInt32[int32(rng.IntN(int(math.MaxInt32)))] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				// Use only non-negative values to stay within IntN capabilities
+				test.MapInt64[int64(rng.IntN(int(math.MaxInt32)))] = rng.IntN(100)
+			}
+			if rng.IntN(2) == 0 {
+				test.MapBool[true] = rng.IntN(100)
+			}
+			if rng.IntN(2) == 0 {
+				test.MapBool[false] = rng.IntN(100)
+			}
+
+			for range rng.IntN(50) {
+				var k [4]byte
+				for i := 0; i < 4; i++ {
+					k[i] = uint8(rng.Uint64())
+				}
+				test.MapArray[k] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				var k ArrayMapKey
+				for i := 0; i < 4; i++ {
+					k[i] = uint8(rng.Uint64())
+				}
+				test.MapArray2[k] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				var k ExternalArr
+				for i := 0; i < 4; i++ {
+					k[i] = uint8(rng.Uint64())
+				}
+				test.MapArray3[k] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				var k [4]uint32
+				for i := 0; i < 4; i++ {
+					k[i] = rng.Uint32()
+				}
+				test.MapArray4[k] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				// Use only non-negative values to stay within IntN capabilities
+				test.MapDuration[mapKeyShimmed(rng.IntN(math.MaxInt32))] = rng.IntN(100)
+			}
+		}
+		var encoded [][]byte
+		b, err := test.MarshalMsg(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		encoded = append(encoded, b)
+		var buf bytes.Buffer
+		en := msgp.NewWriter(&buf)
+		err = test.EncodeMsg(en)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = en.Flush()
+		if err != nil {
+			t.Fatal(err)
+		}
+		encoded = append(encoded, buf.Bytes())
+		for _, enc := range encoded {
+			var decoded, decoded2 MyMapKeyStruct2
+			_, err = decoded.UnmarshalMsg(enc)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(&decoded, &test) {
+				t.Errorf("decoded != test")
+			}
+			dec := msgp.NewReader(bytes.NewReader(enc))
+			err = decoded2.DecodeMsg(dec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(&decoded2, &test) {
+				t.Errorf("decoded2 != test")
+			}
+		}
+	}
+}

--- a/_generated/map_shim_key.go
+++ b/_generated/map_shim_key.go
@@ -1,0 +1,76 @@
+package _generated
+
+import (
+	"encoding/hex"
+	"strconv"
+)
+
+//go:generate msgp -unexported -v
+
+//msgp:maps shim
+
+//msgp:shim mapKey as:string using:mapKeyToString/stringToMapKey witherr:true
+
+type mapKey uint64
+
+type mapKeyString string
+
+//msgp:shim mapKeyBytes as:string using:hexEncode/hexDecode witherr:false
+
+type mapKeyBytes [8]byte
+
+//msgp:replace ExternalString with:string
+
+type MyMapKeyStruct struct {
+	Map      map[mapKey]int         `msg:",allownil"` // Keys are converted to strings via shim
+	MapS     map[mapKeyString]int   `msg:",allownil"` // Keys are strings, with conversion
+	MapX     map[ExternalString]int `msg:",allownil"` // Keys is an external type to the file, replaced with a cast
+	MapB     map[mapKeyBytes]int    `msg:",allownil"` // Keys are bytes, converted to hex strings via shim
+	MapUint  map[uint64]int         `msg:",allownil"` // Will be ignored (as current behavior)
+	Original map[string]int         `msg:",allownil"` // Original map, for comparison purposes
+
+	// Should all be ignored:
+	MapFloat32    map[float32]int    `msg:",allownil"`
+	MapFloat64    map[float64]int    `msg:",allownil"`
+	MapComplex64  map[complex64]int  `msg:",allownil"`
+	MapComplex128 map[complex128]int `msg:",allownil"`
+	MapUint2      map[uint]int       `msg:",allownil"`
+	MapUint8      map[uint8]int      `msg:",allownil"`
+	MapUint16     map[uint16]int     `msg:",allownil"`
+	MapUint32     map[uint32]int     `msg:",allownil"`
+	MapUint64     map[uint64]int     `msg:",allownil"`
+	MapByte       map[byte]int       `msg:",allownil"`
+	MapInt        map[int]int        `msg:",allownil"`
+	MapInt8       map[int8]int       `msg:",allownil"`
+	MapInt16      map[int16]int      `msg:",allownil"`
+	MapInt32      map[int32]int      `msg:",allownil"`
+	MapInt64      map[int64]int      `msg:",allownil"`
+	MapBool       map[bool]int       `msg:",allownil"`
+}
+
+// stringToMapKey and mapKeyToString are shim functions that convert between
+// mapKey and string.
+func stringToMapKey(s string) (mapKey, error) {
+	v, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return mapKey(v), nil
+}
+
+func mapKeyToString(k mapKey) string {
+	return strconv.FormatUint(uint64(k), 10)
+}
+
+func hexEncode(b mapKeyBytes) string {
+	return hex.EncodeToString(b[:])
+}
+
+func hexDecode(s string) mapKeyBytes {
+	var b [8]byte
+	_, err := hex.Decode(b[:], []byte(s))
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/_generated/map_shim_key_test.go
+++ b/_generated/map_shim_key_test.go
@@ -1,0 +1,78 @@
+package _generated
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"math/rand/v2"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestShimmedKeys(t *testing.T) {
+	rng := rand.New(rand.NewPCG(0, 0))
+	// Generate a bunch of random maps
+	for i := range 500 {
+		var test MyMapKeyStruct
+		if i != 0 {
+			// Don't add anything to the first object
+			test.Map = make(map[mapKey]int)
+			test.MapS = make(map[mapKeyString]int)
+			test.MapX = make(map[ExternalString]int)
+			test.MapB = make(map[mapKeyBytes]int)
+			for range rng.IntN(50) {
+				test.Map[mapKey(rng.IntN(math.MaxInt32))] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				test.MapS[mapKeyString(strconv.Itoa(rng.IntN(math.MaxInt32)))] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				test.MapX[ExternalString(strconv.Itoa(rng.IntN(math.MaxInt32)))] = rng.IntN(100)
+			}
+			for range rng.IntN(50) {
+				var tmp [8]byte
+				binary.LittleEndian.PutUint64(tmp[:], rng.Uint64())
+				test.MapB[tmp] = rng.IntN(100)
+			}
+
+		}
+		var encoded [][]byte
+		b, err := test.MarshalMsg(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		encoded = append(encoded, b)
+		var buf bytes.Buffer
+		en := msgp.NewWriter(&buf)
+		err = test.EncodeMsg(en)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = en.Flush()
+		if err != nil {
+			t.Fatal(err)
+		}
+		encoded = append(encoded, buf.Bytes())
+		for _, enc := range encoded {
+			var decoded, decoded2 MyMapKeyStruct
+			_, err = decoded.UnmarshalMsg(enc)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(&decoded, &test) {
+				t.Errorf("decoded != test")
+			}
+			dec := msgp.NewReader(bytes.NewReader(enc))
+			err = decoded2.DecodeMsg(dec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(&decoded2, &test) {
+				t.Errorf("decoded2 != test")
+			}
+		}
+	}
+}

--- a/gen/decode.go
+++ b/gen/decode.go
@@ -236,7 +236,7 @@ func (d *decodeGen) gBase(b *BaseElem) {
 
 	// close block for 'tmp'
 	if b.Convert && b.Value != IDENT {
-		if b.ShimMode == Cast {
+		if b.ShimMode == Cast && !b.ShimErrs {
 			d.p.printf("\n%s = %s(%s)\n}", vname, b.FromBase(), tmp)
 		} else {
 			d.p.printf("\n%s, err = %s(%s)\n}", vname, b.FromBase(), tmp)
@@ -260,9 +260,8 @@ func (d *decodeGen) gMap(m *Map) {
 	// pair and assign
 	d.needsField()
 	d.p.printf("\nfor %s > 0 {\n%s--", sz, sz)
-	d.p.declare(m.Keyidx, "string")
+	m.readKey(d.ctx, d.p, d, d.assignAndCheck)
 	d.p.declare(m.Validx, m.Value.TypeName())
-	d.assignAndCheck(m.Keyidx, stringTyp)
 	d.ctx.PushVar(m.Keyidx)
 	m.Value.SetIsAllowNil(false)
 	next(d, m.Value)

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -282,10 +282,14 @@ func (a *Array) IfZeroExpr() string { return "" }
 // Map is a map[string]Elem
 type Map struct {
 	common
-	Keyidx     string // key variable name
-	Validx     string // value variable name
-	Value      Elem   // value element
-	isAllowNil bool
+	Keyidx        string // key variable name
+	Validx        string // value variable name
+	Key           Elem   // key element (if not string)
+	Value         Elem   // value element
+	AllowMapShims bool   // Allow map keys to be shimmed (default true)
+	AllowBinMaps  bool   // Allow maps with binary keys to be used (default false)
+	AutoMapShims  bool   // Automatically shim map keys of builtin types(default false)
+	isAllowNil    bool
 }
 
 func (m *Map) SetVarname(s string) {
@@ -306,7 +310,11 @@ func (m *Map) TypeName() string {
 	if m.alias != "" {
 		return m.alias
 	}
-	m.Alias("map[string]" + m.Value.TypeName())
+	keyType := "string"
+	if m.Key != nil {
+		keyType = m.Key.TypeName()
+	}
+	m.Alias("map[" + keyType + "]" + m.Value.TypeName())
 	return m.alias
 }
 
@@ -314,6 +322,23 @@ func (m *Map) Copy() Elem {
 	g := *m
 	g.Value = m.Value.Copy()
 	return &g
+}
+
+// readKey will read the key into the variable named by m.Keyidx.
+func (m *Map) readKey(ctx *Context, p printer, t traversal, assignAndCheck func(name string, base string)) {
+	if m.Key != nil && m.AllowBinMaps {
+		p.declare(m.Keyidx, m.Key.TypeName())
+		ctx.PushVar(m.Keyidx)
+		m.Key.SetVarname(m.Keyidx)
+		next(t, m.Key)
+		ctx.Pop()
+		return
+	}
+	// No key, so we assume the key as a string.
+	p.declare(m.Keyidx, "string")
+	assignAndCheck(m.Keyidx, stringTyp)
+	p.wrapErrCheck(ctx.ArgsStr())
+
 }
 
 func (m *Map) Complexity() int {
@@ -574,6 +599,7 @@ type BaseElem struct {
 	ShimMode     ShimMode  // Method used to shim
 	ShimToBase   string    // shim to base type, or empty
 	ShimFromBase string    // shim from base type, or empty
+	ShimErrs     bool      // ShimToBase has errors on function
 	Value        Primitive // Type of element
 	Convert      bool      // should we do an explicit conversion?
 	zerocopy     bool      // Allow zerocopy for byte slices in unmarshal.

--- a/gen/encode.go
+++ b/gen/encode.go
@@ -246,7 +246,26 @@ func (e *encodeGen) gMap(m *Map) {
 	e.writeAndCheck(mapHeader, lenAsUint32, vname)
 
 	e.p.printf("\nfor %s, %s := range %s {", m.Keyidx, m.Validx, vname)
-	e.writeAndCheck(stringTyp, literalFmt, m.Keyidx)
+	if m.Key != nil {
+		if m.AllowBinMaps {
+			e.ctx.PushVar(m.Keyidx)
+			m.Key.SetVarname(m.Keyidx)
+			next(e, m.Key)
+			e.ctx.Pop()
+		} else {
+			keyIdx := m.Keyidx
+			if key, ok := m.Key.(*BaseElem); ok {
+				if key.Value == String {
+					keyIdx = fmt.Sprintf("%s(%s)", key.ToBase(), keyIdx)
+				} else if key.alias != "" {
+					keyIdx = fmt.Sprintf("string(%s)", keyIdx)
+				}
+			}
+			e.writeAndCheck(stringTyp, literalFmt, keyIdx)
+		}
+	} else {
+		e.writeAndCheck(stringTyp, literalFmt, m.Keyidx)
+	}
 	e.ctx.PushVar(m.Keyidx)
 	m.Value.SetIsAllowNil(false)
 	next(e, m.Value)

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -247,7 +247,7 @@ func (u *unmarshalGen) gBase(b *BaseElem) {
 
 	// close 'tmp' block
 	if b.Convert && b.Value != IDENT {
-		if b.ShimMode == Cast {
+		if b.ShimMode == Cast && !b.ShimErrs {
 			u.p.printf("\n%s = %s(%s)\n", b.Varname(), b.FromBase(), refname)
 		} else {
 			u.p.printf("\n%s, err = %s(%s)\n", b.Varname(), b.FromBase(), refname)
@@ -309,8 +309,8 @@ func (u *unmarshalGen) gMap(m *Map) {
 
 	// loop and get key,value
 	u.p.printf("\nfor %s > 0 {", sz)
-	u.p.printf("\nvar %s string; var %s %s; %s--", m.Keyidx, m.Validx, m.Value.TypeName(), sz)
-	u.assignAndCheck(m.Keyidx, stringTyp)
+	u.p.printf("\nvar %s %s; %s--", m.Validx, m.Value.TypeName(), sz)
+	m.readKey(u.ctx, u.p, u, u.assignAndCheck)
 	u.ctx.PushVar(m.Keyidx)
 	m.Value.SetIsAllowNil(false)
 	next(u, m.Value)

--- a/parse/inline.go
+++ b/parse/inline.go
@@ -46,6 +46,9 @@ func (fs *FileSet) findShim(id string, e gen.Elem, addID bool) {
 			fs.nextShim(&el.Els, id, e)
 		case *gen.Map:
 			fs.nextShim(&el.Value, id, e)
+			if el.Key != nil {
+				fs.nextShim(&el.Key, id, e)
+			}
 		case *gen.Ptr:
 			fs.nextShim(&el.Value, id, e)
 		}
@@ -73,6 +76,9 @@ func (fs *FileSet) nextShim(ref *gen.Elem, id string, e gen.Elem) {
 			fs.nextShim(&el.Els, id, e)
 		case *gen.Map:
 			fs.nextShim(&el.Value, id, e)
+			if el.Key != nil {
+				fs.nextShim(&el.Key, id, e)
+			}
 		case *gen.Ptr:
 			fs.nextShim(&el.Value, id, e)
 		}


### PR DESCRIPTION
* Allows for binary map keys
* Allows for non-string map keys to be shimmed as well as cast from string type aliases.

Adds directive `maps`

* `//msgp:maps shim|binary`

Not adding the directive will retain current behaviour where maps without string keys are ignored.

Adding 'shim' will require you to add shims to custom map key types. Shims must be with string type. See `_generated/map_shim_key.go` for examples.

Adding `binary` will allow for binary marshaling of map keys. Types are inferred with standard rules. Binary encoding can be shimmed and can return any standard type. See `_generated/map_bin_key.go` for examples.

Updates/Resolves: #331 #345 #305 #257 #232