### PR TITLE
msgp: Reader: reset limits on cached readers

### DIFF
--- a/msgp/read.go
+++ b/msgp/read.go
@@ -121,6 +121,10 @@ func Decode(r io.Reader, d Decodable) error {
 // reader will be buffered.
 func NewReader(r io.Reader) *Reader {
 	p := readerPool.Get().(*Reader)
+	p.recursionDepth = 0
+	p.maxElements = 0
+	p.maxRecursionDepth = 0
+	p.maxStrLen = 0
 	if p.R == nil {
 		p.R = fwd.NewReader(r)
 	} else {


### PR DESCRIPTION
A hand-written implementation of DecodeMsg may adjust the reader limits inside msgp.CopyToJSON, msgp.Decode, and so forth. Ensure that a Reader pulled from the pool has the same limits (zeros) every time.