### PR TITLE
Allow commandline directives

### DIFF
--- a/_generated/compactfloats.go
+++ b/_generated/compactfloats.go
@@ -1,13 +1,9 @@
 package _generated
 
-//go:generate msgp
-
-//msgp:compactfloats
+//go:generate msgp -d "msgp:compactfloats" -d "replace F64 with:float64" -v
 
 //msgp:ignore F64
 type F64 float64
-
-//msgp:replace F64 with:float64
 
 type Floats struct {
 	A     float64

--- a/_generated/custom_tag.go
+++ b/_generated/custom_tag.go
@@ -1,7 +1,6 @@
 package _generated
 
-//go:generate msgp
-//msgp:tag mytag
+//go:generate msgp -d "tag mytag"
 
 type CustomTag struct {
 	Foo string `mytag:"foo_custom_name"`

--- a/parse/directives.go
+++ b/parse/directives.go
@@ -203,29 +203,34 @@ func tag(text []string, f *FileSet) error {
 		return nil
 	}
 	f.tagName = strings.TrimSpace(text[1])
+	infof("using field tag %q\n", f.tagName)
 	return nil
 }
 
 //msgp:pointer
 func pointer(text []string, f *FileSet) error {
+	infof("using pointer receiver\n")
 	f.pointerRcv = true
 	return nil
 }
 
 //msgp:compactfloats
 func compactfloats(text []string, f *FileSet) error {
+	infof("using compact floats\n")
 	f.CompactFloats = true
 	return nil
 }
 
 //msgp:clearomitted
 func clearomitted(text []string, f *FileSet) error {
+	infof("clearing omitted fields\n")
 	f.ClearOmitted = true
 	return nil
 }
 
 //msgp:newtime
 func newtime(text []string, f *FileSet) error {
+	infof("using new time encoding\n")
 	f.NewTime = true
 	return nil
 }
@@ -243,5 +248,6 @@ func newtimezone(text []string, f *FileSet) error {
 	default:
 		return fmt.Errorf("timezone directive should be either 'local' or 'utc'; found %q", text[1])
 	}
+	infof("using timezone %q\n", text[1])
 	return nil
 }

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -35,12 +35,13 @@ type FileSet struct {
 // directory will be parsed.
 // If unexport is false, only exported identifiers are included in the FileSet.
 // If the resulting FileSet would be empty, an error is returned.
-func File(name string, unexported bool) (*FileSet, error) {
+func File(name string, unexported bool, directives []string) (*FileSet, error) {
 	pushstate(name)
 	defer popstate()
 	fs := &FileSet{
 		Specs:      make(map[string]ast.Expr),
 		Identities: make(map[string]gen.Elem),
+		Directives: append([]string{}, directives...),
 	}
 
 	fset := token.NewFileSet()
@@ -77,7 +78,7 @@ func File(name string, unexported bool) (*FileSet, error) {
 			return nil, err
 		}
 		fs.Package = f.Name.Name
-		fs.Directives = yieldComments(f.Comments)
+		fs.Directives = append(fs.Directives, yieldComments(f.Comments)...)
 		if !unexported {
 			ast.FileExports(f)
 		}


### PR DESCRIPTION
Make it possible to add directives as commandline parameter.

Alternatively to `//msgp:tag json` directives can also be specified using the `-d` flag. Example: `msgp -d "tag json"`. Multiple flags can be added.

Directives in files take precedence over commandline.

Bonus: Print info on all directives.