### PR TITLE
Use safer clearomitted zeroing

### DIFF
--- a/_generated/clearomitted.go
+++ b/_generated/clearomitted.go
@@ -33,8 +33,8 @@ type ClearOmitted0 struct {
 	Adur                time.Duration                      `msg:"adur,omitempty"`
 	AJSON               json.Number                        `msg:"ajson,omitempty"`
 	AnAny               any                                `msg:"anany,omitempty"`
-
-	ClearOmittedTuple ClearOmittedTuple `msg:"ozt"` // the inside of a tuple should ignore both omitempty and omitzero
+	ExtType             Numberwang                         `msg:"extType,omitempty"` // External type that is primitive.
+	ClearOmittedTuple   ClearOmittedTuple                  `msg:"ozt"`               // the inside of a tuple should ignore both omitempty and omitzero
 }
 
 type ClearOmittedA struct {

--- a/gen/decode.go
+++ b/gen/decode.go
@@ -316,7 +316,7 @@ func (d *decodeGen) structAsMap(s *Struct) {
 			if fze != "" {
 				d.p.printf("%s = %s\n", fieldElem.Varname(), fze)
 			} else {
-				d.p.printf("%s = %s{}\n", fieldElem.Varname(), fieldElem.TypeName())
+				d.p.printf("var tmp %s\n%s = tmp\n", fieldElem.TypeName(), fieldElem.Varname())
 			}
 			d.p.printf("}\n")
 		}

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -376,7 +376,7 @@ func (u *unmarshalGen) mapstruct(s *Struct) {
 			if fze != "" {
 				u.p.printf("%s = %s\n", fieldElem.Varname(), fze)
 			} else {
-				u.p.printf("%s = %s{}\n", fieldElem.Varname(), fieldElem.TypeName())
+				u.p.printf("var tmp %s\n%s = tmp\n", fieldElem.TypeName(), fieldElem.Varname())
 			}
 			u.p.printf("}\n")
 		}


### PR DESCRIPTION
For external types that are a primitive the `field = X{}` will cause a compiler error. While this can be worked around with `msgp:replace X uint8` for example that is a bit annoying.

Instead use `var tmp X; field = tmp` for types we know aren't primitives.

Codegen before/after:

```go
	if (zb0001Mask & 0x80000) == 0 {
		z.ExtType = Numberwang{}
	}

	if (zb0001Mask & 0x80000) == 0 {
		var tmp Numberwang
		z.ExtType = tmp
	}
```

`type Numberwang int8` defined externally.