### PR TITLE
fix: NewWriter(nil) uses io.Discard

### DIFF
--- a/msgp/nil_writer_test.go
+++ b/msgp/nil_writer_test.go
@@ -1,0 +1,13 @@
+package msgp
+
+import "testing"
+
+func TestNewWriterNil(t *testing.T) {
+	w := NewWriter(nil)
+	if err := w.WriteString("hi"); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/msgp/write.go
+++ b/msgp/write.go
@@ -120,6 +120,9 @@ type Writer struct {
 
 // NewWriter returns a new *Writer.
 func NewWriter(w io.Writer) *Writer {
+	if w == nil {
+		w = io.Discard
+	}
 	if wr, ok := w.(*Writer); ok {
 		return wr
 	}


### PR DESCRIPTION
## What

`NewWriter(nil)` uses `io.Discard` instead of keeping a nil writer.

## Why

Optional encode sinks should not panic on Flush/Write.

## Test

- `TestNewWriterNil`