### PR TITLE
msgp: fuzz test: fix overflow on 32-bit systems

### DIFF
--- a/msgp/read.go
+++ b/msgp/read.go
@@ -175,7 +175,7 @@ func (m *Reader) CopyNext(w io.Writer) (int64, error) {
 	// Opportunistic optimization: if we can fit the whole thing in the m.R
 	// buffer, then just get a pointer to that, and pass it to w.Write,
 	// avoiding an allocation.
-	if int(sz) <= m.R.BufferSize() {
+	if int(sz) >= 0 && int(sz) <= m.R.BufferSize() {
 		var nn int
 		var buf []byte
 		buf, err = m.R.Next(int(sz))


### PR DESCRIPTION
On 32-bit systems, int(sz) can yield a negative value, which in turn leads to us passing a negative value to fwd.Reader.Next. (See https://github.com/philhofer/fwd/issues/36.)

The simplest fix here is just to check that the conversion doesn't yield a negative value.