### PR TITLE
remove redundant // +build directives

### DIFF
--- a/msgp/advise_linux.go
+++ b/msgp/advise_linux.go
@@ -1,5 +1,4 @@
 //go:build linux && !appengine && !tinygo
-// +build linux,!appengine,!tinygo
 
 package msgp
 

--- a/msgp/advise_other.go
+++ b/msgp/advise_other.go
@@ -1,5 +1,4 @@
 //go:build (!linux && !tinygo && !windows) || appengine
-// +build !linux,!tinygo,!windows appengine
 
 package msgp
 

--- a/msgp/elsize_default.go
+++ b/msgp/elsize_default.go
@@ -1,5 +1,4 @@
 //go:build !tinygo
-// +build !tinygo
 
 package msgp
 

--- a/msgp/elsize_tinygo.go
+++ b/msgp/elsize_tinygo.go
@@ -1,5 +1,4 @@
 //go:build tinygo
-// +build tinygo
 
 package msgp
 

--- a/msgp/errors_default.go
+++ b/msgp/errors_default.go
@@ -1,5 +1,4 @@
 //go:build !tinygo
-// +build !tinygo
 
 package msgp
 

--- a/msgp/errors_tinygo.go
+++ b/msgp/errors_tinygo.go
@@ -1,5 +1,4 @@
 //go:build tinygo
-// +build tinygo
 
 package msgp
 

--- a/msgp/file.go
+++ b/msgp/file.go
@@ -1,7 +1,4 @@
 //go:build (linux || darwin || dragonfly || freebsd || illumos || netbsd || openbsd) && !appengine && !tinygo
-// +build linux darwin dragonfly freebsd illumos netbsd openbsd
-// +build !appengine
-// +build !tinygo
 
 package msgp
 

--- a/msgp/file_port.go
+++ b/msgp/file_port.go
@@ -1,5 +1,4 @@
 //go:build windows || appengine || tinygo
-// +build windows appengine tinygo
 
 package msgp
 

--- a/msgp/file_test.go
+++ b/msgp/file_test.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin || dragonfly || freebsd || illumos || netbsd || openbsd
-// +build linux darwin dragonfly freebsd illumos netbsd openbsd
 
 package msgp_test
 

--- a/msgp/purego.go
+++ b/msgp/purego.go
@@ -1,5 +1,4 @@
 //go:build (purego && !unsafe) || appengine
-// +build purego,!unsafe appengine
 
 package msgp
 

--- a/msgp/unsafe.go
+++ b/msgp/unsafe.go
@@ -1,5 +1,4 @@
 //go:build (!purego && !appengine) || (!appengine && purego && unsafe)
-// +build !purego,!appengine !appengine,purego,unsafe
 
 package msgp
 


### PR DESCRIPTION
This PR removes redundant `// +build` directives. From https://pkg.go.dev/cmd/go@go1.23.0#hdr-Build_constraints:

> Go versions 1.16 and earlier used a different syntax for build constraints, with a "// +build" prefix. The gofmt command will add an equivalent //go:build constraint when encountering the older syntax.

Also see https://pkg.go.dev/golang.org/x/tools@v0.39.0/go/analysis/passes/buildtag.