### PR TITLE
Add array/map iterators

### DIFF
--- a/msgp/iter.go
+++ b/msgp/iter.go
@@ -1,0 +1,876 @@
+package msgp
+
+import (
+	"fmt"
+	"iter"
+	"time"
+)
+
+// ArrayExtraTypes is a type constraint that includes all types that can be
+// decoded from an array.
+// Even though 'any' type can be used, its pointer must implement the
+// Decodable when using Reader or Unmarhaler interface when reading from bytes.
+type ArrayExtraTypes interface {
+	bool | string | []byte | complex64 | complex128 | time.Time | time.Duration | any
+}
+
+// ReadArray returns an iterator that can be used to iterate over the elements
+// of an array in the MessagePack data while being read by the provided Reader.
+// The type parameter V specifies the type of the elements in the array.
+// The type parameter V must be ArrayExtraTypes or a type whose
+// pointer implements the Decodable interface.
+// Use ReadNumberArray for numbers.
+// The returned iterator implements the iter.Seq[V] interface,
+// allowing for sequential access to the array elements.
+func ReadArray[V ArrayExtraTypes](m *Reader) iter.Seq2[V, error] {
+	return func(yield func(V, error) bool) {
+		// Assuming Reader has a method to read array length
+		var x V
+		length, err := m.ReadArrayHeader()
+		if err != nil {
+			yield(x, err)
+			return
+		}
+		switch any(x).(type) {
+		case string:
+			for range length {
+				v, err := m.ReadString()
+				if !yield(any(v).(V), err) {
+					return
+				}
+			}
+		case []byte:
+			for range length {
+				v, err := m.ReadBytes(nil)
+				if !yield(any(v).(V), err) {
+					return
+				}
+			}
+		case bool:
+			for range length {
+				v, err := m.ReadBool()
+				if !yield(any(v).(V), err) {
+					return
+				}
+			}
+		case time.Time:
+			for range length {
+				v, err := m.ReadTime()
+				if !yield(any(v).(V), err) {
+					return
+				}
+			}
+		case time.Duration:
+			for range length {
+				v, err := m.ReadDuration()
+				if !yield(any(v).(V), err) {
+					return
+				}
+			}
+		case complex64:
+			for range length {
+				v, err := m.ReadComplex64()
+				if !yield(any(v).(V), err) {
+					return
+				}
+			}
+		case complex128:
+			for range length {
+				v, err := m.ReadComplex128()
+				if !yield(any(v).(V), err) {
+				}
+			}
+		default:
+			for range length {
+				var v V
+				ptr := &v
+				if dc, ok := any(ptr).(Decodable); ok {
+					err = dc.DecodeMsg(m)
+					if !yield(v, err) {
+						return
+					}
+				} else {
+					err = fmt.Errorf("cannot decode into type %T", ptr)
+					return
+				}
+			}
+		}
+	}
+}
+
+// MapKeyTypes are possible key types. Usually this is a string.
+// Even though 'any' type can be used, its pointer must implement the Decodable interface.
+type MapKeyTypes interface {
+	NumberTypes | bool | string | []byte | complex64 | complex128 | time.Time | time.Duration | any
+}
+
+// MapValueTypes are possible value types.
+// Even though 'any' type can be used, its pointer must implement the Decodable interface.
+type MapValueTypes interface {
+	NumberTypes | bool | string | []byte | complex64 | complex128 | time.Time | time.Duration | any
+}
+
+// ReadMap returns an iterator that can be used to iterate over the elements
+// of a map in the MessagePack data while being read by the provided Reader.
+// The type parameters K and V specify the types of the keys and values in the map.
+// The returned iterator implements the iter.Seq2[K, V] interface,
+// allowing for sequential access to the map elements.
+// The returned function can be used to read any error that occurred during iteration when iteration is done.
+func ReadMap[K MapKeyTypes, V MapValueTypes](m *Reader) (iter.Seq2[K, V], func() error) {
+	var err error
+	return func(yield func(K, V) bool) {
+		// Assuming Reader has a method to read array length
+		var length uint32
+		length, err = m.ReadArrayHeader()
+		if err != nil {
+			return
+		}
+		for range length {
+			var key K
+			switch v := any(key).(type) {
+			case string:
+				if v, err = m.ReadString(); err != nil {
+					return
+				}
+				key = (any)(v).(K)
+			case []byte:
+				if v, err = m.ReadBytes(nil); err != nil {
+					return
+				}
+				key = (any)(v).(K)
+			case bool:
+				if v, err = m.ReadBool(); err != nil {
+					return
+				}
+				key = (any)(v).(K)
+			case time.Time:
+				if v, err = m.ReadTime(); err != nil {
+					return
+				}
+				key = (any)(v).(K)
+			case time.Duration:
+				if v, err = m.ReadDuration(); err != nil {
+					return
+				}
+				key = (any)(v).(K)
+			case complex64:
+				if v, err = m.ReadComplex64(); err != nil {
+					return
+				}
+				key = (any)(v).(K)
+			case complex128:
+				if v, err = m.ReadComplex128(); err != nil {
+					return
+				}
+				key = (any)(v).(K)
+			case uint8:
+				if v, err = m.ReadUint8(); err != nil {
+					return
+				}
+				key = (any)(v).(K)
+			case uint16:
+				if v, err = m.ReadUint16(); err != nil {
+					return
+				}
+				key = (any)(v).(K)
+			case uint32:
+				if v, err = m.ReadUint32(); err != nil {
+					return
+				}
+				key = (any)(v).(K)
+			case uint64:
+				if v, err = m.ReadUint64(); err != nil {
+					return
+				}
+				key = (any)(v).(K)
+			case uint:
+				if v, err = m.ReadUint(); err != nil {
+					return
+				}
+				key = (any)(v).(K)
+			case int8:
+				if v, err = m.ReadInt8(); err != nil {
+					return
+				}
+				key = (any)(v).(K)
+			case int16:
+				if v, err = m.ReadInt16(); err != nil {
+					return
+				}
+				key = (any)(v).(K)
+			case int32:
+				if v, err = m.ReadInt32(); err != nil {
+					return
+				}
+				key = (any)(v).(K)
+			case int64:
+				if v, err = m.ReadInt64(); err != nil {
+					return
+				}
+				key = (any)(v).(K)
+			case int:
+				if v, err = m.ReadInt(); err != nil {
+					return
+				}
+				key = (any)(v).(K)
+			case float32:
+				if v, err = m.ReadFloat32(); err != nil {
+					return
+				}
+				key = (any)(v).(K)
+			case float64:
+				if v, err = m.ReadFloat64(); err != nil {
+					return
+				}
+				key = (any)(v).(K)
+			default:
+				ptr := &key
+				if dc, ok := any(ptr).(Decodable); ok {
+					if err = dc.DecodeMsg(m); err != nil {
+						return
+					}
+				} else {
+					err = fmt.Errorf("cannot decode key into type %T", ptr)
+					return
+				}
+			}
+
+			var val V
+			switch v := any(key).(type) {
+			case string:
+				if v, err = m.ReadString(); err != nil {
+					return
+				}
+				val = (any)(v).(V)
+			case []byte:
+				if v, err = m.ReadBytes(nil); err != nil {
+					return
+				}
+				val = (any)(v).(V)
+			case bool:
+				if v, err = m.ReadBool(); err != nil {
+					return
+				}
+				val = (any)(v).(V)
+			case time.Time:
+				if v, err = m.ReadTime(); err != nil {
+					return
+				}
+				val = (any)(v).(V)
+			case time.Duration:
+				if v, err = m.ReadDuration(); err != nil {
+					return
+				}
+				val = (any)(v).(V)
+			case complex64:
+				if v, err = m.ReadComplex64(); err != nil {
+					return
+				}
+				val = (any)(v).(V)
+			case complex128:
+				if v, err = m.ReadComplex128(); err != nil {
+					return
+				}
+				val = (any)(v).(V)
+			case int8:
+				if v, err = m.ReadInt8(); err != nil {
+					return
+				}
+				val = (any)(v).(V)
+			case int16:
+				if v, err = m.ReadInt16(); err != nil {
+					return
+				}
+				val = (any)(v).(V)
+			case int32:
+				if v, err = m.ReadInt32(); err != nil {
+					return
+				}
+				val = (any)(v).(V)
+			case int64:
+				if v, err = m.ReadInt64(); err != nil {
+					return
+				}
+				val = (any)(v).(V)
+			case int:
+				if v, err = m.ReadInt(); err != nil {
+					return
+				}
+				val = (any)(v).(V)
+			case float32:
+				if v, err = m.ReadFloat32(); err != nil {
+					return
+				}
+				val = (any)(v).(V)
+			case float64:
+				if v, err = m.ReadFloat64(); err != nil {
+					return
+				}
+				val = (any)(v).(V)
+			case uint8:
+				if v, err = m.ReadUint8(); err != nil {
+					return
+				}
+				val = (any)(v).(V)
+			case uint16:
+				if v, err = m.ReadUint16(); err != nil {
+					return
+				}
+				val = (any)(v).(V)
+			case uint32:
+				if v, err = m.ReadUint32(); err != nil {
+					return
+				}
+				val = (any)(v).(V)
+			case uint64:
+				if v, err = m.ReadUint64(); err != nil {
+					return
+				}
+				val = (any)(v).(V)
+			case uint:
+				if v, err = m.ReadUint(); err != nil {
+					return
+				}
+				val = (any)(v).(V)
+
+			default:
+				ptr := &val
+				if dc, ok := any(ptr).(Decodable); ok {
+					if err = dc.DecodeMsg(m); err != nil {
+						return
+					}
+				} else {
+					err = fmt.Errorf("cannot decode value into type %T", ptr)
+					return
+				}
+			}
+			if !yield(key, val) {
+				return
+			}
+		}
+	}, func() error { return err }
+}
+
+// NumberTypes is a type constraint that includes all numeric types.
+type NumberTypes interface {
+	uint | uint8 | uint16 | uint32 | uint64 | int | int8 | int16 | int32 | int64 | float32 | float64
+}
+
+// ReadNumberArray returns an iterator that can be used to iterate over the elements
+// of an array in the MessagePack data while being read by the provided Reader.
+// The type parameter V specifies the type of the elements in the array.
+// The returned iterator implements the iter.Seq[V] interface,
+// allowing for sequential access to the array elements.
+func ReadNumberArray[V NumberTypes](m *Reader) iter.Seq2[V, error] {
+	return func(yield func(V, error) bool) {
+		// Assuming Reader has a method to read array length
+		var x V
+		length, err := m.ReadArrayHeader()
+		if err != nil {
+			yield(x, err)
+			return
+		}
+
+		switch any(x).(type) {
+		case uint8:
+			for range length {
+				v, err := m.ReadUint8()
+				if !yield(V(v), err) {
+					return
+				}
+			}
+		case uint16:
+			for range length {
+				v, err := m.ReadUint16()
+				if !yield(V(v), err) {
+					return
+				}
+			}
+		case uint32:
+			for range length {
+				v, err := m.ReadUint32()
+				if !yield(V(v), err) {
+					return
+				}
+			}
+		case uint64:
+			for range length {
+				v, err := m.ReadUint64()
+				if !yield(V(v), err) {
+					return
+				}
+			}
+		case uint:
+			for range length {
+				v, err := m.ReadUint()
+				if !yield(V(v), err) {
+					return
+				}
+			}
+		case int8:
+			for range length {
+				v, err := m.ReadInt8()
+				if !yield(V(v), err) {
+					return
+				}
+			}
+		case int16:
+			for range length {
+				v, err := m.ReadInt16()
+				if !yield(V(v), err) {
+					return
+				}
+			}
+		case int32:
+			for range length {
+				v, err := m.ReadInt32()
+				if !yield(V(v), err) {
+					return
+				}
+			}
+		case int64:
+			for range length {
+				v, err := m.ReadInt64()
+				if !yield(V(v), err) {
+					return
+				}
+			}
+		case int:
+			for range length {
+				v, err := m.ReadInt()
+				if !yield(V(v), err) {
+					return
+				}
+			}
+		case float32:
+			for range length {
+				v, err := m.ReadFloat32()
+				if !yield(V(v), err) {
+					return
+				}
+			}
+		case float64:
+			for range length {
+				v, err := m.ReadFloat64()
+				if !yield(V(v), err) {
+					return
+				}
+			}
+		default:
+			panic("unreachable")
+		}
+	}
+}
+
+// ReadNumberArrayBytes returns an iterator that can be used to iterate over the elements
+// of an array in the MessagePack data.
+// The type parameter V specifies the type of the elements in the array.
+// The returned iterator implements the iter.Seq[V] interface,
+// allowing for sequential access to the array elements.
+// After the iterator is exhausted, the remaining bytes in the buffer
+// and any error can be read by calling the returned function.
+func ReadNumberArrayBytes[V NumberTypes](b []byte) (iter.Seq[V], func() (remain []byte, err error)) {
+	sz, b, err := ReadArrayHeaderBytes(b)
+	if err != nil {
+		return nil, func() ([]byte, error) { return b, err }
+	}
+
+	var readValue func() (V, error)
+	var v V
+	switch any(v).(type) {
+	case uint8:
+		readValue = func() (V, error) {
+			var val uint8
+			val, b, err = ReadUint8Bytes(b)
+			return V(val), err
+		}
+	case uint16:
+		readValue = func() (V, error) {
+			var val uint16
+			val, b, err = ReadUint16Bytes(b)
+			return V(val), err
+		}
+	case uint32:
+		readValue = func() (V, error) {
+			var val uint32
+			val, b, err = ReadUint32Bytes(b)
+			return V(val), err
+		}
+	case uint64:
+		readValue = func() (V, error) {
+			var val uint64
+			val, b, err = ReadUint64Bytes(b)
+			return V(val), err
+		}
+	case uint:
+		readValue = func() (V, error) {
+			var val uint
+			val, b, err = ReadUintBytes(b)
+			return V(val), err
+		}
+	case int8:
+		readValue = func() (V, error) {
+			var val int8
+			val, b, err = ReadInt8Bytes(b)
+			return V(val), err
+		}
+	case int16:
+		readValue = func() (V, error) {
+			var val int16
+			val, b, err = ReadInt16Bytes(b)
+			return V(val), err
+		}
+	case int32:
+		readValue = func() (V, error) {
+			var val int32
+			val, b, err = ReadInt32Bytes(b)
+			return V(val), err
+		}
+	case int64:
+		readValue = func() (V, error) {
+			var val int64
+			val, b, err = ReadInt64Bytes(b)
+			return V(val), err
+		}
+	case int:
+		readValue = func() (V, error) {
+			var val int
+			val, b, err = ReadIntBytes(b)
+			return V(val), err
+		}
+	case float32:
+		readValue = func() (V, error) {
+			var val float32
+			val, b, err = ReadFloat32Bytes(b)
+			return V(val), err
+		}
+	case float64:
+		readValue = func() (V, error) {
+			var val float64
+			val, b, err = ReadFloat64Bytes(b)
+			return V(val), err
+		}
+	default:
+		panic("unreachable")
+	}
+	return func(yield func(V) bool) {
+		for sz > 0 {
+			v, err = readValue()
+			if err != nil || !yield(v) {
+				return
+			}
+			sz--
+		}
+	}, func() ([]byte, error) { return b, err }
+}
+
+// ReadArrayBytes returns an iterator that can be used to iterate over the elements
+// of an array in the MessagePack data while being read by the provided Reader.
+// The type parameter V specifies the type of the elements in the array.
+// The type parameter V must be bool, string, []byte or a type whose
+// pointer implements the Unmarshaler interface.
+// Use ReadNumberArrayBytes for numbers.
+// The returned iterator implements the iter.Seq[V] interface,
+// allowing for sequential access to the array elements.
+// Byte slices will reference the same underlying data.
+// After the iterator is exhausted, the remaining bytes in the buffer
+// and any error can be read by calling the returned function.
+func ReadArrayBytes[V ArrayExtraTypes](b []byte) (iter.Seq[V], func() (remain []byte, err error)) {
+	sz, b, err := ReadArrayHeaderBytes(b)
+	if err != nil {
+		return nil, func() ([]byte, error) { return b, err }
+	}
+	return func(yield func(V) bool) {
+			var x V
+			switch any(x).(type) {
+			case string:
+				for range sz {
+					var v string
+					v, b, err = ReadStringBytes(b)
+					if err != nil || !yield(any(v).(V)) {
+						return
+					}
+				}
+			case []byte:
+				for range sz {
+					var v []byte
+					v, b, err = ReadBytesZC(b)
+					if err != nil || !yield(any(v).(V)) {
+						return
+					}
+				}
+			case bool:
+				for range sz {
+					var v bool
+					v, b, err = ReadBoolBytes(b)
+					if err != nil || !yield(any(v).(V)) {
+						return
+					}
+				}
+			case time.Time:
+				for range sz {
+					var v time.Time
+					v, b, err = ReadTimeBytes(b)
+					if err != nil || !yield(any(v).(V)) {
+						return
+					}
+				}
+			case time.Duration:
+				for range sz {
+					var v time.Duration
+					v, b, err = ReadDurationBytes(b)
+					if err != nil || !yield(any(v).(V)) {
+						return
+					}
+				}
+			case complex64:
+				for range sz {
+					var v complex64
+					v, b, err = ReadComplex64Bytes(b)
+					if err != nil || !yield(any(v).(V)) {
+						return
+					}
+				}
+			case complex128:
+				for range sz {
+					var v complex128
+					v, b, err = ReadComplex128Bytes(b)
+					if err != nil || !yield(any(v).(V)) {
+						return
+					}
+				}
+			default:
+				for range sz {
+					var v V
+					ptr := &v
+					if um, ok := any(ptr).(Unmarshaler); ok {
+						b, err = um.UnmarshalMsg(b)
+						if err != nil || !yield(v) {
+							return
+						}
+					} else {
+						err = fmt.Errorf("cannot unmarshal into type %T", ptr)
+						return
+					}
+				}
+			}
+		}, func() (remain []byte, err error) {
+			return b, err
+		}
+}
+
+// ReadMapBytes returns an iterator over key-value pairs of a map encoded in MessagePack bytes.
+// The type parameters K and V specify the types of the keys and values in the map.
+// The iterator yields pairs in wire order. After iteration completes (or stops early),
+// call the returned tail function to get any remaining bytes and the first error encountered (if any).
+// K and V must be one of the supported built-in types, or pointers to types implementing Unmarshaler.
+// Byte slices will reference the same underlying data.
+func ReadMapBytes[K MapKeyTypes, V MapValueTypes](b []byte) (iter.Seq2[K, V], func() (remain []byte, err error)) {
+	sz, b, err := ReadMapHeaderBytes(b)
+	if err != nil {
+		return nil, func() ([]byte, error) { return b, err }
+	}
+
+	readKey := func() (K, error) {
+		var key K
+		switch any(key).(type) {
+		case string:
+			var v string
+			v, b, err = ReadStringBytes(b)
+			key = any(v).(K)
+		case []byte:
+			var v []byte
+			v, b, err = ReadBytesZC(b)
+			key = any(v).(K)
+		case bool:
+			var v bool
+			v, b, err = ReadBoolBytes(b)
+			key = any(v).(K)
+		case time.Time:
+			var v time.Time
+			v, b, err = ReadTimeBytes(b)
+			key = any(v).(K)
+		case time.Duration:
+			var v time.Duration
+			v, b, err = ReadDurationBytes(b)
+			key = any(v).(K)
+		case complex64:
+			var v complex64
+			v, b, err = ReadComplex64Bytes(b)
+			key = any(v).(K)
+		case complex128:
+			var v complex128
+			v, b, err = ReadComplex128Bytes(b)
+			key = any(v).(K)
+		case uint8:
+			var v uint8
+			v, b, err = ReadUint8Bytes(b)
+			key = any(v).(K)
+		case uint16:
+			var v uint16
+			v, b, err = ReadUint16Bytes(b)
+			key = any(v).(K)
+		case uint32:
+			var v uint32
+			v, b, err = ReadUint32Bytes(b)
+			key = any(v).(K)
+		case uint64:
+			var v uint64
+			v, b, err = ReadUint64Bytes(b)
+			key = any(v).(K)
+		case uint:
+			var v uint
+			v, b, err = ReadUintBytes(b)
+			key = any(v).(K)
+		case int8:
+			var v int8
+			v, b, err = ReadInt8Bytes(b)
+			key = any(v).(K)
+		case int16:
+			var v int16
+			v, b, err = ReadInt16Bytes(b)
+			key = any(v).(K)
+		case int32:
+			var v int32
+			v, b, err = ReadInt32Bytes(b)
+			key = any(v).(K)
+		case int64:
+			var v int64
+			v, b, err = ReadInt64Bytes(b)
+			key = any(v).(K)
+		case int:
+			var v int
+			v, b, err = ReadIntBytes(b)
+			key = any(v).(K)
+		case float32:
+			var v float32
+			v, b, err = ReadFloat32Bytes(b)
+			key = any(v).(K)
+		case float64:
+			var v float64
+			v, b, err = ReadFloat64Bytes(b)
+			key = any(v).(K)
+		default:
+			// Fallback for custom types implementing Unmarshaler
+			ptr := &key
+			if um, ok := any(ptr).(Unmarshaler); ok {
+				b, err = um.UnmarshalMsg(b)
+			} else {
+				err = fmt.Errorf("cannot unmarshal key into type %T", ptr)
+			}
+		}
+		return key, err
+	}
+
+	readVal := func() (V, error) {
+		var val V
+		switch any(val).(type) {
+		case string:
+			var v string
+			v, b, err = ReadStringBytes(b)
+			val = any(v).(V)
+		case []byte:
+			var v []byte
+			v, b, err = ReadBytesZC(b)
+			val = any(v).(V)
+		case bool:
+			var v bool
+			v, b, err = ReadBoolBytes(b)
+			val = any(v).(V)
+		case time.Time:
+			var v time.Time
+			v, b, err = ReadTimeBytes(b)
+			val = any(v).(V)
+		case time.Duration:
+			var v time.Duration
+			v, b, err = ReadDurationBytes(b)
+			val = any(v).(V)
+		case complex64:
+			var v complex64
+			v, b, err = ReadComplex64Bytes(b)
+			val = any(v).(V)
+		case complex128:
+			var v complex128
+			v, b, err = ReadComplex128Bytes(b)
+			val = any(v).(V)
+		case uint8:
+			var v uint8
+			v, b, err = ReadUint8Bytes(b)
+			val = any(v).(V)
+		case uint16:
+			var v uint16
+			v, b, err = ReadUint16Bytes(b)
+			val = any(v).(V)
+		case uint32:
+			var v uint32
+			v, b, err = ReadUint32Bytes(b)
+			val = any(v).(V)
+		case uint64:
+			var v uint64
+			v, b, err = ReadUint64Bytes(b)
+			val = any(v).(V)
+		case uint:
+			var v uint
+			v, b, err = ReadUintBytes(b)
+			val = any(v).(V)
+		case int8:
+			var v int8
+			v, b, err = ReadInt8Bytes(b)
+			val = any(v).(V)
+		case int16:
+			var v int16
+			v, b, err = ReadInt16Bytes(b)
+			val = any(v).(V)
+		case int32:
+			var v int32
+			v, b, err = ReadInt32Bytes(b)
+			val = any(v).(V)
+		case int64:
+			var v int64
+			v, b, err = ReadInt64Bytes(b)
+			val = any(v).(V)
+		case int:
+			var v int
+			v, b, err = ReadIntBytes(b)
+			val = any(v).(V)
+		case float32:
+			var v float32
+			v, b, err = ReadFloat32Bytes(b)
+			val = any(v).(V)
+		case float64:
+			var v float64
+			v, b, err = ReadFloat64Bytes(b)
+			val = any(v).(V)
+		default:
+			// Fallback for custom types implementing Unmarshaler
+			ptr := &val
+			if um, ok := any(ptr).(Unmarshaler); ok {
+				b, err = um.UnmarshalMsg(b)
+			} else {
+				err = fmt.Errorf("cannot unmarshal value into type %T", ptr)
+			}
+		}
+		return val, err
+	}
+
+	return func(yield func(K, V) bool) {
+			for sz > 0 {
+				k, e := readKey()
+				if e != nil {
+					err = e
+					return
+				}
+				v, e := readVal()
+				if e != nil {
+					err = e
+					return
+				}
+				if !yield(k, v) {
+					return
+				}
+				sz--
+			}
+		}, func() ([]byte, error) {
+			return b, err
+		}
+}

