### PR TITLE
Add support for aliases on tags

### DIFF
--- a/_generated/alias.go
+++ b/_generated/alias.go
@@ -1,0 +1,21 @@
+package _generated
+
+//go:generate msgp
+
+type AliasedFieldsV3 struct {
+	CurrentName string `msg:"newname,alias=name"`
+	MultiAlias  int    `msg:"key3,alias=key2;key1"`
+	NoAlias     bool   `msg:"no_alias"`
+}
+
+type AliasedFieldsV2 struct {
+	CurrentName string `msg:"newname,alias=name"`
+	MultiAlias  int    `msg:"key2,alias=key1"`
+	NoAlias     bool   `msg:"no_alias"`
+}
+
+type AliasedFieldsV1 struct {
+	CurrentName string `msg:"name"`
+	MultiAlias  int    `msg:"key1"`
+	NoAlias     bool   `msg:"no_alias"`
+}

--- a/_generated/alias_test.go
+++ b/_generated/alias_test.go
@@ -1,0 +1,97 @@
+package _generated
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestAliasUnmarshal(t *testing.T) {
+	v1 := AliasedFieldsV1{
+		CurrentName: "v1",
+		MultiAlias:  1,
+		NoAlias:     true,
+	}
+	v1Marshalled, err := v1.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v2 := AliasedFieldsV2{
+		CurrentName: "v2",
+		MultiAlias:  2,
+		NoAlias:     true,
+	}
+	v2Marshalled, err := v2.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v3 := AliasedFieldsV3{
+		CurrentName: "v3",
+		MultiAlias:  3,
+		NoAlias:     true,
+	}
+	v3Marshalled, err := v3.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type deserializer interface {
+		msgp.Unmarshaler
+		msgp.Decodable
+	}
+	unmarshal := func(t testing.TB, unmarshaler deserializer, bts []byte) {
+		t.Helper()
+
+		remainingBytes, err := unmarshaler.UnmarshalMsg(bts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(remainingBytes) > 0 {
+			t.Fatal("unexpected remaining bytes")
+		}
+	}
+	decode := func(t testing.TB, decoder deserializer, bts []byte) {
+		t.Helper()
+
+		reader := msgp.NewReader(bytes.NewReader(bts))
+		err := decoder.DecodeMsg(reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if reader.Buffered() != 0 {
+			t.Fatal("unexpected remaining bytes")
+		}
+	}
+
+	for _, deserializeFn := range []func(testing.TB, deserializer, []byte){unmarshal, decode} {
+		t.Run("v3 with aliases supports all", func(t *testing.T) {
+			var v3Res AliasedFieldsV3
+			deserializeFn(t, &v3Res, v1Marshalled)
+			if v3Res.CurrentName != v1.CurrentName || v3Res.MultiAlias != v1.MultiAlias || v3Res.NoAlias != v1.NoAlias {
+				t.Fatalf("mismatch: %+v != %+v", v3Res, v1)
+			}
+
+			deserializeFn(t, &v3Res, v2Marshalled)
+			if v3Res.CurrentName != v2.CurrentName || v3Res.MultiAlias != v2.MultiAlias || v3Res.NoAlias != v2.NoAlias {
+				t.Fatalf("mismatch: %+v != %+v", v3Res, v1)
+			}
+
+			deserializeFn(t, &v3Res, v3Marshalled)
+			if v3Res.CurrentName != v3.CurrentName || v3Res.MultiAlias != v3.MultiAlias || v3Res.NoAlias != v3.NoAlias {
+				t.Fatalf("mismatch: %+v != %+v", v3Res, v1)
+			}
+		})
+
+		t.Run("v2 supports v1", func(t *testing.T) {
+			var v2Res AliasedFieldsV2
+			deserializeFn(t, &v2Res, v1Marshalled)
+			if v2Res.CurrentName != v1.CurrentName || v2Res.MultiAlias != v1.MultiAlias || v2Res.NoAlias != v1.NoAlias {
+				t.Fatalf("mismatch: %+v != %+v", v2Res, v1)
+			}
+		})
+	}
+}

--- a/gen/decode.go
+++ b/gen/decode.go
@@ -260,7 +260,11 @@ func (d *decodeGen) structAsMap(s *Struct) {
 	d.p.print("\nswitch msgp.UnsafeString(field) {")
 	for i := range s.Fields {
 		d.ctx.PushString(s.Fields[i].FieldName)
-		d.p.printf("\ncase %q:", s.Fields[i].FieldTag)
+		d.p.printf("\ncase %q", s.Fields[i].FieldTag)
+		for _, alias := range s.Fields[i].FieldAliases {
+			d.p.printf(", %q", alias)
+		}
+		d.p.print(":")
 		fieldElem := s.Fields[i].FieldElem
 		anField := s.Fields[i].HasTagPart("allownil") && fieldElem.AllowNil()
 

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -642,6 +642,7 @@ type StructField struct {
 	FieldName     string   // the name of the struct field
 	FieldElem     Elem     // the field type
 	FieldLimit    uint32   // field-specific size limit for slices/maps (0 = no limit)
+	FieldAliases  []string // old key names that should also be accepted during deserialization
 }
 
 // HasTagPart returns true if the specified tag part (option) is present.

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -320,7 +320,11 @@ func (u *unmarshalGen) mapstruct(s *Struct) {
 		if !u.p.ok() {
 			return
 		}
-		u.p.printf("\ncase %q:", s.Fields[i].FieldTag)
+		u.p.printf("\ncase %q", s.Fields[i].FieldTag)
+		for _, alias := range s.Fields[i].FieldAliases {
+			u.p.printf(", %q", alias)
+		}
+		u.p.print(":")
 		u.ctx.PushString(s.Fields[i].FieldName)
 
 		fieldElem := s.Fields[i].FieldElem

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -542,7 +542,6 @@ func (fs *FileSet) getField(f *ast.Field) []gen.StructField {
 				case "flatten":
 					flatten = true
 				default:
-					// Check for limit=N format
 					if strings.HasPrefix(tag, "limit=") {
 						limitStr := strings.TrimPrefix(tag, "limit=")
 						if limit, err := strconv.ParseUint(limitStr, 10, 32); err == nil {
@@ -550,6 +549,9 @@ func (fs *FileSet) getField(f *ast.Field) []gen.StructField {
 						} else {
 							warnf("invalid limit value in field tag: %s", limitStr)
 						}
+					} else if strings.HasPrefix(tag, "alias=") {
+						aliasStr := strings.TrimPrefix(tag, "alias=")
+						sf[0].FieldAliases = append(sf[0].FieldAliases, strings.Split(aliasStr, ";")...)
 					}
 				}
 			}


### PR DESCRIPTION
I maintain usages of msgp that initially neglected to specify short name tags. As such, their full msgp tag is a quite long name. In order to optimize the byte allocations of these objects, I'd like to move the serialized tag to a new name. Doing so today would require manually editing the generated code or hand-rolling our own.

This PR adds the ability to add an `alias=<oldName1>;<oldName2>;...` tag to msgp labels. Aliases are only supported on deserialization - they do not affect the key at serialization time.