### PR TITLE
Update fuzz tests plus minor fixes

### DIFF
--- a/msgp/fuzz_test.go
+++ b/msgp/fuzz_test.go
@@ -117,6 +117,21 @@ func FuzzReader(f *testing.F) {
 		reset()
 		r.ReadUint8()
 		reset()
+		r.ReadBinaryUnmarshal(encodingReader{})
+		reset()
+		r.ReadTextUnmarshal(encodingReader{})
+		reset()
+		r.ReadTextUnmarshalString(encodingReader{})
+		reset()
+		for range ReadArray(r, r.ReadInt) {
+		}
+		reset()
+		iter, errfn := ReadMap(r, r.ReadString, r.ReadUint64)
+		for range iter {
+		}
+		errfn()
+		reset()
+
 		r.Skip()
 		reset()
 
@@ -170,6 +185,14 @@ func FuzzReadBytes(f *testing.F) {
 		ReadUint64Bytes(data)
 		ReadUintBytes(data)
 		UnmarshalAsJSON(io.Discard, data)
+		iter, errfn := ReadArrayBytes(data, ReadIntBytes)
+		for range iter {
+		}
+		errfn()
+		iter2, errfn2 := ReadMapBytes(data, ReadStringBytes, ReadUint64Bytes)
+		for range iter2 {
+		}
+		errfn2()
 		Skip(data)
 	})
 }
@@ -305,4 +328,14 @@ func parseCorpusValue(line []byte) ([]byte, error) {
 		return []byte(s), nil
 	}
 	return nil, fmt.Errorf("expected []byte")
+}
+
+type encodingReader struct{}
+
+func (e encodingReader) UnmarshalBinary(data []byte) error {
+	return nil
+}
+
+func (e encodingReader) UnmarshalText(data []byte) error {
+	return nil
 }

--- a/msgp/iter.go
+++ b/msgp/iter.go
@@ -14,6 +14,7 @@ import (
 // The type parameter V specifies the type of the elements in the array.
 // The returned iterator implements the iter.Seq[V] interface,
 // allowing for sequential access to the array elements.
+// The iterator will always stop after one error has been encountered.
 func ReadArray[T any](m *Reader, readFn func() (T, error)) iter.Seq2[T, error] {
 	return func(yield func(T, error) bool) {
 		// Check if nil
@@ -31,7 +32,7 @@ func ReadArray[T any](m *Reader, readFn func() (T, error)) iter.Seq2[T, error] {
 		for range length {
 			var v T
 			v, err = readFn()
-			if !yield(v, err) {
+			if !yield(v, err) || err != nil {
 				return
 			}
 		}

--- a/msgp/read.go
+++ b/msgp/read.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"io"
 	"math"
 	"strconv"
@@ -1571,6 +1572,11 @@ func (m *Reader) ReadIntf() (i any, err error) {
 
 // ReadBinaryUnmarshal reads a binary-encoded object from the reader and unmarshals it into dst.
 func (m *Reader) ReadBinaryUnmarshal(dst encoding.BinaryUnmarshaler) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("msgp: panic during UnmarshalBinary: %v", r)
+		}
+	}()
 	tmp := bytesPool.Get().([]byte)
 	defer bytesPool.Put(tmp) //nolint:staticcheck
 	tmp, err = m.ReadBytes(tmp[:0])
@@ -1582,6 +1588,11 @@ func (m *Reader) ReadBinaryUnmarshal(dst encoding.BinaryUnmarshaler) (err error)
 
 // ReadTextUnmarshal reads a text-encoded bin array from the reader and unmarshals it into dst.
 func (m *Reader) ReadTextUnmarshal(dst encoding.TextUnmarshaler) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("msgp: panic during UnmarshalText: %v", r)
+		}
+	}()
 	tmp := bytesPool.Get().([]byte)
 	defer bytesPool.Put(tmp) //nolint:staticcheck
 	tmp, err = m.ReadBytes(tmp[:0])
@@ -1593,6 +1604,11 @@ func (m *Reader) ReadTextUnmarshal(dst encoding.TextUnmarshaler) (err error) {
 
 // ReadTextUnmarshalString reads a text-encoded string from the reader and unmarshals it into dst.
 func (m *Reader) ReadTextUnmarshalString(dst encoding.TextUnmarshaler) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("msgp: panic during UnmarshalText: %v", r)
+		}
+	}()
 	tmp := bytesPool.Get().([]byte)
 	defer bytesPool.Put(tmp) //nolint:staticcheck
 	tmp, err = m.ReadStringAsBytes(tmp[:0])


### PR DESCRIPTION
Decided to make ReadArray always stop after an error. There is a too high risk of running into an infinite loop.

Added size checks for (Writer.)WriteBytes/WriteString/WriteStringFromBytes

Add panic recovery to binary marshal helpers.