### PR TITLE
size: fix compile error for a fixed-size convert shim (#446)

### DIFF
--- a/_generated/convert.go
+++ b/_generated/convert.go
@@ -81,3 +81,22 @@ type ConvertErrVal string
 type ConvertErr struct {
 	Err ConvertErrVal
 }
+
+//msgp:shim ConvertIntVal as:int64 using:fromConvertIntVal/toConvertIntVal mode:convert
+//msgp:ignore ConvertIntVal
+
+func fromConvertIntVal(v ConvertIntVal) (int64, error) {
+	return int64(v), nil
+}
+
+func toConvertIntVal(i int64) (ConvertIntVal, error) {
+	return ConvertIntVal(i), nil
+}
+
+type ConvertIntVal int64
+
+// ConvertInt exercises a fixed-size (int64) convert shim, whose generated
+// Msgsize must not declare an unused temporary (#446).
+type ConvertInt struct {
+	Int ConvertIntVal
+}

--- a/_generated/convert.go
+++ b/_generated/convert.go
@@ -95,8 +95,12 @@ func toConvertIntVal(i int64) (ConvertIntVal, error) {
 
 type ConvertIntVal int64
 
-// ConvertInt exercises a fixed-size (int64) convert shim, whose generated
-// Msgsize must not declare an unused temporary (#446).
+// ConvertInt exercises a fixed-size (int64) convert shim.
 type ConvertInt struct {
-	Int ConvertIntVal
+	Int  ConvertIntVal
+	Ptr  *ConvertIntVal
+	Map  map[string]ConvertIntVal
+	MapP map[string]*ConvertIntVal
+	Arr  []ConvertIntVal
+	ArrP []*ConvertIntVal
 }

--- a/_generated/convert_test.go
+++ b/_generated/convert_test.go
@@ -2,6 +2,7 @@ package _generated
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 
 	"github.com/tinylib/msgp/msgp"
@@ -60,9 +61,16 @@ func TestConvertToMarshalError(t *testing.T) {
 }
 
 func TestConvertInt(t *testing.T) {
-	// #446: a fixed-size convert shim must generate a Msgsize that is an
-	// accurate constant and compiles (no unassigned temporary).
-	in := ConvertInt{Int: 42}
+	// A fixed-size convert shim must report an accurate constant Msgsize.
+	v := ConvertIntVal(7)
+	in := ConvertInt{
+		Int:  42,
+		Ptr:  &v,
+		Map:  map[string]ConvertIntVal{"a": 1},
+		MapP: map[string]*ConvertIntVal{"b": &v},
+		Arr:  []ConvertIntVal{1, 2},
+		ArrP: []*ConvertIntVal{&v},
+	}
 	b, err := in.MarshalMsg(nil)
 	if err != nil {
 		t.Fatal(err)
@@ -74,7 +82,7 @@ func TestConvertInt(t *testing.T) {
 	if _, err = out.UnmarshalMsg(b); err != nil {
 		t.Fatal(err)
 	}
-	if out != in {
+	if !reflect.DeepEqual(out, in) {
 		t.Fatalf("round-trip mismatch: %v != %v", out, in)
 	}
 }

--- a/_generated/convert_test.go
+++ b/_generated/convert_test.go
@@ -58,3 +58,23 @@ func TestConvertToMarshalError(t *testing.T) {
 		t.Fatalf("expected conversion error, found %v", err.Error())
 	}
 }
+
+func TestConvertInt(t *testing.T) {
+	// #446: a fixed-size convert shim must generate a Msgsize that is an
+	// accurate constant and compiles (no unassigned temporary).
+	in := ConvertInt{Int: 42}
+	b, err := in.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if in.Msgsize() < len(b) {
+		t.Fatalf("Msgsize %d under-reports marshaled size %d", in.Msgsize(), len(b))
+	}
+	var out ConvertInt
+	if _, err = out.UnmarshalMsg(b); err != nil {
+		t.Fatal(err)
+	}
+	if out != in {
+		t.Fatalf("round-trip mismatch: %v != %v", out, in)
+	}
+}

--- a/gen/size.go
+++ b/gen/size.go
@@ -230,21 +230,19 @@ func (s *sizeGen) gBase(b *BaseElem) {
 	if b.Convert && b.ShimMode == Convert {
 		if fixedSize(b.Value) {
 			// A fixed-size base has a constant wire size, so there is no need
-			// for a temporary holding the converted value. Emitting an
-			// (unassigned) temporary left it unused, producing a "declared and
-			// not used" compile error in the generated Msgsize (#446).
+			// for a temporary holding the converted value.
 			s.addConstant(basesizeExpr(b.Value, "", b.BaseName()))
-		} else {
-			s.state = add
-			vname := randIdent()
-			s.p.printf("\nvar %s %s", vname, b.BaseType())
-
-			// ensure we don't get "unused variable" warnings from outer slice iterations
-			s.p.printf("\n_ = %s", b.Varname())
-
-			s.p.printf("\ns += %s", basesizeExpr(b.Value, vname, b.BaseName()))
-			s.state = expr
+			return
 		}
+		s.state = add
+		vname := randIdent()
+		s.p.printf("\nvar %s %s", vname, b.BaseType())
+
+		// ensure we don't get "unused variable" warnings from outer slice iterations
+		s.p.printf("\n_ = %s", b.Varname())
+
+		s.p.printf("\ns += %s", basesizeExpr(b.Value, vname, b.BaseName()))
+		s.state = expr
 	} else {
 		vname := b.Varname()
 		if b.Convert {

--- a/gen/size.go
+++ b/gen/size.go
@@ -228,16 +228,23 @@ func (s *sizeGen) gBase(b *BaseElem) {
 		return
 	}
 	if b.Convert && b.ShimMode == Convert {
-		s.state = add
-		vname := randIdent()
-		s.p.printf("\nvar %s %s", vname, b.BaseType())
+		if fixedSize(b.Value) {
+			// A fixed-size base has a constant wire size, so there is no need
+			// for a temporary holding the converted value. Emitting an
+			// (unassigned) temporary left it unused, producing a "declared and
+			// not used" compile error in the generated Msgsize (#446).
+			s.addConstant(basesizeExpr(b.Value, "", b.BaseName()))
+		} else {
+			s.state = add
+			vname := randIdent()
+			s.p.printf("\nvar %s %s", vname, b.BaseType())
 
-		// ensure we don't get "unused variable" warnings from outer slice iterations
-		s.p.printf("\n_ = %s", b.Varname())
+			// ensure we don't get "unused variable" warnings from outer slice iterations
+			s.p.printf("\n_ = %s", b.Varname())
 
-		s.p.printf("\ns += %s", basesizeExpr(b.Value, vname, b.BaseName()))
-		s.state = expr
-
+			s.p.printf("\ns += %s", basesizeExpr(b.Value, vname, b.BaseName()))
+			s.state = expr
+		}
 	} else {
 		vname := b.Varname()
 		if b.Convert {


### PR DESCRIPTION
Fixes #446.

### Problem

A `//msgp:shim T as:BASE using:to/from mode:convert` directive makes the size generator emit a `Msgsize()` that declares a temporary for the converted base value and never assigns it. For a **fixed-size** base (`int64`, `float64`, ...) `basesizeExpr` returns a compile-time constant that ignores the temporary, so the generated code fails to compile:

```
_generated/convert_gen.go:273:6: declared and not used: zb0001
```

### Fix

In `(*sizeGen).gBase`, split the `mode:convert` branch on `fixedSize(b.Value)`. For a fixed-size base the wire size is a constant, so emit it directly (`s.addConstant(basesizeExpr(b.Value, "", b.BaseName()))`) and skip the temporary entirely.

Variable-size bases are intentionally left as-is (they compile and only under-report the size). Per the discussion on #446, computing their exact size in `Msgsize` would require calling the shim, which can be more expensive than the resulting under-allocation - so this PR fixes the compile error without adding shim calls to `Msgsize`.

### Test

Added a fixed-size (`int64`) convert-shim fixture (`ConvertIntVal` / `ConvertInt`) to `_generated/convert.go` and a `TestConvertInt` round-trip test to `_generated/convert_test.go`. Red-green verified: `go generate ./_generated && go test ./_generated` fails to build (`declared and not used`) with the old generator and passes with the fixed one; `ConvertInt.Msgsize()` is now the constant `1 + 4 + msgp.Int64Size`. `gofmt` and `go vet ./gen` are clean.
