### PR TITLE
Add (Reader).ReadBytesLimit

### DIFF
--- a/_generated/limits_test.go
+++ b/_generated/limits_test.go
@@ -2,6 +2,7 @@ package _generated
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -1045,7 +1046,7 @@ func TestAllowNilSecurityLimits(t *testing.T) {
 
 		reader := msgp.NewReader(bytes.NewReader(buf))
 		err := data.DecodeMsg(reader)
-		if err != msgp.ErrLimitExceeded {
+		if !errors.Is(err, msgp.ErrLimitExceeded) {
 			t.Errorf("Expected ErrLimitExceeded for allownil bytes exceeding limit, got %v", err)
 		}
 	})
@@ -1160,7 +1161,7 @@ func TestAllowNilSecurityLimits(t *testing.T) {
 
 		reader := msgp.NewReader(bytes.NewReader(buf))
 		err := data.DecodeMsg(reader)
-		if err != msgp.ErrLimitExceeded {
+		if !errors.Is(err, msgp.ErrLimitExceeded) {
 			t.Errorf("Expected ErrLimitExceeded (header-first check), got %v", err)
 		}
 	})
@@ -1361,7 +1362,7 @@ func TestAllowNilZeroCopy(t *testing.T) {
 
 		reader := msgp.NewReader(bytes.NewReader(buf))
 		err := data.DecodeMsg(reader)
-		if err != msgp.ErrLimitExceeded {
+		if !errors.Is(err, msgp.ErrLimitExceeded) {
 			t.Errorf("Expected ErrLimitExceeded for zerocopy allownil field exceeding limit, got %v", err)
 		}
 	})
@@ -1379,7 +1380,7 @@ func TestAllowNilZeroCopy(t *testing.T) {
 
 		reader := msgp.NewReader(bytes.NewReader(buf))
 		err := data.DecodeMsg(reader)
-		if err != msgp.ErrLimitExceeded {
+		if !errors.Is(err, msgp.ErrLimitExceeded) {
 			t.Errorf("Expected ErrLimitExceeded (header-first check) for zerocopy allownil, got %v", err)
 		}
 	})

--- a/msgp/read.go
+++ b/msgp/read.go
@@ -1009,6 +1009,63 @@ func (m *Reader) ReadBytes(scratch []byte) (b []byte, err error) {
 	return
 }
 
+// ReadBytesLimit reads a MessagePack 'bin' object
+// from the reader and returns its value. It may
+// use 'scratch' for storage if it is non-nil.
+// If n >= 0 this will be the maximum bytes read.
+// If n < 0, the cap(scratch) will be the limit.
+// If SetMaxElements has been used on the Reader,
+// that will only be checked if the scratch is too small.
+func (m *Reader) ReadBytesLimit(scratch []byte, n int64) (b []byte, err error) {
+	var p []byte
+	var lead byte
+	p, err = m.R.Peek(2)
+	if err != nil {
+		return
+	}
+	lead = p[0]
+	var read int64
+	switch lead {
+	case mbin8:
+		read = int64(p[1])
+		m.R.Skip(2)
+	case mbin16:
+		p, err = m.R.Next(3)
+		if err != nil {
+			return
+		}
+		read = int64(big.Uint16(p[1:]))
+	case mbin32:
+		p, err = m.R.Next(5)
+		if err != nil {
+			return
+		}
+		read = int64(big.Uint32(p[1:]))
+	default:
+		err = badPrefix(BinType, lead)
+		return
+	}
+	if n < 0 {
+		n = int64(cap(scratch))
+	}
+	fmt.Println(n, read)
+	if read > n {
+		err = ErrLimitExceeded
+		return
+	}
+	if int64(cap(scratch)) < read {
+		b = make([]byte, read)
+		if read > int64(m.GetMaxElements()) {
+			err = ErrLimitExceeded
+			return
+		}
+	} else {
+		b = scratch[0:read]
+	}
+	_, err = m.R.ReadFull(b)
+	return
+}
+
 // ReadBytesHeader reads the size header
 // of a MessagePack 'bin' object. The user
 // is responsible for dealing with the next


### PR DESCRIPTION
Simplifies generated code.

Fixes https://github.com/tinylib/msgp/issues/425

Modify a few tests to allow wrapped errors.