--- a/msgp/iter.go
+++ b/msgp/iter.go
@@ -1,3 +1,5 @@
+//go:build go1.23
+
 package msgp
 
 import (

--- a/msgp/iter.go
+++ b/msgp/iter.go
@@ -80,6 +80,7 @@ func ReadArray[V ArrayExtraTypes](m *Reader) iter.Seq2[V, error] {
 			for range length {
 				v, err := m.ReadComplex128()
 				if !yield(any(v).(V), err) {
+					return
 				}
 			}
 		default:
@@ -92,7 +93,7 @@ func ReadArray[V ArrayExtraTypes](m *Reader) iter.Seq2[V, error] {
 						return
 					}
 				} else {
-					err = fmt.Errorf("cannot decode into type %T", ptr)
+					yield(v, fmt.Errorf("cannot decode into type %T", ptr))
 					return
 				}
 			}
@@ -226,6 +227,7 @@ func ReadMap[K MapKeyTypes, V MapValueTypes](m *Reader) (iter.Seq2[K, V], func()
 				}
 				key = (any)(v).(K)
 			default:
+				_ = v
 				ptr := &key
 				if dc, ok := any(ptr).(Decodable); ok {
 					if err = dc.DecodeMsg(m); err != nil {
@@ -336,6 +338,7 @@ func ReadMap[K MapKeyTypes, V MapValueTypes](m *Reader) (iter.Seq2[K, V], func()
 				val = (any)(v).(V)
 
 			default:
+				_ = v
 				ptr := &val
 				if dc, ok := any(ptr).(Decodable); ok {
 					if err = dc.DecodeMsg(m); err != nil {

--- a/msgp/iter.go
+++ b/msgp/iter.go
@@ -3,119 +3,66 @@
 package msgp
 
 import (
+	"cmp"
 	"fmt"
 	"iter"
-	"time"
+	"maps"
+	"math"
+	"slices"
 )
-
-// ArrayExtraTypes is a type constraint that includes all types that can be
-// decoded from an array.
-// Even though 'any' type can be used, its pointer must implement the
-// Decodable when using Reader or Unmarhaler interface when reading from bytes.
-type ArrayExtraTypes interface {
-	bool | string | []byte | complex64 | complex128 | time.Time | time.Duration | any
-}
 
 // ReadArray returns an iterator that can be used to iterate over the elements
 // of an array in the MessagePack data while being read by the provided Reader.
 // The type parameter V specifies the type of the elements in the array.
-// The type parameter V must be ArrayExtraTypes or a type whose
-// pointer implements the Decodable interface.
-// Use ReadNumberArray for numbers.
 // The returned iterator implements the iter.Seq[V] interface,
 // allowing for sequential access to the array elements.
-func ReadArray[V ArrayExtraTypes](m *Reader) iter.Seq2[V, error] {
-	return func(yield func(V, error) bool) {
+func ReadArray[T any](m *Reader, readFn func() (T, error)) iter.Seq2[T, error] {
+	return func(yield func(T, error) bool) {
 		// Check if nil
 		if m.IsNil() {
 			m.ReadNil()
 			return
 		}
 		// Regular array.
-		var x V
+		var empty T
 		length, err := m.ReadArrayHeader()
 		if err != nil {
-			yield(x, fmt.Errorf("cannot read array header: %w", err))
+			yield(empty, fmt.Errorf("cannot read array header: %w", err))
 			return
 		}
-		switch any(x).(type) {
-		case string:
-			for range length {
-				v, err := m.ReadString()
-				if !yield(any(v).(V), err) {
-					return
-				}
-			}
-		case []byte:
-			for range length {
-				v, err := m.ReadBytes(nil)
-				if !yield(any(v).(V), err) {
-					return
-				}
-			}
-		case bool:
-			for range length {
-				v, err := m.ReadBool()
-				if !yield(any(v).(V), err) {
-					return
-				}
-			}
-		case time.Time:
-			for range length {
-				v, err := m.ReadTime()
-				if !yield(any(v).(V), err) {
-					return
-				}
-			}
-		case time.Duration:
-			for range length {
-				v, err := m.ReadDuration()
-				if !yield(any(v).(V), err) {
-					return
-				}
-			}
-		case complex64:
-			for range length {
-				v, err := m.ReadComplex64()
-				if !yield(any(v).(V), err) {
-					return
-				}
-			}
-		case complex128:
-			for range length {
-				v, err := m.ReadComplex128()
-				if !yield(any(v).(V), err) {
-					return
-				}
-			}
-		default:
-			for range length {
-				var v V
-				ptr := &v
-				if dc, ok := any(ptr).(Decodable); ok {
-					err = dc.DecodeMsg(m)
-					if !yield(v, err) {
-						return
-					}
-				} else {
-					yield(v, fmt.Errorf("cannot decode into type %T", ptr))
-					return
-				}
+		for range length {
+			var v T
+			v, err = readFn()
+			if !yield(v, err) {
+				return
 			}
 		}
 	}
 }
 
-// MapKeyTypes are possible key types. Usually this is a string.
-// Even though 'any' type can be used, its pointer must implement the Decodable interface.
-type MapKeyTypes interface {
-	NumberTypes | bool | string | []byte | complex64 | complex128 | time.Time | time.Duration | any
-}
-
-// MapValueTypes are possible value types.
-// Even though 'any' type can be used, its pointer must implement the Decodable interface.
-type MapValueTypes interface {
-	NumberTypes | bool | string | []byte | complex64 | complex128 | time.Time | time.Duration | any
+// WriteArray writes an array to the provided Writer.
+// The writeFn parameter specifies the function to use to write each element of the array.
+func WriteArray[T any](w *Writer, a []T, writeFn func(T) error) error {
+	// Check if nil
+	if a == nil {
+		return w.WriteNil()
+	}
+	if uint64(len(a)) > math.MaxUint32 {
+		return fmt.Errorf("array too large to encode: %d elements", len(a))
+	}
+	// Write array header
+	err := w.WriteArrayHeader(uint32(len(a)))
+	if err != nil {
+		return err
+	}
+	// Write elements
+	for _, v := range a {
+		err = writeFn(v)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // ReadMap returns an iterator that can be used to iterate over the elements
@@ -124,7 +71,7 @@ type MapValueTypes interface {
 // The returned iterator implements the iter.Seq2[K, V] interface,
 // allowing for sequential access to the map elements.
 // The returned function can be used to read any error that occurred during iteration when iteration is done.
-func ReadMap[K MapKeyTypes, V MapValueTypes](m *Reader) (iter.Seq2[K, V], func() error) {
+func ReadMap[K, V any](m *Reader, readKey func() (K, error), readVal func() (V, error)) (iter.Seq2[K, V], func() error) {
 	var err error
 	return func(yield func(K, V) bool) {
 		var sz uint32
@@ -136,231 +83,6 @@ func ReadMap[K MapKeyTypes, V MapValueTypes](m *Reader) (iter.Seq2[K, V], func()
 		if err != nil {
 			err = fmt.Errorf("cannot read map header: %w", err)
 			return
-		}
-
-		// Prepare per-type readers once, avoid switching for each element.
-		// Key reader.
-		var readKey func() (K, error)
-		{
-			var keyZero K
-			switch any(keyZero).(type) {
-			case string:
-				readKey = func() (K, error) {
-					v, e := m.ReadString()
-					return any(v).(K), e
-				}
-			case []byte:
-				readKey = func() (K, error) {
-					v, e := m.ReadBytes(nil)
-					return any(v).(K), e
-				}
-			case bool:
-				readKey = func() (K, error) {
-					v, e := m.ReadBool()
-					return any(v).(K), e
-				}
-			case time.Time:
-				readKey = func() (K, error) {
-					v, e := m.ReadTime()
-					return any(v).(K), e
-				}
-			case time.Duration:
-				readKey = func() (K, error) {
-					v, e := m.ReadDuration()
-					return any(v).(K), e
-				}
-			case complex64:
-				readKey = func() (K, error) {
-					v, e := m.ReadComplex64()
-					return any(v).(K), e
-				}
-			case complex128:
-				readKey = func() (K, error) {
-					v, e := m.ReadComplex128()
-					return any(v).(K), e
-				}
-			case uint8:
-				readKey = func() (K, error) {
-					v, e := m.ReadUint8()
-					return any(v).(K), e
-				}
-			case uint16:
-				readKey = func() (K, error) {
-					v, e := m.ReadUint16()
-					return any(v).(K), e
-				}
-			case uint32:
-				readKey = func() (K, error) {
-					v, e := m.ReadUint32()
-					return any(v).(K), e
-				}
-			case uint64:
-				readKey = func() (K, error) {
-					v, e := m.ReadUint64()
-					return any(v).(K), e
-				}
-			case uint:
-				readKey = func() (K, error) {
-					v, e := m.ReadUint()
-					return any(v).(K), e
-				}
-			case int8:
-				readKey = func() (K, error) {
-					v, e := m.ReadInt8()
-					return any(v).(K), e
-				}
-			case int16:
-				readKey = func() (K, error) {
-					v, e := m.ReadInt16()
-					return any(v).(K), e
-				}
-			case int32:
-				readKey = func() (K, error) {
-					v, e := m.ReadInt32()
-					return any(v).(K), e
-				}
-			case int64:
-				readKey = func() (K, error) {
-					v, e := m.ReadInt64()
-					return any(v).(K), e
-				}
-			case int:
-				readKey = func() (K, error) {
-					v, e := m.ReadInt()
-					return any(v).(K), e
-				}
-			case float32:
-				readKey = func() (K, error) {
-					v, e := m.ReadFloat32()
-					return any(v).(K), e
-				}
-			case float64:
-				readKey = func() (K, error) {
-					v, e := m.ReadFloat64()
-					return any(v).(K), e
-				}
-			default:
-				readKey = func() (K, error) {
-					var k K
-					ptr := &k
-					if dc, ok := any(ptr).(Decodable); ok {
-						return k, dc.DecodeMsg(m)
-					}
-					return k, fmt.Errorf("cannot decode key into type %T", ptr)
-				}
-			}
-		}
-
-		// Value reader.
-		var readVal func() (V, error)
-		{
-			var valZero V
-			switch any(valZero).(type) {
-			case string:
-				readVal = func() (V, error) {
-					v, e := m.ReadString()
-					return any(v).(V), e
-				}
-			case []byte:
-				readVal = func() (V, error) {
-					v, e := m.ReadBytes(nil)
-					return any(v).(V), e
-				}
-			case bool:
-				readVal = func() (V, error) {
-					v, e := m.ReadBool()
-					return any(v).(V), e
-				}
-			case time.Time:
-				readVal = func() (V, error) {
-					v, e := m.ReadTime()
-					return any(v).(V), e
-				}
-			case time.Duration:
-				readVal = func() (V, error) {
-					v, e := m.ReadDuration()
-					return any(v).(V), e
-				}
-			case complex64:
-				readVal = func() (V, error) {
-					v, e := m.ReadComplex64()
-					return any(v).(V), e
-				}
-			case complex128:
-				readVal = func() (V, error) {
-					v, e := m.ReadComplex128()
-					return any(v).(V), e
-				}
-			case int8:
-				readVal = func() (V, error) {
-					v, e := m.ReadInt8()
-					return any(v).(V), e
-				}
-			case int16:
-				readVal = func() (V, error) {
-					v, e := m.ReadInt16()
-					return any(v).(V), e
-				}
-			case int32:
-				readVal = func() (V, error) {
-					v, e := m.ReadInt32()
-					return any(v).(V), e
-				}
-			case int64:
-				readVal = func() (V, error) {
-					v, e := m.ReadInt64()
-					return any(v).(V), e
-				}
-			case int:
-				readVal = func() (V, error) {
-					v, e := m.ReadInt()
-					return any(v).(V), e
-				}
-			case float32:
-				readVal = func() (V, error) {
-					v, e := m.ReadFloat32()
-					return any(v).(V), e
-				}
-			case float64:
-				readVal = func() (V, error) {
-					v, e := m.ReadFloat64()
-					return any(v).(V), e
-				}
-			case uint8:
-				readVal = func() (V, error) {
-					v, e := m.ReadUint8()
-					return any(v).(V), e
-				}
-			case uint16:
-				readVal = func() (V, error) {
-					v, e := m.ReadUint16()
-					return any(v).(V), e
-				}
-			case uint32:
-				readVal = func() (V, error) {
-					v, e := m.ReadUint32()
-					return any(v).(V), e
-				}
-			case uint64:
-				readVal = func() (V, error) {
-					v, e := m.ReadUint64()
-					return any(v).(V), e
-				}
-			case uint:
-				readVal = func() (V, error) {
-					v, e := m.ReadUint()
-					return any(v).(V), e
-				}
-			default:
-				readVal = func() (V, error) {
-					var v V
-					ptr := &v
-					if dc, ok := any(ptr).(Decodable); ok {
-						return v, dc.DecodeMsg(m)
-					}
-					return v, fmt.Errorf("cannot decode value into type %T", ptr)
-				}
-			}
 		}
 
 		for range sz {
@@ -383,330 +105,119 @@ func ReadMap[K MapKeyTypes, V MapValueTypes](m *Reader) (iter.Seq2[K, V], func()
 	}, func() error { return err }
 }
 
-// NumberTypes is a type constraint that includes all numeric types.
-type NumberTypes interface {
-	uint | uint8 | uint16 | uint32 | uint64 | int | int8 | int16 | int32 | int64 | float32 | float64
-}
-
-// ReadNumberArray returns an iterator that can be used to iterate over the elements
-// of an array in the MessagePack data while being read by the provided Reader.
-// The type parameter V specifies the type of the elements in the array.
-// The returned iterator implements the iter.Seq[V] interface,
-// allowing for sequential access to the array elements.
-func ReadNumberArray[V NumberTypes](m *Reader) iter.Seq2[V, error] {
-	return func(yield func(V, error) bool) {
-		if m.IsNil() {
-			m.ReadNil()
-			return
-		}
-		var x V
-		length, err := m.ReadArrayHeader()
-		if err != nil {
-			yield(x, fmt.Errorf("cannot read array header: %w", err))
-			return
-		}
-
-		switch any(x).(type) {
-		case uint8:
-			for range length {
-				v, err := m.ReadUint8()
-				if !yield(V(v), err) {
-					return
-				}
-			}
-		case uint16:
-			for range length {
-				v, err := m.ReadUint16()
-				if !yield(V(v), err) {
-					return
-				}
-			}
-		case uint32:
-			for range length {
-				v, err := m.ReadUint32()
-				if !yield(V(v), err) {
-					return
-				}
-			}
-		case uint64:
-			for range length {
-				v, err := m.ReadUint64()
-				if !yield(V(v), err) {
-					return
-				}
-			}
-		case uint:
-			for range length {
-				v, err := m.ReadUint()
-				if !yield(V(v), err) {
-					return
-				}
-			}
-		case int8:
-			for range length {
-				v, err := m.ReadInt8()
-				if !yield(V(v), err) {
-					return
-				}
-			}
-		case int16:
-			for range length {
-				v, err := m.ReadInt16()
-				if !yield(V(v), err) {
-					return
-				}
-			}
-		case int32:
-			for range length {
-				v, err := m.ReadInt32()
-				if !yield(V(v), err) {
-					return
-				}
-			}
-		case int64:
-			for range length {
-				v, err := m.ReadInt64()
-				if !yield(V(v), err) {
-					return
-				}
-			}
-		case int:
-			for range length {
-				v, err := m.ReadInt()
-				if !yield(V(v), err) {
-					return
-				}
-			}
-		case float32:
-			for range length {
-				v, err := m.ReadFloat32()
-				if !yield(V(v), err) {
-					return
-				}
-			}
-		case float64:
-			for range length {
-				v, err := m.ReadFloat64()
-				if !yield(V(v), err) {
-					return
-				}
-			}
-		default:
-			panic("unreachable")
-		}
+// WriteMap writes a map to the provided Writer.
+// The writeKey and writeVal parameters specify the functions to use to write each key and value of the map.
+func WriteMap[K comparable, V any](w *Writer, m map[K]V, writeKey func(K) error, writeVal func(V) error) error {
+	if m == nil {
+		return w.WriteNil()
 	}
-}
-
-// ReadNumberArrayBytes returns an iterator that can be used to iterate over the elements
-// of an array in the MessagePack data.
-// The type parameter V specifies the type of the elements in the array.
-// The returned iterator implements the iter.Seq[V] interface,
-// allowing for sequential access to the array elements.
-// After the iterator is exhausted, the remaining bytes in the buffer
-// and any error can be read by calling the returned function.
-func ReadNumberArrayBytes[V NumberTypes](b []byte) (iter.Seq[V], func() (remain []byte, err error)) {
-	if IsNil(b) {
-		b, err := ReadNilBytes(b)
-		return func(yield func(V) bool) {}, func() ([]byte, error) { return b, err }
+	if uint64(len(m)) > math.MaxUint32 {
+		return fmt.Errorf("map too large to encode: %d elements", len(m))
 	}
-	// Regular array.
-	sz, b, err := ReadArrayHeaderBytes(b)
+
+	// Write map header
+	err := w.WriteMapHeader(uint32(len(m)))
 	if err != nil {
-		return func(yield func(V) bool) {}, func() ([]byte, error) { return b, fmt.Errorf("cannot read array header: %w", err) }
+		return err
+	}
+	// Write elements
+	for k, v := range m {
+		err = writeKey(k)
+		if err != nil {
+			return err
+		}
+		err = writeVal(v)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// WriteMapSorted writes a map to the provided Writer.
+// The keys of the map are sorted before writing.
+// This provides deterministic output.
+// The writeKey and writeVal parameters specify the functions
+// to use to write each key and value of the map.
+func WriteMapSorted[K cmp.Ordered, V any](w *Writer, m map[K]V, writeKey func(K) error, writeVal func(V) error) error {
+	if m == nil {
+		return w.WriteNil()
+	}
+	if uint64(len(m)) > math.MaxUint32 {
+		return fmt.Errorf("map too large to encode: %d elements", len(m))
 	}
 
-	var readValue func() (V, error)
-	var v V
-	switch any(v).(type) {
-	case uint8:
-		readValue = func() (V, error) {
-			var val uint8
-			val, b, err = ReadUint8Bytes(b)
-			return V(val), err
-		}
-	case uint16:
-		readValue = func() (V, error) {
-			var val uint16
-			val, b, err = ReadUint16Bytes(b)
-			return V(val), err
-		}
-	case uint32:
-		readValue = func() (V, error) {
-			var val uint32
-			val, b, err = ReadUint32Bytes(b)
-			return V(val), err
-		}
-	case uint64:
-		readValue = func() (V, error) {
-			var val uint64
-			val, b, err = ReadUint64Bytes(b)
-			return V(val), err
-		}
-	case uint:
-		readValue = func() (V, error) {
-			var val uint
-			val, b, err = ReadUintBytes(b)
-			return V(val), err
-		}
-	case int8:
-		readValue = func() (V, error) {
-			var val int8
-			val, b, err = ReadInt8Bytes(b)
-			return V(val), err
-		}
-	case int16:
-		readValue = func() (V, error) {
-			var val int16
-			val, b, err = ReadInt16Bytes(b)
-			return V(val), err
-		}
-	case int32:
-		readValue = func() (V, error) {
-			var val int32
-			val, b, err = ReadInt32Bytes(b)
-			return V(val), err
-		}
-	case int64:
-		readValue = func() (V, error) {
-			var val int64
-			val, b, err = ReadInt64Bytes(b)
-			return V(val), err
-		}
-	case int:
-		readValue = func() (V, error) {
-			var val int
-			val, b, err = ReadIntBytes(b)
-			return V(val), err
-		}
-	case float32:
-		readValue = func() (V, error) {
-			var val float32
-			val, b, err = ReadFloat32Bytes(b)
-			return V(val), err
-		}
-	case float64:
-		readValue = func() (V, error) {
-			var val float64
-			val, b, err = ReadFloat64Bytes(b)
-			return V(val), err
-		}
-	default:
-		panic("unreachable")
+	// Write map header
+	err := w.WriteMapHeader(uint32(len(m)))
+	if err != nil {
+		return err
 	}
-	return func(yield func(V) bool) {
-		for sz > 0 {
-			v, err = readValue()
-			if err != nil || !yield(v) {
-				return
-			}
-			sz--
+	// Write elements
+	for _, k := range slices.Sorted(maps.Keys(m)) {
+		err = writeKey(k)
+		if err != nil {
+			return err
 		}
-	}, func() ([]byte, error) { return b, err }
+		err = writeVal(m[k])
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // ReadArrayBytes returns an iterator that can be used to iterate over the elements
 // of an array in the MessagePack data while being read by the provided Reader.
 // The type parameter V specifies the type of the elements in the array.
-// The type parameter V must be bool, string, []byte or a type whose
-// pointer implements the Unmarshaler interface.
-// Use ReadNumberArrayBytes for numbers.
-// The returned iterator implements the iter.Seq[V] interface,
-// allowing for sequential access to the array elements.
-// Byte slices will reference the same underlying data.
 // After the iterator is exhausted, the remaining bytes in the buffer
 // and any error can be read by calling the returned function.
-func ReadArrayBytes[V ArrayExtraTypes](b []byte) (iter.Seq[V], func() (remain []byte, err error)) {
+func ReadArrayBytes[T any](b []byte, readFn func([]byte) (T, []byte, error)) (iter.Seq[T], func() (remain []byte, err error)) {
 	if IsNil(b) {
 		b, err := ReadNilBytes(b)
-		return func(yield func(V) bool) {}, func() ([]byte, error) { return b, err }
+		return func(yield func(T) bool) {}, func() ([]byte, error) { return b, err }
 	}
 	sz, b, err := ReadArrayHeaderBytes(b)
-	if err != nil {
-		return nil, func() ([]byte, error) { return b, err }
+	if err != nil || sz == 0 {
+		return func(yield func(T) bool) {}, func() ([]byte, error) { return b, err }
 	}
-	return func(yield func(V) bool) {
-			var x V
-			switch any(x).(type) {
-			case string:
-				for range sz {
-					var v string
-					v, b, err = ReadStringBytes(b)
-					if err != nil || !yield(any(v).(V)) {
-						return
-					}
-				}
-			case []byte:
-				for range sz {
-					var v []byte
-					v, b, err = ReadBytesZC(b)
-					if err != nil || !yield(any(v).(V)) {
-						return
-					}
-				}
-			case bool:
-				for range sz {
-					var v bool
-					v, b, err = ReadBoolBytes(b)
-					if err != nil || !yield(any(v).(V)) {
-						return
-					}
-				}
-			case time.Time:
-				for range sz {
-					var v time.Time
-					v, b, err = ReadTimeBytes(b)
-					if err != nil || !yield(any(v).(V)) {
-						return
-					}
-				}
-			case time.Duration:
-				for range sz {
-					var v time.Duration
-					v, b, err = ReadDurationBytes(b)
-					if err != nil || !yield(any(v).(V)) {
-						return
-					}
-				}
-			case complex64:
-				for range sz {
-					var v complex64
-					v, b, err = ReadComplex64Bytes(b)
-					if err != nil || !yield(any(v).(V)) {
-						return
-					}
-				}
-			case complex128:
-				for range sz {
-					var v complex128
-					v, b, err = ReadComplex128Bytes(b)
-					if err != nil || !yield(any(v).(V)) {
-						return
-					}
-				}
-			default:
-				for range sz {
-					var v V
-					ptr := &v
-					if um, ok := any(ptr).(Unmarshaler); ok {
-						b, err = um.UnmarshalMsg(b)
-						if err != nil || !yield(v) {
-							return
-						}
-					} else {
-						err = fmt.Errorf("cannot unmarshal into type %T", ptr)
-						return
-					}
+	return func(yield func(T) bool) {
+			for range sz {
+				var v T
+				v, b, err = readFn(b)
+				if err != nil || !yield(v) {
+					return
 				}
 			}
-		}, func() (remain []byte, err error) {
+		}, func() ([]byte, error) {
 			return b, err
 		}
 }
 
-// ReadMapBytes returns an iterator over key/value pairs from a MessagePack map encoded in b.
-// The iterator yields K,V pairs and this function also returns a closure to obtain the remaining bytes and any error.
-// It avoids per-element type switches by precomputing readKey/readVal funcs based on K and V.
-func ReadMapBytes[K MapKeyTypes, V MapValueTypes](b []byte) (iter.Seq2[K, V], func() (remain []byte, err error)) {
+// AppendArray writes an array to the provided buffer.
+// The writeFn parameter specifies the function to use to write each element of the array.
+// The returned buffer contains the encoded array.
+// The function panics if the map is larger than math.MaxUint32 elements.
+func AppendArray[T any](b []byte, a []T, writeFn func(b []byte, v T) []byte) []byte {
+	if a == nil {
+		return AppendNil(b)
+	}
+	if uint64(len(a)) > math.MaxUint32 {
+		panic(fmt.Sprintf("array too large to encode: %d elements", len(a)))
+	}
+	b = AppendArrayHeader(b, uint32(len(a)))
+	for _, v := range a {
+		b = writeFn(b, v)
+	}
+	return b
+}
+
+// ReadMapBytes returns an iterator over key/value
+// pairs from a MessagePack map encoded in b.
+// The iterator yields K,V pairs and this function also returns
+// a closure to get the remaining bytes and any error.
+func ReadMapBytes[K any, V any](b []byte,
+	readK func([]byte) (K, []byte, error),
+	readV func([]byte) (V, []byte, error)) (iter.Seq2[K, V], func() (remain []byte, err error)) {
 	var err error
 	var sz uint32
 	if IsNil(b) {
@@ -714,288 +225,22 @@ func ReadMapBytes[K MapKeyTypes, V MapValueTypes](b []byte) (iter.Seq2[K, V], fu
 		return func(yield func(K, V) bool) {}, func() ([]byte, error) { return b, err }
 	}
 	sz, b, err = ReadMapHeaderBytes(b)
-	if err != nil {
+	if err != nil || sz == 0 {
 		return func(yield func(K, V) bool) {}, func() ([]byte, error) { return b, err }
-	}
-
-	// Precompute key reader
-	var readKey func() (K, error)
-	{
-		var keyZero K
-		switch any(keyZero).(type) {
-		case string:
-			readKey = func() (K, error) {
-				v, e, er := ReadStringBytes(b)
-				b, err = e, er
-				return any(v).(K), err
-			}
-		case []byte:
-			// Map keys can be str or bin; use specialized helper that accepts both.
-			readKey = func() (K, error) {
-				v, e, er := ReadMapKeyZC(b)
-				b, err = e, er
-				return any(v).(K), err
-			}
-		case bool:
-			readKey = func() (K, error) {
-				v, e, er := ReadBoolBytes(b)
-				b, err = e, er
-				return any(v).(K), err
-			}
-		case time.Time:
-			readKey = func() (K, error) {
-				v, e, er := ReadTimeBytes(b)
-				b, err = e, er
-				return any(v).(K), err
-			}
-		case time.Duration:
-			readKey = func() (K, error) {
-				v, e, er := ReadDurationBytes(b)
-				b, err = e, er
-				return any(v).(K), err
-			}
-		case complex64:
-			readKey = func() (K, error) {
-				v, e, er := ReadComplex64Bytes(b)
-				b, err = e, er
-				return any(v).(K), err
-			}
-		case complex128:
-			readKey = func() (K, error) {
-				v, e, er := ReadComplex128Bytes(b)
-				b, err = e, er
-				return any(v).(K), err
-			}
-		case uint8:
-			readKey = func() (K, error) {
-				v, e, er := ReadUint8Bytes(b)
-				b, err = e, er
-				return any(v).(K), err
-			}
-		case uint16:
-			readKey = func() (K, error) {
-				v, e, er := ReadUint16Bytes(b)
-				b, err = e, er
-				return any(v).(K), err
-			}
-		case uint32:
-			readKey = func() (K, error) {
-				v, e, er := ReadUint32Bytes(b)
-				b, err = e, er
-				return any(v).(K), err
-			}
-		case uint64:
-			readKey = func() (K, error) {
-				v, e, er := ReadUint64Bytes(b)
-				b, err = e, er
-				return any(v).(K), err
-			}
-		case uint:
-			readKey = func() (K, error) {
-				v, e, er := ReadUintBytes(b)
-				b, err = e, er
-				return any(v).(K), err
-			}
-		case int8:
-			readKey = func() (K, error) {
-				v, e, er := ReadInt8Bytes(b)
-				b, err = e, er
-				return any(v).(K), err
-			}
-		case int16:
-			readKey = func() (K, error) {
-				v, e, er := ReadInt16Bytes(b)
-				b, err = e, er
-				return any(v).(K), err
-			}
-		case int32:
-			readKey = func() (K, error) {
-				v, e, er := ReadInt32Bytes(b)
-				b, err = e, er
-				return any(v).(K), err
-			}
-		case int64:
-			readKey = func() (K, error) {
-				v, e, er := ReadInt64Bytes(b)
-				b, err = e, er
-				return any(v).(K), err
-			}
-		case int:
-			readKey = func() (K, error) {
-				v, e, er := ReadIntBytes(b)
-				b, err = e, er
-				return any(v).(K), err
-			}
-		case float32:
-			readKey = func() (K, error) {
-				v, e, er := ReadFloat32Bytes(b)
-				b, err = e, er
-				return any(v).(K), err
-			}
-		case float64:
-			readKey = func() (K, error) {
-				v, e, er := ReadFloat64Bytes(b)
-				b, err = e, er
-				return any(v).(K), err
-			}
-		default:
-			readKey = func() (K, error) {
-				var k K
-				ptr := &k
-				if um, ok := any(ptr).(Unmarshaler); ok {
-					var e error
-					b, e = um.UnmarshalMsg(b)
-					return k, e
-				}
-				return k, fmt.Errorf("cannot unmarshal key into type %T", ptr)
-			}
-		}
-	}
-
-	// Precompute value reader
-	var readVal func() (V, error)
-	{
-		var valZero V
-		switch any(valZero).(type) {
-		case string:
-			readVal = func() (V, error) {
-				v, e, er := ReadStringBytes(b)
-				b, err = e, er
-				return any(v).(V), err
-			}
-		case []byte:
-			// For values, zero-copy read of bin/str payload.
-			readVal = func() (V, error) {
-				v, e, er := ReadBytesZC(b)
-				b, err = e, er
-				return any(v).(V), err
-			}
-		case bool:
-			readVal = func() (V, error) {
-				v, e, er := ReadBoolBytes(b)
-				b, err = e, er
-				return any(v).(V), err
-			}
-		case time.Time:
-			readVal = func() (V, error) {
-				v, e, er := ReadTimeBytes(b)
-				b, err = e, er
-				return any(v).(V), err
-			}
-		case time.Duration:
-			readVal = func() (V, error) {
-				v, e, er := ReadDurationBytes(b)
-				b, err = e, er
-				return any(v).(V), err
-			}
-		case complex64:
-			readVal = func() (V, error) {
-				v, e, er := ReadComplex64Bytes(b)
-				b, err = e, er
-				return any(v).(V), err
-			}
-		case complex128:
-			readVal = func() (V, error) {
-				v, e, er := ReadComplex128Bytes(b)
-				b, err = e, er
-				return any(v).(V), err
-			}
-		case int8:
-			readVal = func() (V, error) {
-				v, e, er := ReadInt8Bytes(b)
-				b, err = e, er
-				return any(v).(V), err
-			}
-		case int16:
-			readVal = func() (V, error) {
-				v, e, er := ReadInt16Bytes(b)
-				b, err = e, er
-				return any(v).(V), err
-			}
-		case int32:
-			readVal = func() (V, error) {
-				v, e, er := ReadInt32Bytes(b)
-				b, err = e, er
-				return any(v).(V), err
-			}
-		case int64:
-			readVal = func() (V, error) {
-				v, e, er := ReadInt64Bytes(b)
-				b, err = e, er
-				return any(v).(V), err
-			}
-		case int:
-			readVal = func() (V, error) {
-				v, e, er := ReadIntBytes(b)
-				b, err = e, er
-				return any(v).(V), err
-			}
-		case float32:
-			readVal = func() (V, error) {
-				v, e, er := ReadFloat32Bytes(b)
-				b, err = e, er
-				return any(v).(V), err
-			}
-		case float64:
-			readVal = func() (V, error) {
-				v, e, er := ReadFloat64Bytes(b)
-				b, err = e, er
-				return any(v).(V), err
-			}
-		case uint8:
-			readVal = func() (V, error) {
-				v, e, er := ReadUint8Bytes(b)
-				b, err = e, er
-				return any(v).(V), err
-			}
-		case uint16:
-			readVal = func() (V, error) {
-				v, e, er := ReadUint16Bytes(b)
-				b, err = e, er
-				return any(v).(V), err
-			}
-		case uint32:
-			readVal = func() (V, error) {
-				v, e, er := ReadUint32Bytes(b)
-				b, err = e, er
-				return any(v).(V), err
-			}
-		case uint64:
-			readVal = func() (V, error) {
-				v, e, er := ReadUint64Bytes(b)
-				b, err = e, er
-				return any(v).(V), err
-			}
-		case uint:
-			readVal = func() (V, error) {
-				v, e, er := ReadUintBytes(b)
-				b, err = e, er
-				return any(v).(V), err
-			}
-		default:
-			readVal = func() (V, error) {
-				var v V
-				ptr := &v
-				if um, ok := any(ptr).(Unmarshaler); ok {
-					var e error
-					b, e = um.UnmarshalMsg(b)
-					return v, e
-				}
-				return v, fmt.Errorf("cannot unmarshal value into type %T", ptr)
-			}
-		}
 	}
 
 	return func(yield func(K, V) bool) {
 		for range sz {
-			k, er := readKey()
-			if er != nil {
-				err = fmt.Errorf("cannot read map key: %w", er)
+			var k K
+			k, b, err = readK(b)
+			if err != nil {
+				err = fmt.Errorf("cannot read map key: %w", err)
 				return
 			}
-			v, er := readVal()
-			if er != nil {
-				err = fmt.Errorf("cannot read map value: %w", er)
+			var v V
+			v, b, err = readV(b)
+			if err != nil {
+				err = fmt.Errorf("cannot read map value: %w", err)
 				return
 			}
 			if !yield(k, v) {
@@ -1003,4 +248,133 @@ func ReadMapBytes[K MapKeyTypes, V MapValueTypes](b []byte) (iter.Seq2[K, V], fu
 			}
 		}
 	}, func() ([]byte, error) { return b, err }
+}
+
+// AppendMap writes a map to the provided buffer.
+// The writeK and writeV parameters specify the functions to use to write each key and value of the map.
+// The returned buffer contains the encoded map.
+// The function panics if the map is larger than math.MaxUint32 elements.
+func AppendMap[K comparable, V any](b []byte, m map[K]V,
+	writeK func(b []byte, k K) []byte,
+	writeV func(b []byte, v V) []byte) []byte {
+	if m == nil {
+		return AppendNil(b)
+	}
+	if uint64(len(m)) > math.MaxUint32 {
+		panic(fmt.Sprintf("map too large to encode: %d elements", len(m)))
+	}
+	b = AppendMapHeader(b, uint32(len(m)))
+	for k, v := range m {
+		b = writeK(b, k)
+		b = writeV(b, v)
+	}
+	return b
+}
+
+// AppendMapSorted writes a map to the provided buffer.
+// Keys are sorted before writing. This provides deterministic output.
+// The writeK and writeV parameters specify the functions to use to write each key and value of the map.
+// The returned buffer contains the encoded map.
+// The function panics if the map is larger than math.MaxUint32 elements.
+func AppendMapSorted[K cmp.Ordered, V any](b []byte, m map[K]V,
+	writeK func(b []byte, k K) []byte,
+	writeV func(b []byte, v V) []byte) []byte {
+	if m == nil {
+		return AppendNil(b)
+	}
+	if uint64(len(m)) > math.MaxUint32 {
+		panic(fmt.Sprintf("map too large to encode: %d elements", len(m)))
+	}
+	b = AppendMapHeader(b, uint32(len(m)))
+	for _, k := range slices.Sorted(maps.Keys(m)) {
+		b = writeK(b, k)
+		b = writeV(b, m[k])
+	}
+	return b
+}
+
+// DecodePtr is a convenience type for decoding into a pointer.
+type DecodePtr[T any] interface {
+	*T
+	Decodable
+}
+
+// DecoderFrom allows augmenting any type with a DecodeMsg method into a method
+// that reads from Reader and returns a T.
+// Provide an instance of T. This value isn't used.
+func DecoderFrom[T any, PT DecodePtr[T]](r *Reader, _ T) func() (T, error) {
+	return func() (T, error) {
+		var t T
+		tPtr := PT(&t)
+		err := tPtr.DecodeMsg(r)
+		return t, err
+	}
+}
+
+// FlexibleEncoder is a constraint for types where either T or *T implements Encodable
+type FlexibleEncoder[T any] interface {
+	Encodable
+	*T // Include *T in the interface
+}
+
+// EncoderTo allows augmenting any type with a EncodeMsg method into a method
+// that writes to Writer on each call.
+// Provide an instance of T. This value isn't used.'
+func EncoderTo[T any, PT FlexibleEncoder[T]](w *Writer, _ T) func(T) error {
+	return func(t T) error {
+		// Check if T implements Marshaler
+		if marshaler, ok := any(t).(Encodable); ok {
+			return marshaler.EncodeMsg(w)
+		}
+		// Check if *T implements Marshaler
+		if ptrMarshaler, ok := any(&t).(Encodable); ok {
+			return ptrMarshaler.EncodeMsg(w)
+		}
+		// The compiler should have asserted this.
+		panic("type does not implement Marshaler")
+	}
+}
+
+// UnmarshalPtr is a convenience type for unmarshaling into a pointer.
+type UnmarshalPtr[T any] interface {
+	*T
+	Unmarshaler
+}
+
+// DecoderFromBytes allows augmenting any type with a UnmarshalMsg method into a method
+// that reads from []byte and returns a T.
+// Provide an instance of T. This value isn't used.
+func DecoderFromBytes[T any, PT UnmarshalPtr[T]](_ T) func([]byte) (T, []byte, error) {
+	return func(b []byte) (T, []byte, error) {
+		var t T
+		tPtr := PT(&t)
+		b, err := tPtr.UnmarshalMsg(b)
+		return t, b, err
+	}
+}
+
+// FlexibleMarshaler is a constraint for types where either T or *T implements Marshaler
+type FlexibleMarshaler[T any] interface {
+	Marshaler
+	*T // Include *T in the interface
+}
+
+// EncoderToBytes allows augmenting any type with a MarshalMsg method into a method
+// that reads from T and returns a []byte.
+// Provide an instance of T. This value isn't used.
+func EncoderToBytes[T any, PT FlexibleMarshaler[T]](_ T) func([]byte, T) []byte {
+	return func(b []byte, t T) []byte {
+		// Check if T implements Marshaler
+		if marshaler, ok := any(t).(Marshaler); ok {
+			b, _ = marshaler.MarshalMsg(b)
+			return b
+		}
+		// Check if *T implements Marshaler
+		if ptrMarshaler, ok := any(&t).(Marshaler); ok {
+			b, _ = ptrMarshaler.MarshalMsg(b)
+			return b
+		}
+		// The compiler should have asserted this.
+		panic("type does not implement Marshaler")
+	}
 }

--- a/msgp/iter.go
+++ b/msgp/iter.go
@@ -106,7 +106,8 @@ func ReadMap[K, V any](m *Reader, readKey func() (K, error), readVal func() (V, 
 }
 
 // WriteMap writes a map to the provided Writer.
-// The writeKey and writeVal parameters specify the functions to use to write each key and value of the map.
+// The writeKey and writeVal parameters specify the functions
+// to use to write each key and value of the map.
 func WriteMap[K comparable, V any](w *Writer, m map[K]V, writeKey func(K) error, writeVal func(V) error) error {
 	if m == nil {
 		return w.WriteNil()
@@ -196,7 +197,7 @@ func ReadArrayBytes[T any](b []byte, readFn func([]byte) (T, []byte, error)) (it
 // AppendArray writes an array to the provided buffer.
 // The writeFn parameter specifies the function to use to write each element of the array.
 // The returned buffer contains the encoded array.
-// The function panics if the map is larger than math.MaxUint32 elements.
+// The function panics if the array is larger than math.MaxUint32 elements.
 func AppendArray[T any](b []byte, a []T, writeFn func(b []byte, v T) []byte) []byte {
 	if a == nil {
 		return AppendNil(b)
@@ -341,8 +342,8 @@ type UnmarshalPtr[T any] interface {
 	Unmarshaler
 }
 
-// DecoderFromBytes allows augmenting any type with a UnmarshalMsg method into a method
-// that reads from []byte and returns a T.
+// DecoderFromBytes allows augmenting any type with an UnmarshalMsg
+// method into a method that reads from []byte and returns a T.
 // Provide an instance of T. This value isn't used.
 func DecoderFromBytes[T any, PT UnmarshalPtr[T]](_ T) func([]byte) (T, []byte, error) {
 	return func(b []byte) (T, []byte, error) {

--- a/msgp/iter_test.go
+++ b/msgp/iter_test.go
@@ -1,0 +1,2923 @@
+//go:build go1.23
+
+package msgp
+
+import (
+	"bytes"
+	"math"
+	"testing"
+	"time"
+)
+
+// collectSeq2 collects values from an iter.Seq2[V, error] into a slice.
+// It stops at the first non-nil error and returns it together with the collected values.
+func collectSeq2[V any](seq func(func(V, error) bool)) (vals []V, err error) {
+	seq(func(v V, e error) bool {
+		if e != nil {
+			err = e
+			return false
+		}
+		vals = append(vals, v)
+		return true
+	})
+	return
+}
+
+func TestReadNumberArray_Int(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	want := []int{1, -2, 3, 0, 42}
+	if err := w.WriteArrayHeader(uint32(len(want))); err != nil {
+		t.Fatalf("WriteArrayHeader: %v", err)
+	}
+	for _, v := range want {
+		if err := w.WriteInt(v); err != nil {
+			t.Fatalf("WriteInt: %v", err)
+		}
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	r := NewReader(&buf)
+	got, err := collectSeq2(ReadNumberArray[int](r))
+	if err != nil {
+		t.Fatalf("iteration error: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("length mismatch: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("index %d: got %v want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestReadNumberArray_Float64(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	want := []float64{0, 1.5, -2.25, 1e9}
+	if err := w.WriteArrayHeader(uint32(len(want))); err != nil {
+		t.Fatalf("WriteArrayHeader: %v", err)
+	}
+	for _, v := range want {
+		if err := w.WriteFloat64(v); err != nil {
+			t.Fatalf("WriteFloat64: %v", err)
+		}
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	r := NewReader(&buf)
+	got, err := collectSeq2(ReadNumberArray[float64](r))
+	if err != nil {
+		t.Fatalf("iteration error: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("length mismatch: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("index %d: got %v want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestReadArray_String(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	want := []string{"", "a", "hello", "世界"}
+	if err := w.WriteArrayHeader(uint32(len(want))); err != nil {
+		t.Fatalf("WriteArrayHeader: %v", err)
+	}
+	for _, v := range want {
+		if err := w.WriteString(v); err != nil {
+			t.Fatalf("WriteString: %v", err)
+		}
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	r := NewReader(&buf)
+	got, err := collectSeq2(ReadArray[string](r))
+	if err != nil {
+		t.Fatalf("iteration error: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("length mismatch: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("index %d: got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestReadArray_Bool(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	want := []bool{true, false, true}
+	if err := w.WriteArrayHeader(uint32(len(want))); err != nil {
+		t.Fatalf("WriteArrayHeader: %v", err)
+	}
+	for _, v := range want {
+		if err := w.WriteBool(v); err != nil {
+			t.Fatalf("WriteBool: %v", err)
+		}
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	r := NewReader(&buf)
+	got, err := collectSeq2(ReadArray[bool](r))
+	if err != nil {
+		t.Fatalf("iteration error: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("length mismatch: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("index %d: got %v want %v", i, got[i], want[i])
+		}
+	}
+}
+
+// A decodable type to exercise the default branch of ReadArray.
+type testDec struct {
+	A int
+	B string
+}
+
+func (t *testDec) MarshalMsg(i []byte) ([]byte, error) {
+	i = AppendInt(i, t.A)
+	i = AppendString(i, t.B)
+	return i, nil
+}
+
+func (t *testDec) UnmarshalMsg(i []byte) ([]byte, error) {
+	var err error
+	if t.A, i, err = ReadIntBytes(i); err != nil {
+		return nil, err
+	}
+	if t.B, i, err = ReadStringBytes(i); err != nil {
+		return nil, err
+	}
+	return i, nil
+}
+
+func (t *testDec) EncodeMsg(w *Writer) error {
+	if err := w.WriteInt(t.A); err != nil {
+		return err
+	}
+	return w.WriteString(t.B)
+}
+
+func (t *testDec) DecodeMsg(r *Reader) error {
+	var err error
+	if t.A, err = r.ReadInt(); err != nil {
+		return err
+	}
+	t.B, err = r.ReadString()
+	return err
+}
+
+func TestReadArray_Decodable(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	want := []testDec{
+		{A: 1, B: "x"},
+		{A: -5, B: "yz"},
+	}
+	if err := w.WriteArrayHeader(uint32(len(want))); err != nil {
+		t.Fatalf("WriteArrayHeader: %v", err)
+	}
+	for i := range want {
+		if err := (&want[i]).EncodeMsg(w); err != nil {
+			t.Fatalf("EncodeMsg: %v", err)
+		}
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	r := NewReader(&buf)
+	got, err := collectSeq2(ReadArray[testDec](r))
+	if err != nil {
+		t.Fatalf("iteration error: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("length mismatch: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].A != want[i].A || got[i].B != want[i].B {
+			t.Fatalf("index %d: got %+v want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestReadArray_TimeAndDuration(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	now := time.Unix(1700000000, 123456789).UTC()
+	durs := []time.Duration{0, time.Second, -5 * time.Millisecond}
+
+	// time.Time
+	if err := w.WriteArrayHeader(2); err != nil {
+		t.Fatalf("WriteArrayHeader: %v", err)
+	}
+	if err := w.WriteTime(now); err != nil {
+		t.Fatalf("WriteTime: %v", err)
+	}
+	if err := w.WriteTime(now.Add(time.Minute)); err != nil {
+		t.Fatalf("WriteTime: %v", err)
+	}
+
+	// time.Duration
+	if err := w.WriteArrayHeader(uint32(len(durs))); err != nil {
+		t.Fatalf("WriteArrayHeader: %v", err)
+	}
+	for _, d := range durs {
+		if err := w.WriteDuration(d); err != nil {
+			t.Fatalf("WriteDuration: %v", err)
+		}
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	r := NewReader(&buf)
+	timesGot, err := collectSeq2(ReadArray[time.Time](r))
+	if err != nil {
+		t.Fatalf("times iteration error: %v", err)
+	}
+	if len(timesGot) != 2 || !timesGot[0].Equal(now) || !timesGot[1].Equal(now.Add(time.Minute)) {
+		t.Fatalf("times mismatch: got %v", timesGot)
+	}
+
+	dursGot, err := collectSeq2(ReadArray[time.Duration](r))
+	if err != nil {
+		t.Fatalf("durations iteration error: %v", err)
+	}
+	if len(dursGot) != len(durs) {
+		t.Fatalf("length mismatch: got %d want %d", len(dursGot), len(durs))
+	}
+	for i := range durs {
+		if dursGot[i] != durs[i] {
+			t.Fatalf("index %d: got %v want %v", i, dursGot[i], durs[i])
+		}
+	}
+}
+
+func TestReadNumberArrayBytes_Uint16(t *testing.T) {
+	var msg []byte
+	want := []uint16{0, 1, 255, 256, 65535}
+
+	msg = AppendArrayHeader(msg, uint32(len(want)))
+	for _, v := range want {
+		msg = AppendUint16(msg, v)
+	}
+
+	seq, tail := ReadNumberArrayBytes[uint16](msg)
+	var got []uint16
+	for v := range seq {
+		got = append(got, v)
+	}
+	remain, err := tail()
+	if err != nil {
+		t.Fatalf("tail err: %v", err)
+	}
+	if len(remain) != 0 {
+		t.Fatalf("expected no remaining bytes, got %d", len(remain))
+	}
+	if len(got) != len(want) {
+		t.Fatalf("length mismatch: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("index %d: got %v want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestReadNumberArrayBytes_ErrOnTruncated(t *testing.T) {
+	var msg []byte
+	// 2 elements, but we will truncate the second one
+	msg = AppendArrayHeader(msg, 2)
+	msg = AppendInt32(msg, 123)
+	full := AppendInt32(msg, 456)
+
+	// Truncate to cause an error when reading the second element.
+	trunc := full[:len(full)-2]
+
+	seq, tail := ReadNumberArrayBytes[int32](trunc)
+	var got []int32
+	for v := range seq {
+		got = append(got, v)
+		// The second element should fail before yielding
+	}
+	if len(got) != 1 || got[0] != 123 {
+		t.Fatalf("expected to read only first element (123), got %v", got)
+	}
+	remain, err := tail()
+	if err == nil {
+		t.Fatalf("expected an error from tail() on truncated input")
+	}
+	// remain can be partial bytes; ensure it's from the truncated buffer
+	if len(remain) != 0 {
+		// Not strictly required, but checks contract that tail returns the remaining unread slice.
+		_ = remain
+	}
+}
+
+func TestReadArray_ErrorOnTooFewElements(t *testing.T) {
+	// Array header says 2, but only 1 element provided.
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+	if err := w.WriteArrayHeader(2); err != nil {
+		t.Fatalf("WriteArrayHeader: %v", err)
+	}
+	if err := w.WriteInt(7); err != nil {
+		t.Fatalf("WriteInt: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	r := NewReader(&buf)
+	var got []int
+	var firstErr error
+	ReadNumberArray[int](r)(func(v int, err error) bool {
+		if err != nil {
+			firstErr = err
+			return false
+		}
+		got = append(got, v)
+		return true
+	})
+	if firstErr == nil {
+		t.Fatalf("expected error due to missing second element, got nil")
+	}
+	if len(got) != 1 || got[0] != 7 {
+		t.Fatalf("unexpected values read before error: %v", got)
+	}
+}
+
+// approxEqual checks approximate equality for float32/float64
+func approxEqual[T ~float32 | ~float64](a, b T) bool {
+	af := float64(a)
+	bf := float64(b)
+	const eps = 1e-6
+	return math.Abs(af-bf) <= eps*(1+math.Max(math.Abs(af), math.Abs(bf)))
+}
+
+func TestRoundtripNumberArray_AllTypes(t *testing.T) {
+	type testcase[V NumberTypes] struct {
+		name  string
+		vals  []V
+		write func(w *Writer, v V) error
+	}
+	now := time.Now() // not used here, avoid unused import warnings if refactoring
+	_ = now
+
+	tests := []any{
+		testcase[uint]{name: "uint", vals: []uint{0, 1, 255, 1 << 20, math.MaxUint32}, write: func(w *Writer, v uint) error { return w.WriteUint(v) }},
+		testcase[uint8]{name: "uint8", vals: []uint8{0, 1, 127, 128, 255}, write: func(w *Writer, v uint8) error { return w.WriteUint8(v) }},
+		testcase[uint16]{name: "uint16", vals: []uint16{0, 255, 256, 65535}, write: func(w *Writer, v uint16) error { return w.WriteUint16(v) }},
+		testcase[uint32]{name: "uint32", vals: []uint32{0, 65535, 1 << 20, math.MaxUint32}, write: func(w *Writer, v uint32) error { return w.WriteUint32(v) }},
+		testcase[uint64]{name: "uint64", vals: []uint64{0, 1, 1 << 40, math.MaxUint32 + 1, math.MaxUint64 >> 1}, write: func(w *Writer, v uint64) error { return w.WriteUint64(v) }},
+		testcase[int]{name: "int", vals: []int{0, 1, -1, 1 << 20, -(1 << 20)}, write: func(w *Writer, v int) error { return w.WriteInt(v) }},
+		testcase[int8]{name: "int8", vals: []int8{0, 1, -1, 127, -128}, write: func(w *Writer, v int8) error { return w.WriteInt8(v) }},
+		testcase[int16]{name: "int16", vals: []int16{0, 1, -1, 32767, -32768}, write: func(w *Writer, v int16) error { return w.WriteInt16(v) }},
+		testcase[int32]{name: "int32", vals: []int32{0, 1, -1, math.MaxInt32, math.MinInt32}, write: func(w *Writer, v int32) error { return w.WriteInt32(v) }},
+		testcase[int64]{name: "int64", vals: []int64{0, 1, -1, math.MaxInt32 + 1, math.MinInt32 - 1}, write: func(w *Writer, v int64) error { return w.WriteInt64(v) }},
+		testcase[float32]{name: "float32", vals: []float32{0, 1.5, -2.25, 3.14159, 1e20}, write: func(w *Writer, v float32) error { return w.WriteFloat32(v) }},
+		testcase[float64]{name: "float64", vals: []float64{0, 1.5, -2.25, math.Pi, 1e308}, write: func(w *Writer, v float64) error { return w.WriteFloat64(v) }},
+	}
+
+	for _, anytc := range tests {
+		switch tc := anytc.(type) {
+		case testcase[uint]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.vals))); err != nil {
+				t.Fatalf("WriteArrayHeader %s: %v", tc.name, err)
+			}
+			for _, v := range tc.vals {
+				if err := tc.write(w, v); err != nil {
+					t.Fatalf("%s write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			got, err := collectSeq2(ReadNumberArray[uint](r))
+			if err != nil {
+				t.Fatalf("%s iterate: %v", tc.name, err)
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: got %d want %d", tc.name, len(got), len(tc.vals))
+			}
+			for i := range got {
+				if got[i] != tc.vals[i] {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case testcase[uint8]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.vals))); err != nil {
+				t.Fatalf("WriteArrayHeader %s: %v", tc.name, err)
+			}
+			for _, v := range tc.vals {
+				if err := tc.write(w, v); err != nil {
+					t.Fatalf("%s write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			got, err := collectSeq2(ReadNumberArray[uint8](r))
+			if err != nil {
+				t.Fatalf("%s iterate: %v", tc.name, err)
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: got %d want %d", tc.name, len(got), len(tc.vals))
+			}
+			for i := range got {
+				if got[i] != tc.vals[i] {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case testcase[uint16]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.vals))); err != nil {
+				t.Fatalf("WriteArrayHeader %s: %v", tc.name, err)
+			}
+			for _, v := range tc.vals {
+				if err := tc.write(w, v); err != nil {
+					t.Fatalf("%s write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			got, err := collectSeq2(ReadNumberArray[uint16](r))
+			if err != nil {
+				t.Fatalf("%s iterate: %v", tc.name, err)
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: got %d want %d", tc.name, len(got), len(tc.vals))
+			}
+			for i := range got {
+				if got[i] != tc.vals[i] {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case testcase[uint32]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.vals))); err != nil {
+				t.Fatalf("WriteArrayHeader %s: %v", tc.name, err)
+			}
+			for _, v := range tc.vals {
+				if err := tc.write(w, v); err != nil {
+					t.Fatalf("%s write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			got, err := collectSeq2(ReadNumberArray[uint32](r))
+			if err != nil {
+				t.Fatalf("%s iterate: %v", tc.name, err)
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: got %d want %d", tc.name, len(got), len(tc.vals))
+			}
+			for i := range got {
+				if got[i] != tc.vals[i] {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case testcase[uint64]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.vals))); err != nil {
+				t.Fatalf("WriteArrayHeader %s: %v", tc.name, err)
+			}
+			for _, v := range tc.vals {
+				if err := tc.write(w, v); err != nil {
+					t.Fatalf("%s write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			got, err := collectSeq2(ReadNumberArray[uint64](r))
+			if err != nil {
+				t.Fatalf("%s iterate: %v", tc.name, err)
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: got %d want %d", tc.name, len(got), len(tc.vals))
+			}
+			for i := range got {
+				if got[i] != tc.vals[i] {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case testcase[int]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.vals))); err != nil {
+				t.Fatalf("WriteArrayHeader %s: %v", tc.name, err)
+			}
+			for _, v := range tc.vals {
+				if err := tc.write(w, v); err != nil {
+					t.Fatalf("%s write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			got, err := collectSeq2(ReadNumberArray[int](r))
+			if err != nil {
+				t.Fatalf("%s iterate: %v", tc.name, err)
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: got %d want %d", tc.name, len(got), len(tc.vals))
+			}
+			for i := range got {
+				if got[i] != tc.vals[i] {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case testcase[int8]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.vals))); err != nil {
+				t.Fatalf("WriteArrayHeader %s: %v", tc.name, err)
+			}
+			for _, v := range tc.vals {
+				if err := tc.write(w, v); err != nil {
+					t.Fatalf("%s write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			got, err := collectSeq2(ReadNumberArray[int8](r))
+			if err != nil {
+				t.Fatalf("%s iterate: %v", tc.name, err)
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: got %d want %d", tc.name, len(got), len(tc.vals))
+			}
+			for i := range got {
+				if got[i] != tc.vals[i] {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case testcase[int16]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.vals))); err != nil {
+				t.Fatalf("WriteArrayHeader %s: %v", tc.name, err)
+			}
+			for _, v := range tc.vals {
+				if err := tc.write(w, v); err != nil {
+					t.Fatalf("%s write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			got, err := collectSeq2(ReadNumberArray[int16](r))
+			if err != nil {
+				t.Fatalf("%s iterate: %v", tc.name, err)
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: got %d want %d", tc.name, len(got), len(tc.vals))
+			}
+			for i := range got {
+				if got[i] != tc.vals[i] {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case testcase[int32]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.vals))); err != nil {
+				t.Fatalf("WriteArrayHeader %s: %v", tc.name, err)
+			}
+			for _, v := range tc.vals {
+				if err := tc.write(w, v); err != nil {
+					t.Fatalf("%s write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			got, err := collectSeq2(ReadNumberArray[int32](r))
+			if err != nil {
+				t.Fatalf("%s iterate: %v", tc.name, err)
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: got %d want %d", tc.name, len(got), len(tc.vals))
+			}
+			for i := range got {
+				if got[i] != tc.vals[i] {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case testcase[int64]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.vals))); err != nil {
+				t.Fatalf("WriteArrayHeader %s: %v", tc.name, err)
+			}
+			for _, v := range tc.vals {
+				if err := tc.write(w, v); err != nil {
+					t.Fatalf("%s write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			got, err := collectSeq2(ReadNumberArray[int64](r))
+			if err != nil {
+				t.Fatalf("%s iterate: %v", tc.name, err)
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: got %d want %d", tc.name, len(got), len(tc.vals))
+			}
+			for i := range got {
+				if got[i] != tc.vals[i] {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case testcase[float32]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.vals))); err != nil {
+				t.Fatalf("WriteArrayHeader %s: %v", tc.name, err)
+			}
+			for _, v := range tc.vals {
+				if err := tc.write(w, v); err != nil {
+					t.Fatalf("%s write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			got, err := collectSeq2(ReadNumberArray[float32](r))
+			if err != nil {
+				t.Fatalf("%s iterate: %v", tc.name, err)
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: got %d want %d", tc.name, len(got), len(tc.vals))
+			}
+			for i := range got {
+				if !approxEqual(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case testcase[float64]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.vals))); err != nil {
+				t.Fatalf("WriteArrayHeader %s: %v", tc.name, err)
+			}
+			for _, v := range tc.vals {
+				if err := tc.write(w, v); err != nil {
+					t.Fatalf("%s write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			got, err := collectSeq2(ReadNumberArray[float64](r))
+			if err != nil {
+				t.Fatalf("%s iterate: %v", tc.name, err)
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: got %d want %d", tc.name, len(got), len(tc.vals))
+			}
+			for i := range got {
+				if !approxEqual(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		}
+	}
+}
+
+func TestRoundtripArray_AllTypes(t *testing.T) {
+	type regCase[V ArrayExtraTypes] struct {
+		name  string
+		vals  []V
+		write func(*Writer, V) error
+		eq    func(a, b V) bool
+	}
+
+	now := time.Unix(1700000000, 123456789).UTC()
+	later := now.Add(5 * time.Minute)
+
+	rcases := []any{
+		regCase[bool]{name: "bool", vals: []bool{true, false, true}, write: func(w *Writer, v bool) error { return w.WriteBool(v) }, eq: func(a, b bool) bool { return a == b }},
+		regCase[string]{name: "string", vals: []string{"", "a", "hello", "世界"}, write: func(w *Writer, v string) error { return w.WriteString(v) }, eq: func(a, b string) bool { return a == b }},
+		regCase[[]byte]{name: "bytes", vals: [][]byte{nil, {}, {0x00}, {0x01, 0x02, 0x03}}, write: func(w *Writer, v []byte) error { return w.WriteBytes(v) }, eq: func(a, b []byte) bool {
+			if len(a) != len(b) {
+				return false
+			}
+			for i := range a {
+				if a[i] != b[i] {
+					return false
+				}
+			}
+			return true
+		}},
+		regCase[time.Time]{name: "time", vals: []time.Time{now, later}, write: func(w *Writer, v time.Time) error { return w.WriteTime(v) }, eq: func(a, b time.Time) bool { return a.Equal(b) }},
+		regCase[time.Duration]{name: "duration", vals: []time.Duration{0, time.Second, -5 * time.Millisecond}, write: func(w *Writer, v time.Duration) error { return w.WriteDuration(v) }, eq: func(a, b time.Duration) bool { return a == b }},
+		regCase[complex64]{name: "complex64", vals: []complex64{0, 1 + 2i, -3.5 + 4.25i}, write: func(w *Writer, v complex64) error { return w.WriteComplex64(v) }, eq: func(a, b complex64) bool { return a == b }},
+		regCase[complex128]{name: "complex128", vals: []complex128{0, 1 + 2i, -3.5 + 4.25i}, write: func(w *Writer, v complex128) error { return w.WriteComplex128(v) }, eq: func(a, b complex128) bool { return a == b }},
+		regCase[testDec]{name: "decoder", vals: []testDec{{A: 1, B: "abc"}, {A: 2, B: "def"}}, write: func(w *Writer, v testDec) error { return v.EncodeMsg(w) }, eq: func(a, b testDec) bool { return a == b }},
+	}
+
+	for _, anytc := range rcases {
+		switch tc := anytc.(type) {
+		case regCase[bool]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.vals))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for _, v := range tc.vals {
+				if err := tc.write(w, v); err != nil {
+					t.Fatalf("%s write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			got, err := collectSeq2(ReadArray[bool](r))
+			if err != nil {
+				t.Fatalf("%s iterate: %v", tc.name, err)
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: got %d want %d", tc.name, len(got), len(tc.vals))
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case regCase[string]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.vals))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for _, v := range tc.vals {
+				if err := tc.write(w, v); err != nil {
+					t.Fatalf("%s write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			got, err := collectSeq2(ReadArray[string](r))
+			if err != nil {
+				t.Fatalf("%s iterate: %v", tc.name, err)
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: got %d want %d", tc.name, len(got), len(tc.vals))
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %q want %q", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case regCase[[]byte]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.vals))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for _, v := range tc.vals {
+				if err := tc.write(w, v); err != nil {
+					t.Fatalf("%s write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			got, err := collectSeq2(ReadArray[[]byte](r))
+			if err != nil {
+				t.Fatalf("%s iterate: %v", tc.name, err)
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: got %d want %d", tc.name, len(got), len(tc.vals))
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case regCase[time.Time]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.vals))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for _, v := range tc.vals {
+				if err := tc.write(w, v); err != nil {
+					t.Fatalf("%s write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			got, err := collectSeq2(ReadArray[time.Time](r))
+			if err != nil {
+				t.Fatalf("%s iterate: %v", tc.name, err)
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: got %d want %d", tc.name, len(got), len(tc.vals))
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case regCase[time.Duration]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.vals))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for _, v := range tc.vals {
+				if err := tc.write(w, v); err != nil {
+					t.Fatalf("%s write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			got, err := collectSeq2(ReadArray[time.Duration](r))
+			if err != nil {
+				t.Fatalf("%s iterate: %v", tc.name, err)
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: got %d want %d", tc.name, len(got), len(tc.vals))
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case regCase[complex64]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.vals))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for _, v := range tc.vals {
+				if err := tc.write(w, v); err != nil {
+					t.Fatalf("%s write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			got, err := collectSeq2(ReadArray[complex64](r))
+			if err != nil {
+				t.Fatalf("%s iterate: %v", tc.name, err)
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: got %d want %d", tc.name, len(got), len(tc.vals))
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case regCase[complex128]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.vals))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for _, v := range tc.vals {
+				if err := tc.write(w, v); err != nil {
+					t.Fatalf("%s write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			got, err := collectSeq2(ReadArray[complex128](r))
+			if err != nil {
+				t.Fatalf("%s iterate: %v", tc.name, err)
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: got %d want %d", tc.name, len(got), len(tc.vals))
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case regCase[testDec]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.vals))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for _, v := range tc.vals {
+				if err := tc.write(w, v); err != nil {
+					t.Fatalf("%s write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			got, err := collectSeq2(ReadArray[testDec](r))
+			if err != nil {
+				t.Fatalf("%s iterate: %v", tc.name, err)
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: got %d want %d", tc.name, len(got), len(tc.vals))
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+
+		}
+	}
+}
+
+func TestRoundtripNumberArrayBytes_AllTypes(t *testing.T) {
+	type tb[V NumberTypes] struct {
+		name   string
+		vals   []V
+		append func([]byte, V) []byte
+		eq     func(a, b V) bool
+	}
+
+	tests := []any{
+		tb[uint]{name: "uint", vals: []uint{0, 1, 255, 1 << 20}, append: func(b []byte, v uint) []byte { return AppendUint(b, v) }, eq: func(a, b uint) bool { return a == b }},
+		tb[uint8]{name: "uint8", vals: []uint8{0, 1, 127, 128, 255}, append: func(b []byte, v uint8) []byte { return AppendUint8(b, v) }, eq: func(a, b uint8) bool { return a == b }},
+		tb[uint16]{name: "uint16", vals: []uint16{0, 255, 256, 65535}, append: func(b []byte, v uint16) []byte { return AppendUint16(b, v) }, eq: func(a, b uint16) bool { return a == b }},
+		tb[uint32]{name: "uint32", vals: []uint32{0, 65535, 1 << 20}, append: func(b []byte, v uint32) []byte { return AppendUint32(b, v) }, eq: func(a, b uint32) bool { return a == b }},
+		tb[uint64]{name: "uint64", vals: []uint64{0, 1, 1 << 40}, append: func(b []byte, v uint64) []byte { return AppendUint64(b, v) }, eq: func(a, b uint64) bool { return a == b }},
+		tb[int]{name: "int", vals: []int{0, 1, -1, 1 << 20, -(1 << 20)}, append: func(b []byte, v int) []byte { return AppendInt(b, v) }, eq: func(a, b int) bool { return a == b }},
+		tb[int8]{name: "int8", vals: []int8{0, 1, -1, 127, -128}, append: func(b []byte, v int8) []byte { return AppendInt8(b, v) }, eq: func(a, b int8) bool { return a == b }},
+		tb[int16]{name: "int16", vals: []int16{0, 1, -1, 32767, -32768}, append: func(b []byte, v int16) []byte { return AppendInt16(b, v) }, eq: func(a, b int16) bool { return a == b }},
+		tb[int32]{name: "int32", vals: []int32{0, 1, -1, math.MaxInt32, math.MinInt32}, append: func(b []byte, v int32) []byte { return AppendInt32(b, v) }, eq: func(a, b int32) bool { return a == b }},
+		tb[int64]{name: "int64", vals: []int64{0, 1, -1, math.MaxInt32 + 1, math.MinInt32 - 1}, append: func(b []byte, v int64) []byte { return AppendInt64(b, v) }, eq: func(a, b int64) bool { return a == b }},
+		tb[float32]{name: "float32", vals: []float32{0, 1.5, -2.25, 3.14159, 1e20}, append: func(b []byte, v float32) []byte { return AppendFloat32(b, v) }, eq: func(a, b float32) bool { return approxEqual(a, b) }},
+		tb[float64]{name: "float64", vals: []float64{0, 1.5, -2.25, math.Pi, 1e308}, append: func(b []byte, v float64) []byte { return AppendFloat(b, v) }, eq: func(a, b float64) bool { return approxEqual(a, b) }},
+	}
+
+	for _, anytc := range tests {
+		switch tc := anytc.(type) {
+		case tb[uint]:
+			msg := AppendArrayHeader(nil, uint32(len(tc.vals)))
+			for _, v := range tc.vals {
+				msg = tc.append(msg, v)
+			}
+			seq, tail := ReadNumberArrayBytes[uint](msg)
+			var got []uint
+			for v := range seq {
+				got = append(got, v)
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain: %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: %d", tc.name, len(got))
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case tb[uint8]:
+			msg := AppendArrayHeader(nil, uint32(len(tc.vals)))
+			for _, v := range tc.vals {
+				msg = tc.append(msg, v)
+			}
+			seq, tail := ReadNumberArrayBytes[uint8](msg)
+			var got []uint8
+			for v := range seq {
+				got = append(got, v)
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain: %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: %d", tc.name, len(got))
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case tb[uint16]:
+			msg := AppendArrayHeader(nil, uint32(len(tc.vals)))
+			for _, v := range tc.vals {
+				msg = tc.append(msg, v)
+			}
+			seq, tail := ReadNumberArrayBytes[uint16](msg)
+			var got []uint16
+			for v := range seq {
+				got = append(got, v)
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain: %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: %d", tc.name, len(got))
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case tb[uint32]:
+			msg := AppendArrayHeader(nil, uint32(len(tc.vals)))
+			for _, v := range tc.vals {
+				msg = tc.append(msg, v)
+			}
+			seq, tail := ReadNumberArrayBytes[uint32](msg)
+			var got []uint32
+			for v := range seq {
+				got = append(got, v)
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain: %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: %d", tc.name, len(got))
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case tb[uint64]:
+			msg := AppendArrayHeader(nil, uint32(len(tc.vals)))
+			for _, v := range tc.vals {
+				msg = tc.append(msg, v)
+			}
+			seq, tail := ReadNumberArrayBytes[uint64](msg)
+			var got []uint64
+			for v := range seq {
+				got = append(got, v)
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain: %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: %d", tc.name, len(got))
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case tb[int]:
+			msg := AppendArrayHeader(nil, uint32(len(tc.vals)))
+			for _, v := range tc.vals {
+				msg = tc.append(msg, v)
+			}
+			seq, tail := ReadNumberArrayBytes[int](msg)
+			var got []int
+			for v := range seq {
+				got = append(got, v)
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain: %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: %d", tc.name, len(got))
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case tb[int8]:
+			msg := AppendArrayHeader(nil, uint32(len(tc.vals)))
+			for _, v := range tc.vals {
+				msg = tc.append(msg, v)
+			}
+			seq, tail := ReadNumberArrayBytes[int8](msg)
+			var got []int8
+			for v := range seq {
+				got = append(got, v)
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain: %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: %d", tc.name, len(got))
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case tb[int16]:
+			msg := AppendArrayHeader(nil, uint32(len(tc.vals)))
+			for _, v := range tc.vals {
+				msg = tc.append(msg, v)
+			}
+			seq, tail := ReadNumberArrayBytes[int16](msg)
+			var got []int16
+			for v := range seq {
+				got = append(got, v)
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain: %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: %d", tc.name, len(got))
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case tb[int32]:
+			msg := AppendArrayHeader(nil, uint32(len(tc.vals)))
+			for _, v := range tc.vals {
+				msg = tc.append(msg, v)
+			}
+			seq, tail := ReadNumberArrayBytes[int32](msg)
+			var got []int32
+			for v := range seq {
+				got = append(got, v)
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain: %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: %d", tc.name, len(got))
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case tb[int64]:
+			msg := AppendArrayHeader(nil, uint32(len(tc.vals)))
+			for _, v := range tc.vals {
+				msg = tc.append(msg, v)
+			}
+			seq, tail := ReadNumberArrayBytes[int64](msg)
+			var got []int64
+			for v := range seq {
+				got = append(got, v)
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain: %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: %d", tc.name, len(got))
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case tb[float32]:
+			msg := AppendArrayHeader(nil, uint32(len(tc.vals)))
+			for _, v := range tc.vals {
+				msg = tc.append(msg, v)
+			}
+			seq, tail := ReadNumberArrayBytes[float32](msg)
+			var got []float32
+			for v := range seq {
+				got = append(got, v)
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain: %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: %d", tc.name, len(got))
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case tb[float64]:
+			msg := AppendArrayHeader(nil, uint32(len(tc.vals)))
+			for _, v := range tc.vals {
+				msg = tc.append(msg, v)
+			}
+			seq, tail := ReadNumberArrayBytes[float64](msg)
+			var got []float64
+			for v := range seq {
+				got = append(got, v)
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain: %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len: %d", tc.name, len(got))
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		}
+	}
+}
+
+func TestRoundtripArrayBytes_AllTypes(t *testing.T) {
+	type rb[V ArrayExtraTypes] struct {
+		name   string
+		vals   []V
+		append func([]byte, V) []byte
+		eq     func(a, b V) bool
+	}
+
+	now := time.Unix(1700000000, 123456789).UTC()
+	later := now.Add(7 * time.Second)
+
+	rtests := []any{
+		rb[bool]{name: "bool", vals: []bool{true, false, true}, append: func(b []byte, v bool) []byte { return AppendBool(b, v) }, eq: func(a, b bool) bool { return a == b }},
+		rb[string]{name: "string", vals: []string{"", "hi", "世界"}, append: func(b []byte, v string) []byte { return AppendString(b, v) }, eq: func(a, b string) bool { return a == b }},
+		rb[[]byte]{name: "bytes", vals: [][]byte{nil, {}, {0x00}, {0x01, 0x02}}, append: func(b []byte, v []byte) []byte { return AppendBytes(b, v) }, eq: func(a, b []byte) bool {
+			if len(a) != len(b) {
+				return false
+			}
+			for i := range a {
+				if a[i] != b[i] {
+					return false
+				}
+			}
+			return true
+		}},
+		rb[time.Time]{name: "time", vals: []time.Time{now, later}, append: func(b []byte, v time.Time) []byte { return AppendTime(b, v) }, eq: func(a, b time.Time) bool { return a.Equal(b) }},
+		rb[time.Duration]{name: "duration", vals: []time.Duration{0, time.Second, -3 * time.Millisecond}, append: func(b []byte, v time.Duration) []byte { return AppendDuration(b, v) }, eq: func(a, b time.Duration) bool { return a == b }},
+		rb[complex64]{name: "complex64", vals: []complex64{0, 1 + 2i, -3.5 + 4.25i}, append: func(b []byte, v complex64) []byte { return AppendComplex64(b, v) }, eq: func(a, b complex64) bool { return a == b }},
+		rb[complex128]{name: "complex128", vals: []complex128{0, 1 + 2i, -3.5 + 4.25i}, append: func(b []byte, v complex128) []byte { return AppendComplex128(b, v) }, eq: func(a, b complex128) bool { return a == b }},
+		rb[testDec]{name: "unmarshal", vals: []testDec{{A: 1, B: "abc"}, {A: 2, B: "def"}}, append: func(b []byte, v testDec) []byte { b, _ = v.MarshalMsg(b); return b }, eq: func(a, b testDec) bool { return a == b }},
+	}
+
+	for _, anytc := range rtests {
+		switch tc := anytc.(type) {
+		case rb[bool]:
+			msg := AppendArrayHeader(nil, uint32(len(tc.vals)))
+			for _, v := range tc.vals {
+				msg = tc.append(msg, v)
+			}
+			seq, tail := ReadArrayBytes[bool](msg)
+			var got []bool
+			for v := range seq {
+				got = append(got, v)
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain: %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len mismatch", tc.name)
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case rb[string]:
+			msg := AppendArrayHeader(nil, uint32(len(tc.vals)))
+			for _, v := range tc.vals {
+				msg = tc.append(msg, v)
+			}
+			seq, tail := ReadArrayBytes[string](msg)
+			var got []string
+			for v := range seq {
+				got = append(got, v)
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain: %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len mismatch", tc.name)
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %q want %q", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case rb[[]byte]:
+			msg := AppendArrayHeader(nil, uint32(len(tc.vals)))
+			for _, v := range tc.vals {
+				msg = tc.append(msg, v)
+			}
+			seq, tail := ReadArrayBytes[[]byte](msg)
+			var got [][]byte
+			for v := range seq {
+				got = append(got, v)
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain: %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len mismatch", tc.name)
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case rb[time.Time]:
+			msg := AppendArrayHeader(nil, uint32(len(tc.vals)))
+			for _, v := range tc.vals {
+				msg = tc.append(msg, v)
+			}
+			seq, tail := ReadArrayBytes[time.Time](msg)
+			var got []time.Time
+			for v := range seq {
+				got = append(got, v)
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain: %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len mismatch", tc.name)
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case rb[time.Duration]:
+			msg := AppendArrayHeader(nil, uint32(len(tc.vals)))
+			for _, v := range tc.vals {
+				msg = tc.append(msg, v)
+			}
+			seq, tail := ReadArrayBytes[time.Duration](msg)
+			var got []time.Duration
+			for v := range seq {
+				got = append(got, v)
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain: %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len mismatch", tc.name)
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case rb[complex64]:
+			msg := AppendArrayHeader(nil, uint32(len(tc.vals)))
+			for _, v := range tc.vals {
+				msg = tc.append(msg, v)
+			}
+			seq, tail := ReadArrayBytes[complex64](msg)
+			var got []complex64
+			for v := range seq {
+				got = append(got, v)
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain: %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len mismatch", tc.name)
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case rb[complex128]:
+			msg := AppendArrayHeader(nil, uint32(len(tc.vals)))
+			for _, v := range tc.vals {
+				msg = tc.append(msg, v)
+			}
+			seq, tail := ReadArrayBytes[complex128](msg)
+			var got []complex128
+			for v := range seq {
+				got = append(got, v)
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain: %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len mismatch", tc.name)
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+		case rb[testDec]:
+			msg := AppendArrayHeader(nil, uint32(len(tc.vals)))
+			for _, v := range tc.vals {
+				msg = tc.append(msg, v)
+			}
+			seq, tail := ReadArrayBytes[testDec](msg)
+			var got []testDec
+			for v := range seq {
+				got = append(got, v)
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain: %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.vals) {
+				t.Fatalf("%s len mismatch", tc.name)
+			}
+			for i := range got {
+				if !tc.eq(got[i], tc.vals[i]) {
+					t.Fatalf("%s[%d]: got %v want %v", tc.name, i, got[i], tc.vals[i])
+				}
+			}
+
+		}
+	}
+}
+
+func eqNum[T comparable](a, b T) bool { return a == b }
+
+func TestReadMap_AllNumberTypes_SameKeyValueTypes(t *testing.T) {
+	type numCase[T NumberTypes] struct {
+		name  string
+		keys  []T
+		vals  []T
+		write func(*Writer, T) error
+		eq    func(a, b T) bool
+	}
+	// Equality helpers
+	eqF32 := func(a, b float32) bool { return approxEqual(a, b) }
+	eqF64 := func(a, b float64) bool { return approxEqual(a, b) }
+
+	cases := []any{
+		numCase[uint]{name: "uint", keys: []uint{1, 2, 3}, vals: []uint{10, 20, 30}, write: func(w *Writer, v uint) error { return w.WriteUint(v) }, eq: eqNum[uint]},
+		numCase[uint8]{name: "uint8", keys: []uint8{1, 2, 255}, vals: []uint8{9, 8, 7}, write: func(w *Writer, v uint8) error { return w.WriteUint8(v) }, eq: eqNum[uint8]},
+		numCase[uint16]{name: "uint16", keys: []uint16{1, 300, 65535}, vals: []uint16{100, 200, 300}, write: func(w *Writer, v uint16) error { return w.WriteUint16(v) }, eq: eqNum[uint16]},
+		numCase[uint32]{name: "uint32", keys: []uint32{1, 1 << 20, 4000000000}, vals: []uint32{42, 43, 44}, write: func(w *Writer, v uint32) error { return w.WriteUint32(v) }, eq: eqNum[uint32]},
+		numCase[uint64]{name: "uint64", keys: []uint64{1, 1 << 40, 1<<50 + 123}, vals: []uint64{5, 6, 7}, write: func(w *Writer, v uint64) error { return w.WriteUint64(v) }, eq: eqNum[uint64]},
+		numCase[int]{name: "int", keys: []int{-1, 0, 2}, vals: []int{100, -100, 0}, write: func(w *Writer, v int) error { return w.WriteInt(v) }, eq: eqNum[int]},
+		numCase[int8]{name: "int8", keys: []int8{-128, 0, 127}, vals: []int8{1, -1, 0}, write: func(w *Writer, v int8) error { return w.WriteInt8(v) }, eq: eqNum[int8]},
+		numCase[int16]{name: "int16", keys: []int16{-32768, 0, 32767}, vals: []int16{2, -2, 3}, write: func(w *Writer, v int16) error { return w.WriteInt16(v) }, eq: eqNum[int16]},
+		numCase[int32]{name: "int32", keys: []int32{-1, 0, 1}, vals: []int32{7, 8, 9}, write: func(w *Writer, v int32) error { return w.WriteInt32(v) }, eq: eqNum[int32]},
+		numCase[int64]{name: "int64", keys: []int64{-1, 0, 1<<40 + 5}, vals: []int64{9, 8, 7}, write: func(w *Writer, v int64) error { return w.WriteInt64(v) }, eq: eqNum[int64]},
+		numCase[float32]{name: "float32", keys: []float32{-2.5, 0, 3.25}, vals: []float32{1.5, -0.25, 10}, write: func(w *Writer, v float32) error { return w.WriteFloat32(v) }, eq: eqF32},
+		numCase[float64]{name: "float64", keys: []float64{-2.5, 0, 3.25}, vals: []float64{1.5, -0.25, 10}, write: func(w *Writer, v float64) error { return w.WriteFloat64(v) }, eq: eqF64},
+	}
+
+	for _, anytc := range cases {
+		switch tc := anytc.(type) {
+		case numCase[uint]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.keys))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for i := range tc.keys {
+				if err := tc.write(w, tc.keys[i]); err != nil {
+					t.Fatalf("%s key write: %v", tc.name, err)
+				}
+				if err := tc.write(w, tc.vals[i]); err != nil {
+					t.Fatalf("%s val write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			seq, tail := ReadMap[uint, uint](r)
+			got := make(map[uint]uint, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			if err := tail(); err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size: got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v: got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[uint8]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.keys))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for i := range tc.keys {
+				if err := tc.write(w, tc.keys[i]); err != nil {
+					t.Fatalf("%s key write: %v", tc.name, err)
+				}
+				if err := tc.write(w, tc.vals[i]); err != nil {
+					t.Fatalf("%s val write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			seq, tail := ReadMap[uint8, uint8](r)
+			got := make(map[uint8]uint8, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			if err := tail(); err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size: got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v: got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[uint16]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.keys))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for i := range tc.keys {
+				if err := tc.write(w, tc.keys[i]); err != nil {
+					t.Fatalf("%s key write: %v", tc.name, err)
+				}
+				if err := tc.write(w, tc.vals[i]); err != nil {
+					t.Fatalf("%s val write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			seq, tail := ReadMap[uint16, uint16](r)
+			got := make(map[uint16]uint16, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			if err := tail(); err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size: got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v: got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[uint32]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.keys))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for i := range tc.keys {
+				if err := tc.write(w, tc.keys[i]); err != nil {
+					t.Fatalf("%s key write: %v", tc.name, err)
+				}
+				if err := tc.write(w, tc.vals[i]); err != nil {
+					t.Fatalf("%s val write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			seq, tail := ReadMap[uint32, uint32](r)
+			got := make(map[uint32]uint32, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			if err := tail(); err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size: got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v: got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[uint64]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.keys))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for i := range tc.keys {
+				if err := tc.write(w, tc.keys[i]); err != nil {
+					t.Fatalf("%s key write: %v", tc.name, err)
+				}
+				if err := tc.write(w, tc.vals[i]); err != nil {
+					t.Fatalf("%s val write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			seq, tail := ReadMap[uint64, uint64](r)
+			got := make(map[uint64]uint64, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			if err := tail(); err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size: got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v: got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[int]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.keys))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for i := range tc.keys {
+				if err := tc.write(w, tc.keys[i]); err != nil {
+					t.Fatalf("%s key write: %v", tc.name, err)
+				}
+				if err := tc.write(w, tc.vals[i]); err != nil {
+					t.Fatalf("%s val write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			seq, tail := ReadMap[int, int](r)
+			got := make(map[int]int, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			if err := tail(); err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size: got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v: got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[int8]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.keys))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for i := range tc.keys {
+				if err := tc.write(w, tc.keys[i]); err != nil {
+					t.Fatalf("%s key write: %v", tc.name, err)
+				}
+				if err := tc.write(w, tc.vals[i]); err != nil {
+					t.Fatalf("%s val write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			seq, tail := ReadMap[int8, int8](r)
+			got := make(map[int8]int8, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			if err := tail(); err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size: got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v: got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[int16]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.keys))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for i := range tc.keys {
+				if err := tc.write(w, tc.keys[i]); err != nil {
+					t.Fatalf("%s key write: %v", tc.name, err)
+				}
+				if err := tc.write(w, tc.vals[i]); err != nil {
+					t.Fatalf("%s val write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			seq, tail := ReadMap[int16, int16](r)
+			got := make(map[int16]int16, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			if err := tail(); err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size: got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v: got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[int32]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.keys))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for i := range tc.keys {
+				if err := tc.write(w, tc.keys[i]); err != nil {
+					t.Fatalf("%s key write: %v", tc.name, err)
+				}
+				if err := tc.write(w, tc.vals[i]); err != nil {
+					t.Fatalf("%s val write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			seq, tail := ReadMap[int32, int32](r)
+			got := make(map[int32]int32, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			if err := tail(); err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size: got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v: got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[int64]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.keys))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for i := range tc.keys {
+				if err := tc.write(w, tc.keys[i]); err != nil {
+					t.Fatalf("%s key write: %v", tc.name, err)
+				}
+				if err := tc.write(w, tc.vals[i]); err != nil {
+					t.Fatalf("%s val write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			seq, tail := ReadMap[int64, int64](r)
+			got := make(map[int64]int64, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			if err := tail(); err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size: got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v: got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[float32]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.keys))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for i := range tc.keys {
+				if err := tc.write(w, tc.keys[i]); err != nil {
+					t.Fatalf("%s key write: %v", tc.name, err)
+				}
+				if err := tc.write(w, tc.vals[i]); err != nil {
+					t.Fatalf("%s val write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			seq, tail := ReadMap[float32, float32](r)
+			got := make(map[float32]float32, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			if err := tail(); err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size: got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v: got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[float64]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.keys))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for i := range tc.keys {
+				if err := tc.write(w, tc.keys[i]); err != nil {
+					t.Fatalf("%s key write: %v", tc.name, err)
+				}
+				if err := tc.write(w, tc.vals[i]); err != nil {
+					t.Fatalf("%s val write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			seq, tail := ReadMap[float64, float64](r)
+			got := make(map[float64]float64, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			if err := tail(); err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size: got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v: got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		}
+	}
+}
+
+func TestReadMap_AllRegularTypes_SameKeyValueTypes(t *testing.T) {
+	type regCase[T any] struct {
+		name  string
+		keys  []T
+		vals  []T
+		write func(*Writer, T) error
+		eq    func(a, b T) bool
+	}
+	eqBool := func(a, b bool) bool { return a == b }
+	eqStr := func(a, b string) bool { return a == b }
+	eqBytes := func(a, b []byte) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i := range a {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+	eqTime := func(a, b time.Time) bool { return a.Equal(b) }
+	eqDur := func(a, b time.Duration) bool { return a == b }
+	eqC64 := func(a, b complex64) bool { return a == b }
+	eqC128 := func(a, b complex128) bool { return a == b }
+
+	now := time.Unix(1700000000, 123456789).UTC()
+	later := now.Add(123 * time.Second)
+
+	cases := []any{
+		regCase[bool]{name: "bool", keys: []bool{false, true}, vals: []bool{false, true, false}, write: func(w *Writer, v bool) error { return w.WriteBool(v) }, eq: eqBool},
+		regCase[string]{name: "string", keys: []string{"a", "b", "c"}, vals: []string{"x", "y", "z"}, write: func(w *Writer, v string) error { return w.WriteString(v) }, eq: eqStr},
+		// Note: []byte keys are not comparable in Go; we validate by pair matching instead of using a map.
+		regCase[[]byte]{name: "bytes", keys: [][]byte{{0x01}, {0x02, 0x03}, nil}, vals: [][]byte{{0x09}, {}, {0xFF}}, write: func(w *Writer, v []byte) error { return w.WriteBytes(v) }, eq: eqBytes},
+		regCase[time.Time]{name: "time", keys: []time.Time{now, later}, vals: []time.Time{later, now}, write: func(w *Writer, v time.Time) error { return w.WriteTime(v) }, eq: eqTime},
+		regCase[time.Duration]{name: "duration", keys: []time.Duration{0, time.Second, -5 * time.Millisecond}, vals: []time.Duration{time.Minute, -time.Second, 0}, write: func(w *Writer, v time.Duration) error { return w.WriteDuration(v) }, eq: eqDur},
+		regCase[complex64]{name: "complex64", keys: []complex64{1 + 2i, -3 + 4.5i, 0}, vals: []complex64{9 - 2i, 3 - 4.5i, 7}, write: func(w *Writer, v complex64) error { return w.WriteComplex64(v) }, eq: eqC64},
+		regCase[complex128]{name: "complex128", keys: []complex128{1 + 2i, -3 + 4.5i, 0}, vals: []complex128{9 - 2i, 3 - 4.5i, 7}, write: func(w *Writer, v complex128) error { return w.WriteComplex128(v) }, eq: eqC128},
+	}
+
+	for _, anytc := range cases {
+		switch tc := anytc.(type) {
+		case regCase[bool]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.keys))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for i := range tc.keys {
+				if err := tc.write(w, tc.keys[i]); err != nil {
+					t.Fatalf("%s key write: %v", tc.name, err)
+				}
+				if err := tc.write(w, tc.vals[i]); err != nil {
+					t.Fatalf("%s val write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			seq, tail := ReadMap[bool, bool](r)
+			got := make(map[bool]bool, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			if err := tail(); err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size mismatch", tc.name)
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s: key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case regCase[string]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.keys))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for i := range tc.keys {
+				if err := tc.write(w, tc.keys[i]); err != nil {
+					t.Fatalf("%s key write: %v", tc.name, err)
+				}
+				if err := tc.write(w, tc.vals[i]); err != nil {
+					t.Fatalf("%s val write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			seq, tail := ReadMap[string, string](r)
+			got := make(map[string]string, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			if err := tail(); err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size mismatch", tc.name)
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s: key %q got %q want %q", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case regCase[[]byte]:
+			// For []byte keys (not comparable), validate by pair presence.
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.keys))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for i := range tc.keys {
+				if err := tc.write(w, tc.keys[i]); err != nil {
+					t.Fatalf("%s key write: %v", tc.name, err)
+				}
+				if err := tc.write(w, tc.vals[i]); err != nil {
+					t.Fatalf("%s val write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+
+			type pair struct{ k, v []byte }
+			expected := make([]pair, len(tc.keys))
+			for i := range tc.keys {
+				expected[i] = pair{append([]byte(nil), tc.keys[i]...), append([]byte(nil), tc.vals[i]...)}
+			}
+
+			r := NewReader(&buf)
+			seq, tail := ReadMap[[]byte, []byte](r)
+			var got []pair
+			for k, v := range seq {
+				kk := append([]byte(nil), k...)
+				vv := append([]byte(nil), v...)
+				got = append(got, pair{kk, vv})
+			}
+			if err := tail(); err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(got) != len(expected) {
+				t.Fatalf("%s size mismatch got %d want %d", tc.name, len(got), len(expected))
+			}
+
+			// Match expected pairs
+			match := func(p pair, set []pair) bool {
+				for _, q := range set {
+					if eqBytes(p.k, q.k) && eqBytes(p.v, q.v) {
+						return true
+					}
+				}
+				return false
+			}
+			for _, p := range expected {
+				if !match(p, got) {
+					t.Fatalf("%s missing pair key=%v val=%v", tc.name, p.k, p.v)
+				}
+			}
+		case regCase[time.Time]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.keys))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for i := range tc.keys {
+				if err := tc.write(w, tc.keys[i]); err != nil {
+					t.Fatalf("%s key write: %v", tc.name, err)
+				}
+				if err := tc.write(w, tc.vals[i]); err != nil {
+					t.Fatalf("%s val write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			seq, tail := ReadMap[time.Time, time.Time](r)
+			got := make(map[time.Time]time.Time, len(tc.keys))
+			for k, v := range seq {
+				got[k.UTC()] = v.UTC()
+			}
+			if err := tail(); err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size mismatch", tc.name)
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s: key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case regCase[time.Duration]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.keys))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for i := range tc.keys {
+				if err := tc.write(w, tc.keys[i]); err != nil {
+					t.Fatalf("%s key write: %v", tc.name, err)
+				}
+				if err := tc.write(w, tc.vals[i]); err != nil {
+					t.Fatalf("%s val write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			seq, tail := ReadMap[time.Duration, time.Duration](r)
+			got := make(map[time.Duration]time.Duration, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			if err := tail(); err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(got) != len(tc.keys) {
+				t.Logf("got: %#v", got)
+				t.Fatalf("%s size mismatch", tc.name)
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s: key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case regCase[complex64]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.keys))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for i := range tc.keys {
+				if err := tc.write(w, tc.keys[i]); err != nil {
+					t.Fatalf("%s key write: %v", tc.name, err)
+				}
+				if err := tc.write(w, tc.vals[i]); err != nil {
+					t.Fatalf("%s val write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			seq, tail := ReadMap[complex64, complex64](r)
+			got := make(map[complex64]complex64, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			if err := tail(); err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size mismatch", tc.name)
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s: key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case regCase[complex128]:
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			if err := w.WriteArrayHeader(uint32(len(tc.keys))); err != nil {
+				t.Fatalf("hdr %s: %v", tc.name, err)
+			}
+			for i := range tc.keys {
+				if err := tc.write(w, tc.keys[i]); err != nil {
+					t.Fatalf("%s key write: %v", tc.name, err)
+				}
+				if err := tc.write(w, tc.vals[i]); err != nil {
+					t.Fatalf("%s val write: %v", tc.name, err)
+				}
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			r := NewReader(&buf)
+			seq, tail := ReadMap[complex128, complex128](r)
+			got := make(map[complex128]complex128, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			if err := tail(); err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size mismatch", tc.name)
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s: key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		}
+	}
+}
+
+func TestReadMapBytes_AllNumberTypes_SameKeyValueTypes(t *testing.T) {
+	type numCase[T NumberTypes] struct {
+		name   string
+		keys   []T
+		vals   []T
+		append func([]byte, T) []byte
+		eq     func(a, b T) bool
+	}
+
+	eqF32 := func(a, b float32) bool { return approxEqual(a, b) }
+	eqF64 := func(a, b float64) bool { return approxEqual(a, b) }
+
+	cases := []any{
+		numCase[uint]{name: "uint", keys: []uint{1, 2, 3}, vals: []uint{10, 20, 30}, append: AppendUint, eq: eqNum[uint]},
+		numCase[uint8]{name: "uint8", keys: []uint8{1, 2, 255}, vals: []uint8{9, 8, 7}, append: AppendUint8, eq: eqNum[uint8]},
+		numCase[uint16]{name: "uint16", keys: []uint16{1, 300, 65535}, vals: []uint16{100, 200, 300}, append: AppendUint16, eq: eqNum[uint16]},
+		numCase[uint32]{name: "uint32", keys: []uint32{1, 1 << 20, 4000000000}, vals: []uint32{42, 43, 44}, append: AppendUint32, eq: eqNum[uint32]},
+		numCase[uint64]{name: "uint64", keys: []uint64{1, 1 << 40, 1<<50 + 123}, vals: []uint64{5, 6, 7}, append: AppendUint64, eq: eqNum[uint64]},
+		numCase[int]{name: "int", keys: []int{-1, 0, 2}, vals: []int{100, -100, 0}, append: AppendInt, eq: eqNum[int]},
+		numCase[int8]{name: "int8", keys: []int8{-128, 0, 127}, vals: []int8{1, -1, 0}, append: AppendInt8, eq: eqNum[int8]},
+		numCase[int16]{name: "int16", keys: []int16{-32768, 0, 32767}, vals: []int16{2, -2, 3}, append: AppendInt16, eq: eqNum[int16]},
+		numCase[int32]{name: "int32", keys: []int32{-1, 0, 1}, vals: []int32{7, 8, 9}, append: AppendInt32, eq: eqNum[int32]},
+		numCase[int64]{name: "int64", keys: []int64{-1, 0, 1<<40 + 5}, vals: []int64{9, 8, 7}, append: AppendInt64, eq: eqNum[int64]},
+		numCase[float32]{name: "float32", keys: []float32{-2.5, 0, 3.25}, vals: []float32{1.5, -0.25, 10}, append: AppendFloat32, eq: eqF32},
+		numCase[float64]{name: "float64", keys: []float64{-2.5, 0, 3.25}, vals: []float64{1.5, -0.25, 10}, append: AppendFloat, eq: eqF64},
+	}
+
+	for _, anytc := range cases {
+		switch tc := anytc.(type) {
+		case numCase[uint]:
+			msg := AppendMapHeader(nil, uint32(len(tc.keys)))
+			for i := range tc.keys {
+				msg = tc.append(msg, tc.keys[i])
+				msg = tc.append(msg, tc.vals[i])
+			}
+			seq, tail := ReadMapBytes[uint, uint](msg)
+			got := make(map[uint]uint, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[uint8]:
+			msg := AppendMapHeader(nil, uint32(len(tc.keys)))
+			for i := range tc.keys {
+				msg = tc.append(msg, tc.keys[i])
+				msg = tc.append(msg, tc.vals[i])
+			}
+			seq, tail := ReadMapBytes[uint8, uint8](msg)
+			got := make(map[uint8]uint8, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[uint16]:
+			msg := AppendMapHeader(nil, uint32(len(tc.keys)))
+			for i := range tc.keys {
+				msg = tc.append(msg, tc.keys[i])
+				msg = tc.append(msg, tc.vals[i])
+			}
+			seq, tail := ReadMapBytes[uint16, uint16](msg)
+			got := make(map[uint16]uint16, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[uint32]:
+			msg := AppendMapHeader(nil, uint32(len(tc.keys)))
+			for i := range tc.keys {
+				msg = tc.append(msg, tc.keys[i])
+				msg = tc.append(msg, tc.vals[i])
+			}
+			seq, tail := ReadMapBytes[uint32, uint32](msg)
+			got := make(map[uint32]uint32, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[uint64]:
+			msg := AppendMapHeader(nil, uint32(len(tc.keys)))
+			for i := range tc.keys {
+				msg = tc.append(msg, tc.keys[i])
+				msg = tc.append(msg, tc.vals[i])
+			}
+			seq, tail := ReadMapBytes[uint64, uint64](msg)
+			got := make(map[uint64]uint64, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[int]:
+			msg := AppendMapHeader(nil, uint32(len(tc.keys)))
+			for i := range tc.keys {
+				msg = tc.append(msg, tc.keys[i])
+				msg = tc.append(msg, tc.vals[i])
+			}
+			seq, tail := ReadMapBytes[int, int](msg)
+			got := make(map[int]int, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[int8]:
+			msg := AppendMapHeader(nil, uint32(len(tc.keys)))
+			for i := range tc.keys {
+				msg = tc.append(msg, tc.keys[i])
+				msg = tc.append(msg, tc.vals[i])
+			}
+			seq, tail := ReadMapBytes[int8, int8](msg)
+			got := make(map[int8]int8, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[int16]:
+			msg := AppendMapHeader(nil, uint32(len(tc.keys)))
+			for i := range tc.keys {
+				msg = tc.append(msg, tc.keys[i])
+				msg = tc.append(msg, tc.vals[i])
+			}
+			seq, tail := ReadMapBytes[int16, int16](msg)
+			got := make(map[int16]int16, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[int32]:
+			msg := AppendMapHeader(nil, uint32(len(tc.keys)))
+			for i := range tc.keys {
+				msg = tc.append(msg, tc.keys[i])
+				msg = tc.append(msg, tc.vals[i])
+			}
+			seq, tail := ReadMapBytes[int32, int32](msg)
+			got := make(map[int32]int32, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[int64]:
+			msg := AppendMapHeader(nil, uint32(len(tc.keys)))
+			for i := range tc.keys {
+				msg = tc.append(msg, tc.keys[i])
+				msg = tc.append(msg, tc.vals[i])
+			}
+			seq, tail := ReadMapBytes[int64, int64](msg)
+			got := make(map[int64]int64, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[float32]:
+			msg := AppendMapHeader(nil, uint32(len(tc.keys)))
+			for i := range tc.keys {
+				msg = tc.append(msg, tc.keys[i])
+				msg = tc.append(msg, tc.vals[i])
+			}
+			seq, tail := ReadMapBytes[float32, float32](msg)
+			got := make(map[float32]float32, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case numCase[float64]:
+			msg := AppendMapHeader(nil, uint32(len(tc.keys)))
+			for i := range tc.keys {
+				msg = tc.append(msg, tc.keys[i])
+				msg = tc.append(msg, tc.vals[i])
+			}
+			seq, tail := ReadMapBytes[float64, float64](msg)
+			got := make(map[float64]float64, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size got %d want %d", tc.name, len(got), len(tc.keys))
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		}
+	}
+}
+
+func TestReadMapBytes_AllRegularTypes_SameKeyValueTypes(t *testing.T) {
+	type regCase[T any] struct {
+		name   string
+		keys   []T
+		vals   []T
+		append func([]byte, T) []byte
+		eq     func(a, b T) bool
+	}
+
+	eqBool := func(a, b bool) bool { return a == b }
+	eqStr := func(a, b string) bool { return a == b }
+	eqBytes := func(a, b []byte) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i := range a {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+	eqTime := func(a, b time.Time) bool { return a.Equal(b) }
+	eqDur := func(a, b time.Duration) bool { return a == b }
+	eqC64 := func(a, b complex64) bool { return a == b }
+	eqC128 := func(a, b complex128) bool { return a == b }
+
+	now := time.Unix(1700000000, 123456789).UTC()
+	later := now.Add(99 * time.Second)
+
+	cases := []any{
+		regCase[bool]{name: "bool", keys: []bool{false, true}, vals: []bool{false, true}, append: AppendBool, eq: eqBool},
+		regCase[string]{name: "string", keys: []string{"a", "b", "c"}, vals: []string{"x", "y", "z"}, append: AppendString, eq: eqStr},
+		regCase[[]byte]{name: "bytes", keys: [][]byte{{0x01}, {0x02, 0x03}, nil}, vals: [][]byte{{0x09}, {}, {0xFF}}, append: AppendBytes, eq: eqBytes},
+		regCase[time.Time]{name: "time", keys: []time.Time{now, later}, vals: []time.Time{later, now}, append: AppendTime, eq: eqTime},
+		regCase[time.Duration]{name: "duration", keys: []time.Duration{0, time.Second, -5 * time.Millisecond}, vals: []time.Duration{time.Minute, -time.Second, 0}, append: AppendDuration, eq: eqDur},
+		regCase[complex64]{name: "complex64", keys: []complex64{1 + 2i, -3 + 4.5i, 0}, vals: []complex64{9 - 2i, 3 - 4.5i, 7}, append: AppendComplex64, eq: eqC64},
+		regCase[complex128]{name: "complex128", keys: []complex128{1 + 2i, -3 + 4.5i, 0}, vals: []complex128{9 - 2i, 3 - 4.5i, 7}, append: AppendComplex128, eq: eqC128},
+	}
+
+	for _, anytc := range cases {
+		switch tc := anytc.(type) {
+		case regCase[bool]:
+			msg := AppendMapHeader(nil, uint32(len(tc.keys)))
+			for i := range tc.keys {
+				msg = tc.append(msg, tc.keys[i])
+				msg = tc.append(msg, tc.vals[i])
+			}
+			seq, tail := ReadMapBytes[bool, bool](msg)
+			got := make(map[bool]bool, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size mismatch", tc.name)
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case regCase[string]:
+			msg := AppendMapHeader(nil, uint32(len(tc.keys)))
+			for i := range tc.keys {
+				msg = tc.append(msg, tc.keys[i])
+				msg = tc.append(msg, tc.vals[i])
+			}
+			seq, tail := ReadMapBytes[string, string](msg)
+			got := make(map[string]string, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size mismatch", tc.name)
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %q got %q want %q", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case regCase[[]byte]:
+			// For []byte keys (not comparable), validate by pair presence.
+			type pair struct{ k, v []byte }
+			msg := AppendMapHeader(nil, uint32(len(tc.keys)))
+			for i := range tc.keys {
+				msg = tc.append(msg, append([]byte(nil), tc.keys[i]...))
+				msg = tc.append(msg, append([]byte(nil), tc.vals[i]...))
+			}
+			expected := make([]pair, len(tc.keys))
+			for i := range tc.keys {
+				expected[i] = pair{append([]byte(nil), tc.keys[i]...), append([]byte(nil), tc.vals[i]...)}
+			}
+
+			seq, tail := ReadMapBytes[[]byte, []byte](msg)
+			var got []pair
+			for k, v := range seq {
+				kk := append([]byte(nil), k...)
+				vv := append([]byte(nil), v...)
+				got = append(got, pair{kk, vv})
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain %d", tc.name, len(remain))
+			}
+			if len(got) != len(expected) {
+				t.Fatalf("%s count got %d want %d", tc.name, len(got), len(expected))
+			}
+			match := func(p pair, set []pair) bool {
+				for _, q := range set {
+					if eqBytes(p.k, q.k) && eqBytes(p.v, q.v) {
+						return true
+					}
+				}
+				return false
+			}
+			for _, p := range expected {
+				if !match(p, got) {
+					t.Fatalf("%s missing pair key=%v val=%v", tc.name, p.k, p.v)
+				}
+			}
+		case regCase[time.Time]:
+			msg := AppendMapHeader(nil, uint32(len(tc.keys)))
+			for i := range tc.keys {
+				msg = tc.append(msg, tc.keys[i])
+				msg = tc.append(msg, tc.vals[i])
+			}
+			seq, tail := ReadMapBytes[time.Time, time.Time](msg)
+			got := make(map[time.Time]time.Time, len(tc.keys))
+			for k, v := range seq {
+				got[k.UTC()] = v.UTC()
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size mismatch", tc.name)
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case regCase[time.Duration]:
+			msg := AppendMapHeader(nil, uint32(len(tc.keys)))
+			for i := range tc.keys {
+				msg = tc.append(msg, tc.keys[i])
+				msg = tc.append(msg, tc.vals[i])
+			}
+			seq, tail := ReadMapBytes[time.Duration, time.Duration](msg)
+			got := make(map[time.Duration]time.Duration, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size mismatch", tc.name)
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case regCase[complex64]:
+			msg := AppendMapHeader(nil, uint32(len(tc.keys)))
+			for i := range tc.keys {
+				msg = tc.append(msg, tc.keys[i])
+				msg = tc.append(msg, tc.vals[i])
+			}
+			seq, tail := ReadMapBytes[complex64, complex64](msg)
+			got := make(map[complex64]complex64, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size mismatch", tc.name)
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		case regCase[complex128]:
+			msg := AppendMapHeader(nil, uint32(len(tc.keys)))
+			for i := range tc.keys {
+				msg = tc.append(msg, tc.keys[i])
+				msg = tc.append(msg, tc.vals[i])
+			}
+			seq, tail := ReadMapBytes[complex128, complex128](msg)
+			got := make(map[complex128]complex128, len(tc.keys))
+			for k, v := range seq {
+				got[k] = v
+			}
+			remain, err := tail()
+			if err != nil {
+				t.Fatalf("%s tail: %v", tc.name, err)
+			}
+			if len(remain) != 0 {
+				t.Fatalf("%s remain %d", tc.name, len(remain))
+			}
+			if len(got) != len(tc.keys) {
+				t.Fatalf("%s size mismatch", tc.name)
+			}
+			for i := range tc.keys {
+				if !tc.eq(got[tc.keys[i]], tc.vals[i]) {
+					t.Fatalf("%s key %v got %v want %v", tc.name, tc.keys[i], got[tc.keys[i]], tc.vals[i])
+				}
+			}
+		}
+	}
+}
+
+func TestReadMapBytes_TailErrorOnTruncated(t *testing.T) {
+	// Prepare a map with 2 entries: {1: 10, 2: 20}
+	// Then truncate after encoding the second key to induce an error while reading the second value.
+	msg := AppendMapHeader(nil, 2)
+	msg = AppendInt(msg, 1)
+	msg = AppendInt(msg, 10)
+	msg = AppendInt(msg, 2)
+	full := AppendInt(msg, 20)
+	trunc := full[:len(full)-2] // truncate some bytes from the last value
+
+	seq, tail := ReadMapBytes[int, int](trunc)
+	got := make(map[int]int)
+	for k, v := range seq {
+		got[k] = v
+	}
+	// We expect only the first pair to be read
+	if len(got) != 1 || got[1] != 10 {
+		t.Fatalf("expected only first pair (1:10), got %v", got)
+	}
+	remain, err := tail()
+	if err == nil {
+		t.Fatalf("expected tail error due to truncation")
+	}
+	_ = remain // remaining bytes content is not strictly asserted here
+}

--- a/msgp/read.go
+++ b/msgp/read.go
@@ -582,7 +582,7 @@ func (m *Reader) ReadFloat64() (f float64, err error) {
 	var p []byte
 	p, err = m.R.Peek(9)
 	if err != nil {
-		// we'll allow a coversion from float32 to float64,
+		// we'll allow a conversion from float32 to float64,
 		// since we don't lose any precision
 		if err == io.EOF && len(p) > 0 && p[0] == mfloat32 {
 			ef, err := m.ReadFloat32()


### PR DESCRIPTION
Allows to receive iterators for arrays or maps, so inputs can be directly iterated over.

New functions in msgp:

```go
// ReadArray returns an iterator that can be used to iterate over the elements
// of an array in the MessagePack data while being read by the provided Reader.
// The type parameter V specifies the type of the elements in the array.
// The returned iterator implements the iter.Seq[V] interface,
// allowing for sequential access to the array elements.
func ReadArray[T any](m *Reader, readFn func() (T, error)) iter.Seq2[T, error]

// WriteArray writes an array to the provided Writer.
// The writeFn parameter specifies the function to use to write each element of the array.
func WriteArray[T any](w *Writer, a []T, writeFn func(T) error) error

// ReadMap returns an iterator that can be used to iterate over the elements
// of a map in the MessagePack data while being read by the provided Reader.
// The type parameters K and V specify the types of the keys and values in the map.
// The returned iterator implements the iter.Seq2[K, V] interface,
// allowing for sequential access to the map elements.
// The returned function can be used to read any error that
// occurred during iteration when iteration is done.
func ReadMap[K, V any](m *Reader, readKey func() (K, error), readVal func() (V, error)) (iter.Seq2[K, V], func() error)

// WriteMap writes a map to the provided Writer.
// The writeKey and writeVal parameters specify the functions
// to use to write each key and value of the map.
func WriteMap[K comparable, V any](w *Writer, m map[K]V, writeKey func(K) error, writeVal func(V) error) error

// WriteMapSorted writes a map to the provided Writer.
// The keys of the map are sorted before writing.
// This provides deterministic output, but will allocate to sort the keys.
// The writeKey and writeVal parameters specify the functions
// to use to write each key and value of the map.
func WriteMapSorted[K cmp.Ordered, V any](w *Writer, m map[K]V, writeKey func(K) error, writeVal func(V) error) error 

// ReadArrayBytes returns an iterator that can be used to iterate over the elements
// of an array in the MessagePack data while being read by the provided Reader.
// The type parameter V specifies the type of the elements in the array.
// After the iterator is exhausted, the remaining bytes in the buffer
// and any error can be read by calling the returned function.
func ReadArrayBytes[T any](b []byte, readFn func([]byte) (T, []byte, error)) (iter.Seq[T], func() (remain []byte, err error))

// AppendArray writes an array to the provided buffer.
// The writeFn parameter specifies the function to use to write each element of the array.
// The returned buffer contains the encoded array.
// The function panics if the array is larger than math.MaxUint32 elements.
func AppendArray[T any](b []byte, a []T, writeFn func(b []byte, v T) []byte) []byte

// ReadMapBytes returns an iterator over key/value
// pairs from a MessagePack map encoded in b.
// The iterator yields K,V pairs, and this function also returns
// a closure to get the remaining bytes and any error.
func ReadMapBytes[K any, V any](b []byte,
	readK func([]byte) (K, []byte, error),
	readV func([]byte) (V, []byte, error)) (iter.Seq2[K, V], func() (remain []byte, err error))


// AppendMap writes a map to the provided buffer.
// The writeK and writeV parameters specify the functions to use to write each key and value of the map.
// The returned buffer contains the encoded map.
// The function panics if the map is larger than math.MaxUint32 elements.
func AppendMap[K comparable, V any](b []byte, m map[K]V,
	writeK func(b []byte, k K) []byte,
	writeV func(b []byte, v V) []byte) []byte

// AppendMapSorted writes a map to the provided buffer.
// Keys are sorted before writing.
// This provides deterministic output, but will allocate to sort the keys.
// The writeK and writeV parameters specify the functions to use to write each key and value of the map.
// The returned buffer contains the encoded map.
// The function panics if the map is larger than math.MaxUint32 elements.
func AppendMapSorted[K cmp.Ordered, V any](b []byte, m map[K]V,
	writeK func(b []byte, k K) []byte,
	writeV func(b []byte, v V) []byte) []byte

// DecoderFrom allows augmenting any type with a DecodeMsg method into a method
// that reads from Reader and returns a T.
// Provide an instance of T. This value isn't used.
// See ReadArray/ReadMap "struct" examples for usage.
func DecoderFrom[T any, PT DecodePtr[T]](r *Reader, _ T) func() (T, error)

// DecoderFromBytes allows augmenting any type with an UnmarshalMsg
// method into a method that reads from []byte and returns a T.
// Provide an instance of T. This value isn't used.
// See ReadArrayBytes or ReadMapBytes "struct" examples for usage.
func DecoderFromBytes[T any, PT UnmarshalPtr[T]](_ T) func([]byte) (T, []byte, error) 

// EncoderTo allows augmenting any type with an EncodeMsg
// method into a method that writes to Writer on each call.
// Provide an instance of T. This value isn't used.
// See ReadArray or ReadMap "struct" examples for usage.
func EncoderTo[T any, _ FlexibleEncoder[T]](w *Writer, _ T) func(T) error 

// EncoderToBytes allows augmenting any type with a MarshalMsg method into a method
// that reads from T and returns a []byte.
// Provide an instance of T. This value isn't used.
// See ReadArrayBytes or ReadMapBytes "struct" examples for usage.
func EncoderToBytes[T any, _ FlexibleMarshaler[T]](_ T) func([]byte, T) []byte
```

Examples included in godoc.